### PR TITLE
Load Realistic Water Two after Sweet as Honeyside

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -553,6 +553,7 @@ plugins:
       - 'SoS - Civilization.esp'
       - 'Alternate Start - Live Another Life.esp'
       - 'CFTO.esp'
+      - 'Honeyside.esp'
     tag:
       - C.Location
       - C.Regions


### PR DESCRIPTION
Fixes water seam issues caused by Sweet as Honeyside modifying cells near bodies of water.