### PR TITLE
V0.10 masterlist updates

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -466,8 +466,6 @@ plugins:
         udr: 0
         nav: 0
     clean:
-      - crc: 0x8249EC41
-        util: SSEEdit v3.2.1
       - crc: 0xB98044B4
         util: SSEEdit v3.2.1
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -426,6 +426,8 @@ plugins:
       - crc: 0x2BC2FECB
         util: SSEEdit v3.2.1
   - name: 'MoonAndStar_MAS.esp'
+    after:
+      - 'AuroraVillage.esp'
     tag:
       - C.Location
       - C.Water
@@ -441,12 +443,19 @@ plugins:
   - name: 'Undeath.esp'
     after:
       - 'MoonAndStar_MAS.esp'
+    inc:
+      - 'AuroraVillage.esp'
     msg:
       - type: say
         condition: 'checksum("Undeath.esp",EB75A960) or checksum("Undeath.esp",8249EC41)'
         content:
           - lang: en
             text: 'This mod contains wild edits. A manual [SSEEdit](http://www.nexusmods.com/skyrimspecialedition/mods/164) cleaning guide is available [here](https://linnsmusings.wordpress.com/2017/08/27/undeathcleaningguideforle/)'
+      - type: warn
+        condition: 'active("imp_helm_legend.esp") and not active("Improved closefaced helmets for Undeath SSE")'
+        content:
+          - lang: en
+            text: 'This mod has certain conflicts with "imp_helm_legend.esp". Consider using the Improved closefaced helmets for Undeath SSE patch found [here](https://www.nexusmods.com/skyrimspecialedition/mods/14614/).'
     tag:
       - C.Regions
       - C.Water

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -466,6 +466,8 @@ plugins:
         udr: 0
         nav: 0
     clean:
+      - crc: 0x8249EC41
+        util: SSEEdit v3.2.1
       - crc: 0xB98044B4
         util: SSEEdit v3.2.1
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -499,6 +499,10 @@ plugins:
     clean:
       - crc: 0x17CF8EB8
         util: SSEEdit v3.2.1
+  - name: 'Improved closefaced helmets for Undeath SSE.esp'
+    clean:
+      - crc: 0xCC6D50A9
+        util: SSEEdit v3.2.1
   - name: 'MLU.esp'
     global_priority: 60
     tag:
@@ -522,7 +526,17 @@ plugins:
   - name: 'MLU - Immersive Armors.esp'
     tag:
       - Delev
-      - Relev       
+      - Relev
+  - name: 'MLU - Improved Closefaced Helmets.esp'
+    # missing master.
+    req:
+      - 'MLU.esp'
+    tag:
+      - Stats
+      - -Names
+    clean:
+      - crc: 0xB8A1EE4E
+        util: SSEEdit v3.2.1
   - name: 'static mesh improvement mod se.esp'
     global_priority: -90
   - name: 'SMIM-SE-.*.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -530,9 +530,7 @@ plugins:
   - name: 'MLU - Improved Closefaced Helmets.esp'
     # missing master.
     req:
-      - name: 'MLU.esp'
-        display: '[Morrowloot Ultimate](https://www.nexusmods.com/skyrimspecialedition/mods/3058)'
-        condition: 'checksum("MLU - Improved Closefaced Helmets.esp",B8A1EE4E)'
+      - 'MLU.esp'
     tag:
       - Stats
       - --Names

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -499,6 +499,30 @@ plugins:
     clean:
       - crc: 0x17CF8EB8
         util: SSEEdit v3.2.1
+  - name: 'MLU.esp'
+    global_priority: 60
+    tag:
+      - Actors.ACBS
+      - Actors.AIData
+      - Actors.Stats
+      - C.Location
+      - C.Name
+      - C.RecordFlags
+      - C.Regions
+      - C.Water
+      - Delev
+      - Graphics
+      - Invent
+      - Names
+      - Relev
+      - Stats
+    clean:
+      - crc: 0x89111F8E
+        util: SSEEdit v3.2.1
+  - name: 'MLU - Immersive Armors.esp'
+    tag:
+      - Delev
+      - Relev       
   - name: 'static mesh improvement mod se.esp'
     global_priority: -90
   - name: 'SMIM-SE-.*.esp'
@@ -671,10 +695,6 @@ plugins:
     tag:
       - Delev
       - Relev
-  - name: 'MLU - Immersive Armors.esp'
-    tag:
-      - Delev
-      - Relev
   - name: 'RichMerchantsSkyrim_x\d+.esp'
     tag:
       - Relev
@@ -682,8 +702,6 @@ plugins:
     tag:
       - Delev
       - Relev
-  - name: 'MLU.esp'
-    global_priority: 60
   - name: 'JK''s Riverwood.esp'
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -451,11 +451,6 @@ plugins:
         content:
           - lang: en
             text: 'This mod contains wild edits. A manual [SSEEdit](http://www.nexusmods.com/skyrimspecialedition/mods/164) cleaning guide is available [here](https://linnsmusings.wordpress.com/2017/08/27/undeathcleaningguideforle/)'
-      - type: warn
-        condition: 'active("imp_helm_legend.esp") and not active("Improved closefaced helmets for Undeath SSE")'
-        content:
-          - lang: en
-            text: 'This mod has certain conflicts with "imp_helm_legend.esp". Consider using the Improved closefaced helmets for Undeath SSE patch found [here](https://www.nexusmods.com/skyrimspecialedition/mods/14614/).'
     tag:
       - C.Regions
       - C.Water
@@ -479,7 +474,31 @@ plugins:
         util: SSEEdit v3.2.1
       - crc: 0xB98044B4
         util: SSEEdit v3.2.1
-
+  - name: 'imp_helm_legend.esp'
+    after: 
+      - 'MLU.esp'
+    msg:
+      - type: warn
+        condition: 'active("MLU.esp") and not active("MLU - Improved Closefaced Helmets.esp")'
+        content:
+          - lang: en
+            text: 'This mod has certain conflicts with "MLU.esp". Consider using the [MLU - Improved Closefaced Helmets patch](https://www.nexusmods.com/skyrimspecialedition/mods/3058/).'
+      - type: warn
+        condition: 'active("Undeath.esp") and not active("Improved closefaced helmets for Undeath SSE.esp")'
+        content:
+          - lang: en
+            text: 'This mod has certain conflicts with "Undeath.esp". Consider using the [Improved closefaced helmets for Undeath SSE patch](https://www.nexusmods.com/skyrimspecialedition/mods/14614/).'
+    tag:
+      - Graphics
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x8491D752
+        itm: 5
+        udr: 0
+        nav: 0
+    clean:
+      - crc: 0x17CF8EB8
+        util: SSEEdit v3.2.1
   - name: 'static mesh improvement mod se.esp'
     global_priority: -90
   - name: 'SMIM-SE-.*.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -533,7 +533,7 @@ plugins:
       - 'MLU.esp'
     tag:
       - Stats
-      - --Names
+      - -Names
     clean:
       - crc: 0xB8A1EE4E
         util: SSEEdit v3.2.1

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -530,7 +530,9 @@ plugins:
   - name: 'MLU - Improved Closefaced Helmets.esp'
     # missing master.
     req:
-      - 'MLU.esp'
+      - name: 'MLU.esp'
+        display: '[Morrowloot Ultimate](https://www.nexusmods.com/skyrimspecialedition/mods/3058)'
+        condition: 'checksum("MLU - Improved Closefaced Helmets.esp",B8A1EE4E)'
     tag:
       - Stats
       - --Names

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -533,6 +533,7 @@ plugins:
       - 'MLU.esp'
     tag:
       - Stats
+      - --Names
     clean:
       - crc: 0xB8A1EE4E
         util: SSEEdit v3.2.1

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -425,8 +425,52 @@ plugins:
     clean:
       - crc: 0x2BC2FECB
         util: SSEEdit v3.2.1
+  - name: 'MoonAndStar_MAS.esp'
+    tag:
+      - C.Location
+      - C.Water
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0xEB5AEFAF
+        itm: 1
+        udr: 0
+        nav: 0
+    clean:
+      - crc: 0x10F57567
+        util: SSEEdit v3.2.1
+  - name: 'Undeath.esp'
+    after:
+      - 'MoonAndStar_MAS.esp'
+    msg:
+      - type: say
+        condition: 'checksum("Undeath.esp",EB75A960) or checksum("Undeath.esp",8249EC41)'
+        content:
+          - lang: en
+            text: 'This mod contains wild edits. A manual [SSEEdit](http://www.nexusmods.com/skyrimspecialedition/mods/164) cleaning guide is available [here](https://linnsmusings.wordpress.com/2017/08/27/undeathcleaningguideforle/)'
+    tag:
+      - C.Regions
+      - C.Water
+      - Graphics
+      - Invent
+      - Names
+      - Sound
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0xEB75A960
+        itm: 18
+        udr: 0
+        nav: 0
+      - <<: *dirtyPlugin
+        crc: 0x6E988E26
+        itm: 17
+        udr: 0
+        nav: 0
+    clean:
+      - crc: 0x8249EC41
+        util: SSEEdit v3.2.1
+      - crc: 0xB98044B4
+        util: SSEEdit v3.2.1
 
-    
   - name: 'static mesh improvement mod se.esp'
     global_priority: -90
   - name: 'SMIM-SE-.*.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -533,7 +533,6 @@ plugins:
       - 'MLU.esp'
     tag:
       - Stats
-      - -Names
     clean:
       - crc: 0xB8A1EE4E
         util: SSEEdit v3.2.1

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -456,7 +456,7 @@ plugins:
       - C.Water
       - Graphics
       - Invent
-      - Names
+      - -Names
       - Sound
     dirty:
       - <<: *dirtyPlugin

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -436,7 +436,7 @@ plugins:
         udr: 0
         nav: 0
     clean:
-      - crc: 0x10F57567
+      - crc: 0x1DA470CB
         util: SSEEdit v3.2.1
   - name: 'Undeath.esp'
     after:


### PR DESCRIPTION
Moon And Star
- Bash tags added
- Load after AuroraVillage.esp
- Dirty & clean plugin CRC & info.
- Add compatibilty info.

Undeath
- Load after Moon & Star, recommended by M&S author.
- Bash tags added
- Dirty & clean plugin CRC & info.
- Mod contains wild edits, link to manual cleaning guide provided.
- Add compatibilty info. AuroraVillage.esp is not compatible.

Improved Closeface Helmets
- Load after rule for Morrowloot ultimate.
- Compatibility warning for morrowloot & undeath, with links to patches provided.
- Bash tag (Graphics) suggested.
- Dirty & clean plugin info added.
- Link to patch for Improved closefaced helmets for Undeath SSE

Improved Closefaced Helmets Patches
- MLU patch
- Remove bad bash tag
- Flag required master, missing from file header.
- Add clean plugin info.

Morrowloot Ultimate
- Add suggested bash tags
- Add clean plugin CRC
