### PR TITLE
Update Dirty Plugin Info for the Official Plugins

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -193,6 +193,11 @@ plugins:
         crc: 0x3f56d693
         itm: 230
         udr: 91
+      - <<: *dirtyPlugin
+        crc: 0xfe610a99
+        itm: 239
+        udr: 91
+        nav: 2
   - name: 'Dawnguard.esm'
     global_priority: -127
     after:
@@ -229,6 +234,11 @@ plugins:
         itm: 621
         udr: 82
         nav: 57
+      - <<: *dirtyPlugin
+        crc: 0x81a481e8
+        itm: 621
+        udr: 82
+        nav: 57
   - name: 'Hearthfires.esm'
     global_priority: -127
     after:
@@ -248,6 +258,11 @@ plugins:
         nav: 5
       - <<: *dirtyPlugin
         crc: 0xeb21f448
+        itm: 178
+        udr: 11
+        nav: 5
+      - <<: *dirtyPlugin
+        crc: 0xa631401b
         itm: 178
         udr: 11
         nav: 5
@@ -273,6 +288,11 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x32e19c49
         itm: 67
+        udr: 8
+        nav: 1
+      - <<: *dirtyPlugin
+        crc: 0x64625bcd
+        itm: 69
         udr: 8
         nav: 1
   - name: 'ccBGSSSE002-ExoticArrows.esl'


### PR DESCRIPTION
Skyrim Special Edition updated to version 1.5.39, which also included updated official plugins. These new results were attained with SSEEdit 3.2.1.