### PR TITLE
Fix SMIM rule, weapon/armor mod tags & ordering

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -287,6 +287,31 @@ plugins:
   - name: 'Skyrim Alchemy Fixed - Ordinator.esp'
     tag:
       - Delev
+  - name: 'aMidianBorn_ContentAddon.esp'
+    after:
+      - '1nivWICCloaks.esp'
+      - '1nivWICCloaksNoGuards.esp'
+      - 'WarmongerArmory_LeveledList.esp'
+  - name: 'WarmongerArmory_LeveledList.esp'
+    after:
+      - '1nivWICCloaks.esp'
+      - '1nivWICCloaksNoGuards.esp'
+    tag:
+      - Delev
+      - Relev
+  - name: 'Hothtrooper44_ArmorCompilation.esp'
+    after:
+      - 'aMidianBorn_ContentAddon.esp'
+    tag:
+      - Delev
+      - Relev
+  - name: 'MLU - Immersive Armors.esp'
+    tag:
+      - Delev
+      - Relev
+  - name: 'RichMerchantsSkyrim_x\d+.esp'
+    tag:
+      - Relev
   - name: 'Morrowloot.esp'
     tag:
       - Delev

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -165,7 +165,7 @@ plugins:
       - 'Lanterns Of Skyrim - All In One - Main.esm'
   - name: 'static mesh improvement mod se.esp'
     global_priority: -90
-  - name: 'SMIM-SE-*.esp'
+  - name: 'SMIM-SE-.*.esp'
     global_priority: -90
   - name: 'TouringCarriages.esp'
     global_priority: -90


### PR DESCRIPTION
A few more rules I've needed using some oldrim mods with MLU and Wrye Bash.  Also noticed that the SMIM rule wasn't applying due to bad regex.

