### PR TITLE
V0.10 Masterlist Update - New Entries & Remove implicit USSEP bash tags

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -513,6 +513,11 @@ plugins:
     inc:
       - 'AuroraVillage.esp'
     msg:
+      - <<: *hasPluginPatch
+        subs:
+          - 'Improved Closefaced Helmets'
+          - '[Improved closefaced helmets for Undeath](https://www.nexusmods.com/skyrimspecialedition/mods/14614/)'
+        condition: 'active("imp_helm_legend.esp") and not active("Improved closefaced helmets for Undeath SSE.esp")'
       - type: say
         condition: 'checksum("Undeath.esp",EB75A960) or checksum("Undeath.esp",8249EC41)'
         content:
@@ -549,12 +554,6 @@ plugins:
     # Improved closeface helmets
     after:
       - 'MLU.esp'
-    msg:
-      - type: warn
-        condition: 'active("Undeath.esp") and not active("Improved closefaced helmets for Undeath SSE.esp")'
-        content:
-          - lang: en
-            text: 'This mod has certain conflicts with "Undeath.esp". Consider using the [Improved closefaced helmets for Undeath SSE patch](https://www.nexusmods.com/skyrimspecialedition/mods/14614/).'
     tag:
       - Graphics
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -397,19 +397,24 @@ plugins:
             text: '"ccqdrsse001-survivalmode.esl" has a [Known bug](https://www.nexusmods.com/skyrimspecialedition/articles/22/) which is incompatible with "Ordinator - Perks of Skyrim.esp". Consider using the [Unofficial skyrim survival patch](https://www.nexusmods.com/skyrimspecialedition/mods/12655/) to fix this bug.'
   - name: 'Unofficial Skyrim Special Edition Patch.esp'
     global_priority: -120
-    clean:
-      - crc: 0xAE28DBE3
-        util: SSEEdit v3.2.1
     after:
       - 'Lanterns Of Skyrim - All In One - Main.esm'
+    clean:
+    # Version 4.1.2alpha
+      - crc: 0xAE28DBE3
+        util: SSEEdit v3.2.1
   - name: 'unofficial skyrim survival patch.esp'
+    tag:
+      - Graphics
     clean: 
       - crc: 0xF7B1A347
         util: SSEEdit v3.2.1
-    tag:
-      - Graphics
   - name: 'BSAssets.esm'
+    tag: 
+      - C.Light
+      - C.RecordFlags
     clean:
+    # version 1.3.3
       - crc: 0x1D0648B6
         util: SSEEdit v3.2.1
   - name: 'BSHeartland.esm'
@@ -804,6 +809,7 @@ plugins:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'RealisticWaterTwo.esp'
+    #global_priority: 72
     after:
       - 'JK''s Riverwood.esp'
       - 'JKs Whiterun.esp'
@@ -826,10 +832,13 @@ plugins:
       - 'CFTO.esp'
       - 'Honeyside.esp'
     tag:
-      - C.Location
-      - C.Regions
       - C.Water
       - Graphics
+      - Sound
+    clean:
+      # Version 1.4.4
+      - crc: 0xB2812DAF
+        util: SSEEdit v3.2.1
   - name: 'SSEMerged.esp'
     global_priority: 80
     tag:
@@ -850,9 +859,6 @@ plugins:
           - 'Ordinator - Perks of Skyrim'
           - '[Apocalypse - Ordinator Compatibility Patch](https://www.nexusmods.com/skyrimspecialedition/mods/1090/)'
         condition: 'active("Ordinator - Perks of Skyrim.esp") and not active("Apocalypse - Ordinator Compatibility Patch.esp")'
-    tag:
-      - C.Water
-      - C.Regions
     clean:
       # Version 9.45SSE
       - crc: 0x266B3B3B
@@ -891,8 +897,6 @@ plugins:
       - 'PerkusMaximus_Warrior.esp'
       - 'PerkusMaximus_CombatPlus.esp'
     tag:
-      - C.Regions
-      - C.Water
       - Graphics
       - Names
       - Sound
@@ -902,8 +906,6 @@ plugins:
   - name: 'Imperious - Races of Skyrim.esp'
     global_priority: 20
     tag:
-      - Body-Size-F
-      - Body-Size-M
       - Names
       - R.Description
       - R.Skills

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -483,7 +483,6 @@ plugins:
       - 'AuroraVillage.esp'
     tag:
       - C.Location
-      - C.Water
     dirty:
       - <<: *dirtyPlugin
         crc: 0xEB5AEFAF
@@ -506,7 +505,6 @@ plugins:
             text: 'This mod contains wild edits. A manual [SSEEdit](http://www.nexusmods.com/skyrimspecialedition/mods/164) cleaning guide is available [here](https://linnsmusings.wordpress.com/2017/08/27/undeathcleaningguideforle/)'
     tag:
       - C.Regions
-      - C.Water
       - Graphics
       - Invent
       - -Names
@@ -597,8 +595,14 @@ plugins:
     clean:
       - crc: 0xB8A1EE4E
         util: SSEEdit v3.2.1
-  - name: 'static mesh improvement mod se.esp'
+  - name: 'SMIM-SE.esp'
     global_priority: -90
+    tag:
+      - Graphics
+    clean:
+    # BSA VERSION 2.07
+      - crc: 0x35C26177
+        util: SSEEdit v3.2.1
   - name: 'SMIM-SE-.*.esp'
     global_priority: -90
   - name: 'TouringCarriages.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -400,14 +400,14 @@ plugins:
     after:
       - 'Lanterns Of Skyrim - All In One - Main.esm'
     clean:
-      # Version 4.1.2alpha
+      # 4.1.2alpha
       - crc: 0xAE28DBE3
         util: SSEEdit v3.2.1
   - name: 'unofficial skyrim survival patch.esp'
     tag:
       - Graphics
     clean: 
-      # version 2.9
+      # 2.9
       - crc: 0xF7B1A347
         util: SSEEdit v3.2.1
   - name: 'BSAssets.esm'
@@ -417,7 +417,7 @@ plugins:
       - C.Light
       - C.RecordFlags
     clean:
-      # version 1.3.3
+      # 1.3.3
       - crc: 0x1D0648B6
         util: SSEEdit v3.2.1
   - name: 'BSHeartland.esm'
@@ -443,7 +443,7 @@ plugins:
       - Invent
       - Names
     dirty:
-      # version 1.3.3
+      # 1.3.3
       - <<: *dirtyPlugin
         crc: 0x0B12B4E7
         itm: 485
@@ -461,7 +461,7 @@ plugins:
       - Delev
       - Invent
     clean:
-      # version 1.1.2
+      # 1.1.2
       - crc: 0x2BC2FECB
         util: SSEEdit v3.2.1
   - name: 'DLCIntegration.esp'
@@ -478,13 +478,13 @@ plugins:
       - Names
       - Relev
     clean:
-      # version 1.1
+      # 1.1
       - crc: 0xA3FB0FAD
         util: SSEEdit v3.2.1
   - name: 'DLCIntegration Beyond Skyrim Compatibility Patch.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/8032/']
     clean:
-      # version 1.1
+      # 1.1
       - crc: 0x32F4BBE5
         util: SSEEdit v3.2.1
   - name: 'MoonAndStar_MAS.esp'
@@ -494,14 +494,14 @@ plugins:
     tag:
       - C.Location
     dirty:
-      # Version 3.2
+      # 3.2
       - <<: *dirtyPlugin
         crc: 0xEB5AEFAF
         itm: 1
         udr: 0
         nav: 0
     clean:
-      # Version 3.2
+      # 3.2
       - crc: 0x1DA470CB
         util: SSEEdit v3.2.1
   - name: 'Undeath.esp'
@@ -525,20 +525,20 @@ plugins:
       - Graphics
       - Sound
     dirty:
-      # Version 3.2
+      # 3.2
       - <<: *dirtyPlugin
         crc: 0xEB75A960
         itm: 18
         udr: 0
         nav: 0
-      # Version 3.2 without wild edits
+      # 3.2 without wild edits
       - <<: *dirtyPlugin
         crc: 0x6E988E26
         itm: 17
         udr: 0
         nav: 0
     clean:
-      # Version 3.2 Cleaned without wild edits
+      # 3.2 Cleaned without wild edits
       - crc: 0xB98044B4
         util: SSEEdit v3.2.1
   - name: 'UndeathClassicalLichdom SSE.esp'
@@ -556,6 +556,7 @@ plugins:
     tag:
       - Graphics
     dirty:
+      # 1.58
       - <<: *dirtyPlugin
         crc: 0x8491D752
         itm: 5
@@ -594,15 +595,18 @@ plugins:
       - Relev
       - Stats
     clean:
+      # 1.2
       - crc: 0x89111F8E
         util: SSEEdit v3.2.1
   - name: 'MLU - Immersive Armors.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/3058/']
     after:
       - 'MLU - AAE Ultimate Edition.esp'
     tag:
       - Delev
       - Relev
   - name: 'MLU - Improved Closefaced Helmets.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/3058/']
     req:
       # missing master
       - 'MLU.esp'
@@ -623,7 +627,7 @@ plugins:
     tag:
       - Graphics
     clean:
-      # VERSION 2.07
+      # 2.07
       - crc: 0x35C26177
         util: SSEEdit v3.2.1
   - name: 'SMIM-SE-.*.esp'
@@ -638,7 +642,7 @@ plugins:
     tag:
       - C.Location
     clean:
-      # Version 3.0.0
+      # 3.0.0
       - crc: 0x07E8D176
         util: SSEEdit v3.2.1
   - name: 'Cutting Room Floor.esp'
@@ -669,7 +673,7 @@ plugins:
       - NPC.Class
       - Stats
     clean:
-      # Version 3.0.6
+      # 3.0.6
       - crc: 0x699BC58C
         util: SSEEdit v3.2.1
   - name: 'RLO - Major City Exteriors - No Guard Torches.esp'
@@ -721,19 +725,35 @@ plugins:
       - Names
       - NoMerge
     clean:
+      # 1.6.2
       - crc: 0x67ECB699
         util: SSEEdit v3.2.1
   - name: 'Hair Replacer.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/7409/']
+    # Skyrim Hair Replacer
     global_priority: -100
   - name: 'Hair Replacer Assets.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/7409/']
     global_priority: -100
     after:
       - 'Hair Replacer.esp'
   - name: 'Better Vampires.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/1925/']
     after:
       - 'EBM_UnlimitedPower.esp'
       - 'EBM_UnlimitedPower_Vampire.esp'
+    tag: 
+      - Graphics
+      - Names
+      - Relev
+      - Sound
+      - Stats
+    clean:
+      # 8.2
+      - crc: 0xEC44246A
+        util: SSEEdit v3.2.1
   - name: 'Riftrun_HF_v_2_0.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/757/']
     after:
       - 'Hideout_Main.esp'
       - 'Hideout_HF_Main.esp'
@@ -741,30 +761,38 @@ plugins:
       - 'Hideout_Compact.esp'
       - 'Hideout_HF_Compact.esp'
   - name: 'Dovahkiin_Retreat.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/746/']
     after:
       - 'Hideout_HF_Main.esp'
       - 'Hideout_Main.esp'
   - name: 'EBM_Train10x.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/10580/']
+    # ExE Boss's Mods - Train More
     inc:
       - 'EBM_Train25x.esp'
       - 'EBM_Train50x.esp'
       - 'EBM_Train99x.esp'
   - name: 'EBM_Train25x.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/10580/']
     inc:
       - 'EBM_Train10x.esp'
       - 'EBM_Train50x.esp'
       - 'EBM_Train99x.esp'
   - name: 'EBM_Train50x.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/10580/']
     inc:
       - 'EBM_Train10x.esp'
       - 'EBM_Train25x.esp'
       - 'EBM_Train99x.esp'
   - name: 'EBM_Train99x.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/10580/']
     inc:
       - 'EBM_Train10x.esp'
       - 'EBM_Train25x.esp'
       - 'EBM_Train50x.esp'
   - name: 'EBM_UnlimitedPower.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/4210/']
+    # ExE Boss's Mods - UNLIMITED POWER
     inc:
       - 'EBM_UnlimitedPower_DarkBrotherhood.esp'
       - 'EBM_UnlimitedPower_DragonAspect.esp'
@@ -779,7 +807,7 @@ plugins:
     req:
       - *SKSE64
     clean:
-      # Version 5.2
+      # 5.2
       - crc: 0x79ACE179
         util: SSEEdit v3.2.1
   - name: 'Open Cities Skyrim.esp'
@@ -800,10 +828,11 @@ plugins:
       - C.Location
       - C.Regions
     clean:
-      # Version 3.0.4
+      # 3.0.4
       - crc: 0xD16C3B49
         util: SSEEdit v3.2.1
   - name: 'Alternate Start - Live Another Life.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/272/']
     global_priority: 70
     after:
       - 'Open Cities Skyrim.esp'
@@ -811,30 +840,52 @@ plugins:
     tag:
       - C.Location
   - name: '3rdEraWeapMoS-lvlList.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/5019/']
+    # Weapons of the Third Era SSE
     tag:
       - Delev
       - Relev
   - name: 'High Level Enemies.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/3231/']
     tag:
       - Relev
   - name: 'High Level Enemies - Dawnguard.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/3231/']
     tag:
       - Relev
   - name: 'High Level Enemies - Dragonborn.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/3231/']
     tag:
       - Relev
   - name: 'Skyrim Alchemy Fixed.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2262/']
     tag:
       - Delev
   - name: 'Skyrim Alchemy Fixed - Ordinator.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2262/']
     tag:
       - Delev
   - name: 'aMidianBorn_ContentAddon.esp'
+    url: ['https://www.nexusmods.com/skyrim/mods/24909/']
+    # aMidianBorn Book of Silence
     after:
       - '1nivWICCloaks.esp'
       - '1nivWICCloaksNoGuards.esp'
+      - 'BetterQuestObjectives.esp'
       - 'WarmongerArmory_LeveledList.esp'
+    msg:
+      - type: warn
+        condition: 'checksum("aMidianBorn_ContentAddon.esp",59165B9C)'
+        content:
+          - lang: en
+            text: 'Form 43 plugin - This mod has not been converted to work with Skyrim Special Edition'
+    tag:
+      - Delev
+      - Graphics
+      - Relev
+      - Stats
   - name: 'WarmongerArmory_LeveledList.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/4956/']
     after:
       - '1nivWICCloaks.esp'
       - '1nivWICCloaksNoGuards.esp'
@@ -842,22 +893,28 @@ plugins:
       - Delev
       - Relev
   - name: 'Hothtrooper44_ArmorCompilation.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/3479/']
+    # Immersive Armors
     after:
       - 'aMidianBorn_ContentAddon.esp'
     tag:
       - Delev
       - Relev
   - name: 'RichMerchantsSkyrim_x\d+.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/1772/']
     tag:
       - Relev
   - name: 'Morrowloot.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/1255/']
     tag:
       - Delev
       - Relev
   - name: 'JK''s Riverwood.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2013/']
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
   - name: 'JKs Whiterun.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2259/']
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
     tag:
@@ -923,7 +980,7 @@ plugins:
       - Graphics
       - Sound
     clean:
-      # Version 1.4.4
+      # 1.4.4
       - crc: 0xB2812DAF
         util: SSEEdit v3.2.1
   - name: 'SSEMerged.esp'
@@ -947,7 +1004,7 @@ plugins:
           - '[Apocalypse - Ordinator Compatibility](https://www.nexusmods.com/skyrimspecialedition/mods/1090/)'
         condition: 'active("Ordinator - Perks of Skyrim.esp") and not active("Apocalypse - Ordinator Compatibility Patch.esp")'
     clean:
-      # Version 9.45SSE
+      # 9.45SSE
       - crc: 0x266B3B3B
         util: SSEEdit v3.2.1
   - name: 'DeadlyCombat.esp'
@@ -988,6 +1045,7 @@ plugins:
       - Names
       - Sound
     clean:
+      # 9.26SSE
       - crc: 0x38670BC4
         util: SSEEdit v3.2.1
   - name: 'Imperious - Races of Skyrim.esp'
@@ -1104,7 +1162,7 @@ plugins:
       - 'Book Covers Skyrim.esp'
       - 'Relationship Dialogue Overhaul.esp'
     clean:
-      # Version 0.9
+      # 0.9
       - crc: 0x586D2620
         util: SSEEdit v3.2.1
   - name: 'SexyMannequinVyktoria_SSE.esp'
@@ -1393,6 +1451,36 @@ plugins:
       - Actors.AIPackages
       - Names
     clean:
-      # Version 3.2
+      # 3.2
       - crc: 0x9F3FDA79
         util: SSEEdit v3.2.1
+  - name: 'UnlimitedBookshelves.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2885/']
+    # Authors instruction Load directly after Unofficial Skyrim Special Edition Patch in your load order.
+    global_priority: -120
+    clean:
+      # 2.0
+      - crc: 0x86CF0F2B
+        util: SSEEdit v3.2.1
+  # Realistic Lighting Overhaul SE V5
+  - name: 'RLO - Effects.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/844']
+  - name: 'RLO - Exteriors.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/844']
+  - name: 'RLO - Interiors.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/844']
+  - name: 'RLO - Illuminated Spells.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/844']
+    after: 
+      - 'RLO - Interiors.esp'
+  # Realistic Lighting Overhaul SE V5 Patches
+  - name: 'RLO - CRF Patch.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/844']
+  - name: 'RLO - IC Patch.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/844']
+  - name: 'RLO - JK''s Riverwood.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/844']
+  - name: 'RLO - JK''s Whiterun.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/844']
+  - name: 'RLO - VIS Patch.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/844']

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -461,7 +461,7 @@ plugins:
     msg:
       - <<: *hasPluginPatch
         subs:
-          - 'Beyond Skyrim DLC Integration Patch'
+          - 'Beyond Skyrim DLC Integration'
           - '[DLCIntegration Beyond Skyrim Compatibility Patch](https://www.nexusmods.com/skyrimspecialedition/mods/8032/)'
         condition: 'active("BS_DLC_patch.esp") and not active("DLCIntegration Beyond Skyrim Compatibility Patch.esp")'
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -715,8 +715,14 @@ plugins:
     after:
       - 'Realistic Lighting Overhaul - Major City Interiors.esp'
   - name: 'BetterQuestObjectives.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/159/']
+    # Even Better Quest Objectives
     tag:
+      - Names
       - NoMerge
+    clean:
+      - crc: 0x67ECB699
+        util: SSEEdit v3.2.1
   - name: 'Hair Replacer.esp'
     global_priority: -100
   - name: 'Hair Replacer Assets.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -617,23 +617,48 @@ plugins:
     tag:
       - Graphics
   - name: 'SMIM-SE.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/659/']
+    # Static Mesh Improvement Mod SE - BSA version
     global_priority: -90
     tag:
       - Graphics
     clean:
-      # VERSION BSA 2.07
+      # VERSION 2.07
       - crc: 0x35C26177
         util: SSEEdit v3.2.1
   - name: 'SMIM-SE-.*.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/659/']
+    # Static Mesh Improvement Mod SE - Modular installer
     global_priority: -90
+    tag:
+      - Graphics
   - name: 'TouringCarriages.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/15948/']
     global_priority: -90
+    tag:
+      - C.Location
+    clean:
+      # Version 3.0.0
+      - crc: 0x07E8D176
+        util: SSEEdit v3.2.1
   - name: 'Cutting Room Floor.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/276/']
     global_priority: -90
+    msg:
+      - <<: *hasPluginPatch
+        subs:
+          - 'RS Children Overhaul'
+          - '[RS Children Overhaul - CRF Patch](https://www.nexusmods.com/skyrimspecialedition/mods/276/)'
+        condition: 'active("RSkyrimChildren.esm") and not active("RSChildren - CRF Patch.esp")'
     after:
       - 'TouringCarriages.esp'
       - 'WhiterunHoldForest.esp'
     tag:
+      - Actors.ACBS
+      - Actors.AIData
+      - Actors.AIPackages
+      - Actors.CombatStyle
+      - Actors.Stats
       - C.Location
       - C.Owner
       - C.RecordFlags
@@ -641,7 +666,12 @@ plugins:
       - Graphics
       - Invent
       - Names
+      - NPC.Class
       - Stats
+    clean:
+      # Version 3.0.6
+      crc: 0x699BC58C
+      util: SSEEdit v3.2.1
   - name: 'RLO - Major City Exteriors - No Guard Torches.esp'
     after:
       - 'Realistic Lighting Overhaul - Major City Interiors.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -616,6 +616,10 @@ plugins:
     clean:
       - crc: 0xB8A1EE4E
         util: SSEEdit v3.2.1
+  - name: 'static mesh improvement mod se.esp'
+    global_priority: -90
+    tag:
+      - Graphics
   - name: 'SMIM-SE.esp'
     global_priority: -90
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -847,7 +847,6 @@ plugins:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'RealisticWaterTwo.esp'
-    #global_priority: 72
     after:
       - 'JK''s Riverwood.esp'
       - 'JKs Whiterun.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1050,6 +1050,15 @@ plugins:
   - name: 'RDO - AFT v1.66 Patch.esp'
     after:
       - 'Relationship Dialogue Overhaul.esp'
+  - name: 'Serana Dialogue Edit.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/16222/']
+    after:
+      - 'Book Covers Skyrim.esp'
+      - 'Relationship Dialogue Overhaul.esp'
+    clean:
+      # Version 0.9
+      - crc: 0x586D2620
+        util: SSEEdit v3.2.1
   - name: 'SexyMannequinVyktoria_SSE.esp'
     inc:
       - 'SexyMannequinsFemale_SSE.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -431,7 +431,7 @@ plugins:
       - <<: *hasPluginPatch
         subs:
           - 'Ordinator - Perks of Skyrim'
-          - '[Ordinator Beyond Skyrim Bruma Patch](https://www.nexusmods.com/skyrimspecialedition/mods/10934/)'
+          - '[Ordinator Beyond Skyrim Bruma](https://www.nexusmods.com/skyrimspecialedition/mods/10934/)'
         condition: 'active("Ordinator - Perks of Skyrim.esp") and not active("Ordinator - Beyond Skyrim Bruma Patch.esp")'
     tag:
       - Actors.ACBS 
@@ -474,7 +474,7 @@ plugins:
       - <<: *hasPluginPatch
         subs:
           - 'Beyond Skyrim DLC Integration'
-          - '[DLCIntegration Beyond Skyrim Compatibility Patch](https://www.nexusmods.com/skyrimspecialedition/mods/8032/)'
+          - '[DLCIntegration Beyond Skyrim Compatibility](https://www.nexusmods.com/skyrimspecialedition/mods/8032/)'
         condition: 'active("BS_DLC_patch.esp") and not active("DLCIntegration Beyond Skyrim Compatibility Patch.esp")'
     tag:
       - Delev
@@ -896,7 +896,7 @@ plugins:
       - <<: *hasPluginPatch
         subs:
           - 'Ordinator - Perks of Skyrim'
-          - '[Apocalypse - Ordinator Compatibility Patch](https://www.nexusmods.com/skyrimspecialedition/mods/1090/)'
+          - '[Apocalypse - Ordinator Compatibility](https://www.nexusmods.com/skyrimspecialedition/mods/1090/)'
         condition: 'active("Ordinator - Perks of Skyrim.esp") and not active("Apocalypse - Ordinator Compatibility Patch.esp")'
     clean:
       # Version 9.45SSE
@@ -914,14 +914,14 @@ plugins:
       - <<: *hasPluginPatch
         subs:
           - 'Ordinator - Perks of Skyrim'
-          - '[Elemental Destruction - Ordinator Patch](https://www.nexusmods.com/skyrimspecialedition/mods/3536/)'
+          - '[Elemental Destruction - Ordinator](https://www.nexusmods.com/skyrimspecialedition/mods/3536/)'
         condition: 'active("Ordinator - Perks of Skyrim.esp") and not active("Elemental Destruction - Ordinator Patch.esp")'
   - name: 'MultipleEnchantments.esp'
     msg:
       - <<: *hasPluginPatch
         subs:
           - 'Ordinator - Perks of Skyrim'
-          - '[Multiple Enchantments - Ordinator Patch](https://www.nexusmods.com/skyrimspecialedition/mods/5267/)'
+          - '[Multiple Enchantments - Ordinator](https://www.nexusmods.com/skyrimspecialedition/mods/5267/)'
         condition: 'active("Ordinator - Perks of Skyrim.esp") and not active("Multiple Enchantments - Ordinator Patch.esp")'
   - name: 'Ordinator - Perks of Skyrim.esp'
     after: 
@@ -1176,7 +1176,7 @@ plugins:
       - <<: *hasPluginPatch
         subs:
           - 'Ordinator - Perks of Skyrim'
-          - '[HarvestOverhaul - Ordinator Compatibility Patch](https://www.nexusmods.com/skyrimspecialedition/mods/2398/)'
+          - '[HarvestOverhaul - Ordinator Compatibility](https://www.nexusmods.com/skyrimspecialedition/mods/2398/)'
         condition: 'active("Ordinator - Perks of Skyrim.esp") and not active("HOR_OrdinatorPatch.esp")'
     tag:
       - Delev

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -584,15 +584,15 @@ plugins:
           - '[MLU - Improved Closefaced Helmets](https://www.nexusmods.com/skyrimspecialedition/mods/3058/)'
         condition: 'active("imp_helm_legend.esp") and not active("MLU - Improved Closefaced Helmets.esp")'
     tag:
-    - Actors.ACBS
-    - Actors.AIData
-    - Actors.Stats
-    - Delev
-    - Graphics
-    - Invent
-    - Names
-    - Relev
-    - Stats
+      - Actors.ACBS
+      - Actors.AIData
+      - Actors.Stats
+      - Delev
+      - Graphics
+      - Invent
+      - Names
+      - Relev
+      - Stats
     clean:
       - crc: 0x89111F8E
         util: SSEEdit v3.2.1

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -522,7 +522,7 @@ plugins:
         util: SSEEdit v3.2.1
       - crc: 0xB98044B4
         util: SSEEdit v3.2.1
-  - name: 'UndeathClassicalLichdom SSE.esp")'
+  - name: 'UndeathClassicalLichdom SSE.esp'
     msg:
       - <<: *hasPluginPatch
         subs:
@@ -727,6 +727,7 @@ plugins:
             text: '"Ordinator - Perks of Skyrim.esp" The Thiefs Eye perk will not work because you are technically not entering a city. To fix this, open the console and type set ORD_Pic_ThiefsEye_Global_DisableCityWorldspaceOnly to 1. Do not do this if you are not using Open Cities.[Source notes](https://www.nexusmods.com/skyrimspecialedition/articles/22/).'
     tag:
       - C.Location
+      - C.Regions
   - name: 'Alternate Start - Live Another Life.esp'
     global_priority: 70
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -185,7 +185,6 @@ globals:
  
 
 plugins:
-### Official Update & DLC plugins
   - name: 'Update.esm'
     global_priority: -127
     tag:
@@ -305,7 +304,6 @@ plugins:
         itm: 69
         udr: 8
         nav: 1
-### Creation Club plugins
   - name: 'ccBGSSSE002-ExoticArrows.esl'
     global_priority: -127
     after:
@@ -397,7 +395,6 @@ plugins:
         content:
           - lang: en
             text: '"ccqdrsse001-survivalmode.esl" has a [Known bug](https://www.nexusmods.com/skyrimspecialedition/articles/22/) which is incompatible with "Ordinator - Perks of Skyrim.esp". Consider using the [Unofficial skyrim survival patch](https://www.nexusmods.com/skyrimspecialedition/mods/12655/) to fix this bug.'
-### Unofficial Patches
   - name: 'Unofficial Skyrim Special Edition Patch.esp'
     global_priority: -120
     after:
@@ -413,7 +410,6 @@ plugins:
       # version 2.9
       - crc: 0xF7B1A347
         util: SSEEdit v3.2.1
-### Other Plugins
   - name: 'BSAssets.esm'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/10917/']
     # Beyond Skyrim - Bruma SE

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -185,6 +185,7 @@ globals:
  
 
 plugins:
+### Official Update & DLC plugins
   - name: 'Update.esm'
     global_priority: -127
     tag:
@@ -304,6 +305,7 @@ plugins:
         itm: 69
         udr: 8
         nav: 1
+### Creation Club plugins
   - name: 'ccBGSSSE002-ExoticArrows.esl'
     global_priority: -127
     after:
@@ -395,18 +397,20 @@ plugins:
         content:
           - lang: en
             text: '"ccqdrsse001-survivalmode.esl" has a [Known bug](https://www.nexusmods.com/skyrimspecialedition/articles/22/) which is incompatible with "Ordinator - Perks of Skyrim.esp". Consider using the [Unofficial skyrim survival patch](https://www.nexusmods.com/skyrimspecialedition/mods/12655/) to fix this bug.'
+### Unofficial Patches
   - name: 'Unofficial Skyrim Special Edition Patch.esp'
     global_priority: -120
     after:
       - 'Lanterns Of Skyrim - All In One - Main.esm'
     clean:
-    # Version 4.1.2alpha
+      # Version 4.1.2alpha
       - crc: 0xAE28DBE3
         util: SSEEdit v3.2.1
   - name: 'unofficial skyrim survival patch.esp'
     tag:
       - Graphics
     clean: 
+      # version 2.9
       - crc: 0xF7B1A347
         util: SSEEdit v3.2.1
   - name: 'BSAssets.esm'
@@ -414,10 +418,13 @@ plugins:
       - C.Light
       - C.RecordFlags
     clean:
-    # version 1.3.3
+      # version 1.3.3
       - crc: 0x1D0648B6
         util: SSEEdit v3.2.1
+### Other Plugins
   - name: 'BSHeartland.esm'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/10917/']
+    # Beyond Skyrim - Bruma SE
     msg:
       - <<: *hasPluginPatch
         subs:
@@ -438,7 +445,7 @@ plugins:
       - Invent
       - Names
     dirty:
-    # version 1.3.3
+      # version 1.3.3
       - <<: *dirtyPlugin
         crc: 0x0B12B4E7
         itm: 485
@@ -450,14 +457,17 @@ plugins:
       - crc: 0x6F103898
         util: SSEEdit v3.2.1
   - name: 'BS_DLC_patch.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/10917/']
+    # Beyond Skyrim - DLC Integration Patch
     tag:
       - Delev
       - Invent
     clean:
-    # version 1.1.2
+      # version 1.1.2
       - crc: 0x2BC2FECB
         util: SSEEdit v3.2.1
   - name: 'DLCIntegration.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/8032/']
     msg:
       - <<: *hasPluginPatch
         subs:
@@ -470,15 +480,17 @@ plugins:
       - Names
       - Relev
     clean:
-    # version 1.1
+      # version 1.1
       - crc: 0xA3FB0FAD
         util: SSEEdit v3.2.1
   - name: 'DLCIntegration Beyond Skyrim Compatibility Patch.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/8032/']
     clean:
-    # version 1.1
+      # version 1.1
       - crc: 0x32F4BBE5
         util: SSEEdit v3.2.1
   - name: 'MoonAndStar_MAS.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/4301/']
     after:
       - 'AuroraVillage.esp'
     tag:
@@ -493,6 +505,7 @@ plugins:
       - crc: 0x1DA470CB
         util: SSEEdit v3.2.1
   - name: 'Undeath.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/6180']
     after:
       - 'MoonAndStar_MAS.esp'
     inc:
@@ -530,14 +543,11 @@ plugins:
           - '[Undeath Classical Lichdom Patch For Ordinator](https://www.nexusmods.com/skyrimspecialedition/mods/14823)'
         condition: 'active("Ordinator - Perks of Skyrim.esp") and not active("UndeathClassicalLichdom Ordinator Patch.esp")'
   - name: 'imp_helm_legend.esp'
-    after: 
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/824/']
+    # Improved closeface helmets
+    after:
       - 'MLU.esp'
     msg:
-      - type: warn
-        condition: 'active("MLU.esp") and not active("MLU - Improved Closefaced Helmets.esp")'
-        content:
-          - lang: en
-            text: 'This mod has certain conflicts with "MLU.esp". Consider using the [MLU - Improved Closefaced Helmets patch](https://www.nexusmods.com/skyrimspecialedition/mods/3058/).'
       - type: warn
         condition: 'active("Undeath.esp") and not active("Improved closefaced helmets for Undeath SSE.esp")'
         content:
@@ -559,7 +569,20 @@ plugins:
       - crc: 0xCC6D50A9
         util: SSEEdit v3.2.1
   - name: 'MLU.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/3058/']
+    # Morrowloot Ultimate
     global_priority: 60
+    msg:
+      - <<: *hasPluginPatch
+        subs:
+          - 'Immersive Armors'
+          - '[MLU - Immersive Armors](https://www.nexusmods.com/skyrimspecialedition/mods/3058/)'
+        condition: 'active("Hothtrooper44_ArmorCompilation.esp") and not active("MLU - Immersive Armors.esp")'
+      - <<: *hasPluginPatch
+        subs:
+          - 'Improved Closefaced Helmets'
+          - '[MLU - Improved Closefaced Helmets](https://www.nexusmods.com/skyrimspecialedition/mods/3058/)'
+        condition: 'active("imp_helm_legend.esp") and not active("MLU - Improved Closefaced Helmets.esp")'
     tag:
     - Actors.ACBS
     - Actors.AIData
@@ -574,12 +597,14 @@ plugins:
       - crc: 0x89111F8E
         util: SSEEdit v3.2.1
   - name: 'MLU - Immersive Armors.esp'
+    after:
+      - 'MLU - AAE Ultimate Edition.esp'
     tag:
       - Delev
       - Relev
   - name: 'MLU - Improved Closefaced Helmets.esp'
-    # missing master.
     req:
+      # missing master
       - 'MLU.esp'
     tag:
       - Stats
@@ -592,7 +617,7 @@ plugins:
     tag:
       - Graphics
     clean:
-    # BSA VERSION 2.07
+      # VERSION BSA 2.07
       - crc: 0x35C26177
         util: SSEEdit v3.2.1
   - name: 'SMIM-SE-.*.esp'
@@ -935,59 +960,59 @@ plugins:
         display: 'Skyrim Flora Overhaul'
   - name: 'Valerica.esp'
     after:
-    - name: 'BijinAIO_SSE-3.1.1-SV.esp'
-      display: 'Bijin AIO Legendary plus Serana and Valerica'
+      - name: 'BijinAIO_SSE-3.1.1-SV.esp'
+        display: 'Bijin AIO Legendary plus Serana and Valerica'
     msg:
-    - type: warn
-      content: 'Bijin AIO SSE recomends that you deactivate this ESP.'
-      condition: 'active("Valerica.esp") and active("BijinAIO_SSE-3.1.1-SV.esp")'
+      - type: warn
+        content: 'Bijin AIO SSE recomends that you deactivate this ESP.'
+        condition: 'active("Valerica.esp") and active("BijinAIO_SSE-3.1.1-SV.esp")'
   - name: 'Serana.esp'
     after:
-    - name: 'BijinAIO_SSE-3.1.1-SV.esp'
-      display: 'Bijin AIO Legendary plus Serana and Valerica'
+      - name: 'BijinAIO_SSE-3.1.1-SV.esp'
+        display: 'Bijin AIO Legendary plus Serana and Valerica'
     msg:
-    - type: warn
-      content: 'Bijin AIO SSE recomends that you deactivate this ESP.'
-      condition: 'active("Serana.esp") and active("BijinAIO_SSE-3.1.1-SV.esp")'
+      - type: warn
+        content: 'Bijin AIO SSE recomends that you deactivate this ESP.'
+        condition: 'active("Serana.esp") and active("BijinAIO_SSE-3.1.1-SV.esp")'
   - name: 'Bijin Wives.esp'
     after:
-    - name: 'BijinAIO_SSE-3.1.1-SV.esp'
-      display: 'Bijin AIO Legendary plus Serana and Valerica'
-    - name: 'BijinAIO_SSE-3.1.1.esp'
-      display: 'Bijin AIO Legendary SSE'
+      - name: 'BijinAIO_SSE-3.1.1-SV.esp'
+        display: 'Bijin AIO Legendary plus Serana and Valerica'
+      - name: 'BijinAIO_SSE-3.1.1.esp'
+        display: 'Bijin AIO Legendary SSE'
     msg:
-    - type: warn
-      content: 'Bijin AIO SSE recomends that you deactivate this ESP.'
-      condition: 'active("Bijin Wives.esp") and active("BijinAIO_SSE-3.1.1-SV.esp")'
-    - type: warn
-      content: 'Bijin AIO SSE recomends that you deactivate this ESP.'
-      condition: 'active("Bijin Wives.esp") and active("BijinAIO_SSE-3.1.1.esp")'
+      - type: warn
+        content: 'Bijin AIO SSE recomends that you deactivate this ESP.'
+        condition: 'active("Bijin Wives.esp") and active("BijinAIO_SSE-3.1.1-SV.esp")'
+      - type: warn
+        content: 'Bijin AIO SSE recomends that you deactivate this ESP.'
+        condition: 'active("Bijin Wives.esp") and active("BijinAIO_SSE-3.1.1.esp")'
   - name: 'Bijin NPCs.esp'
     after:
-    - name: 'BijinAIO_SSE-3.1.1-SV.esp'
-      display: 'Bijin AIO Legendary plus Serana and Valerica'
-    - name: 'BijinAIO_SSE-3.1.1.esp'
-      display: 'Bijin AIO Legendary SSE'
+      - name: 'BijinAIO_SSE-3.1.1-SV.esp'
+        display: 'Bijin AIO Legendary plus Serana and Valerica'
+      - name: 'BijinAIO_SSE-3.1.1.esp'
+        display: 'Bijin AIO Legendary SSE'
     msg:
-    - type: warn
-      content: 'Bijin AIO SSE recomends that you deactivate this ESP.'
-      condition: 'active("Bijin NPCs.esp") and active("BijinAIO_SSE-3.1.1-SV.esp")'
-    - type: warn
-      content: 'Bijin AIO SSE recomends that you deactivate this ESP.'
-      condition: 'active("Bijin NPCs.esp") and active("BijinAIO_SSE-3.1.1.esp")'
+      - type: warn
+        content: 'Bijin AIO SSE recomends that you deactivate this ESP.'
+        condition: 'active("Bijin NPCs.esp") and active("BijinAIO_SSE-3.1.1-SV.esp")'
+      - type: warn
+        content: 'Bijin AIO SSE recomends that you deactivate this ESP.'
+        condition: 'active("Bijin NPCs.esp") and active("BijinAIO_SSE-3.1.1.esp")'
   - name: 'Bijin Warmaidens.esp'
     after:
-    - name: 'BijinAIO_SSE-3.1.1-SV.esp'
-      display: 'Bijin AIO Legendary plus Serana and Valerica'
-    - name: 'BijinAIO_SSE-3.1.1.esp'
-      display: 'Bijin AIO Legendary SSE'
+      - name: 'BijinAIO_SSE-3.1.1-SV.esp'
+        display: 'Bijin AIO Legendary plus Serana and Valerica'
+      - name: 'BijinAIO_SSE-3.1.1.esp'
+        display: 'Bijin AIO Legendary SSE'
     msg:
-    - type: warn
-      content: 'Bijin AIO SSE recomends that you deactivate this ESP.'
-      condition: 'active("Bijin Warmaidens.esp") and active("BijinAIO_SSE-3.1.1-SV.esp")'
-    - type: warn
-      content: 'Bijin AIO SSE recomends that you deactivate this ESP.'
-      condition: 'active("Bijin Warmaidens.esp") and active("BijinAIO_SSE-3.1.1.esp")'
+      - type: warn
+        content: 'Bijin AIO SSE recomends that you deactivate this ESP.'
+        condition: 'active("Bijin Warmaidens.esp") and active("BijinAIO_SSE-3.1.1-SV.esp")'
+      - type: warn
+        content: 'Bijin AIO SSE recomends that you deactivate this ESP.'
+        condition: 'active("Bijin Warmaidens.esp") and active("BijinAIO_SSE-3.1.1.esp")'
   - name: 'ElysiumEstate-HFNoKids.esp'
     inc:
       - name: 'ElysiumEstate-HF.esp'
@@ -1145,6 +1170,7 @@ plugins:
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'HarvestOverhaul_Redone.esp'
+    URL: ['https://www.nexusmods.com/skyrimspecialedition/mods/2398/']
     msg:
       - <<: *hasPluginPatch
         subs:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -504,10 +504,7 @@ plugins:
           - lang: en
             text: 'This mod contains wild edits. A manual [SSEEdit](http://www.nexusmods.com/skyrimspecialedition/mods/164) cleaning guide is available [here](https://linnsmusings.wordpress.com/2017/08/27/undeathcleaningguideforle/)'
     tag:
-      - C.Regions
       - Graphics
-      - Invent
-      - -Names
       - Sound
     dirty:
       - <<: *dirtyPlugin
@@ -564,20 +561,15 @@ plugins:
   - name: 'MLU.esp'
     global_priority: 60
     tag:
-      - Actors.ACBS
-      - Actors.AIData
-      - Actors.Stats
-      - C.Location
-      - C.Name
-      - C.RecordFlags
-      - C.Regions
-      - C.Water
-      - Delev
-      - Graphics
-      - Invent
-      - Names
-      - Relev
-      - Stats
+    - Actors.ACBS
+    - Actors.AIData
+    - Actors.Stats
+    - Delev
+    - Graphics
+    - Invent
+    - Names
+    - Relev
+    - Stats
     clean:
       - crc: 0x89111F8E
         util: SSEEdit v3.2.1

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -438,6 +438,7 @@ plugins:
       - Invent
       - Names
     dirty:
+    # version 1.3.3
       - <<: *dirtyPlugin
         crc: 0x0B12B4E7
         itm: 485
@@ -449,18 +450,33 @@ plugins:
       - crc: 0x6F103898
         util: SSEEdit v3.2.1
   - name: 'BS_DLC_patch.esp'
-    # Simple patch can fix conflict with "DLCIntegration.esp", none available at this time.
-    msg:
-      - type: warn
-        condition: 'active("DLCIntegration.esp")'
-        content:
-          - lang: en
-            text: 'This mod has certain conflicts with "DLCIntegration.esp". Consider patching this conflict using [SSEEdit](http://www.nexusmods.com/skyrimspecialedition/mods/164).'
     tag:
       - Delev
       - Invent
     clean:
+    # version 1.1.2
       - crc: 0x2BC2FECB
+        util: SSEEdit v3.2.1
+  - name: 'DLCIntegration.esp'
+    msg:
+      - <<: *hasPluginPatch
+        subs:
+          - 'Beyond Skyrim DLC Integration Patch'
+          - '[DLCIntegration Beyond Skyrim Compatibility Patch](https://www.nexusmods.com/skyrimspecialedition/mods/8032/)'
+        condition: 'active("BS_DLC_patch.esp") and not active("DLCIntegration Beyond Skyrim Compatibility Patch.esp")'
+    tag:
+      - Delev
+      - Invent
+      - Names
+      - Relev
+    clean:
+    # version 1.1
+      - crc: 0xA3FB0FAD
+        util: SSEEdit v3.2.1
+  - name: 'DLCIntegration Beyond Skyrim Compatibility Patch.esp'
+    clean:
+    # version 1.1
+      - crc: 0x32F4BBE5
         util: SSEEdit v3.2.1
   - name: 'MoonAndStar_MAS.esp'
     after:
@@ -1247,15 +1263,6 @@ plugins:
   - name: 'TrueStormsSE.esp'
     tag:
       - Sound
-  - name: 'DLCIntegration.esp'
-    tag:
-      - Delev
-      - Invent
-      - Names
-      - Relev
-    clean:
-      - crc: 0xA3FB0FAD
-        util: SSEEdit v3.2.1
   - name: 'SexLab-AmorousAdventures.esp'
     tag:
       - C.Climate

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1327,3 +1327,21 @@ plugins:
   - name: 'Convenient Horses.esp'
     after:
       - 'Open Cities Skyrim.esp'
+  - name: 'TheChoiceIsYours.esp'
+    after:
+      - 'BetterQuestObjectives.esp'
+      - 'Book Covers Skyrim.esp'
+      - 'Immersive Citizens - AI Overhaul.esp'
+      - 'Relationship Dialogue Overhaul.esp'
+    msg:
+      - <<: *hasPluginPatch
+        subs:
+          - 'Book Covers SE'
+          - '[Book Covers Skyrim](https://www.nexusmods.com/skyrimspecialedition/mods/3850/)'
+        condition: 'active("Book Covers Skyrim.esp") and not active("TCIY_BCS Patch.esp")'
+    tag:
+      - Actors.AIPackages
+      - Names
+    clean:
+      - crc: 0x9F3FDA79
+        util: SSEEdit v3.2.1

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -670,8 +670,8 @@ plugins:
       - Stats
     clean:
       # Version 3.0.6
-      crc: 0x699BC58C
-      util: SSEEdit v3.2.1
+      - crc: 0x699BC58C
+        util: SSEEdit v3.2.1
   - name: 'RLO - Major City Exteriors - No Guard Torches.esp'
     after:
       - 'Realistic Lighting Overhaul - Major City Interiors.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -413,7 +413,10 @@ plugins:
       # version 2.9
       - crc: 0xF7B1A347
         util: SSEEdit v3.2.1
+### Other Plugins
   - name: 'BSAssets.esm'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/10917/']
+    # Beyond Skyrim - Bruma SE
     tag: 
       - C.Light
       - C.RecordFlags
@@ -421,7 +424,6 @@ plugins:
       # version 1.3.3
       - crc: 0x1D0648B6
         util: SSEEdit v3.2.1
-### Other Plugins
   - name: 'BSHeartland.esm'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/10917/']
     # Beyond Skyrim - Bruma SE

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -769,9 +769,15 @@ plugins:
       - 'EBM_UnlimitedPower_Vampire.esp'
       - 'EBM_UnlimitedPower_Werewolf.esp'
   - name: 'SkyUI_SE.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/12604/']
     req:
       - *SKSE64
+    clean:
+      # Version 5.2
+      - crc: 0x79ACE179
+        util: SSEEdit v3.2.1
   - name: 'Open Cities Skyrim.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/281/']
     global_priority: 70
     after:
       - 'Unique Region Names.esp'
@@ -787,6 +793,10 @@ plugins:
     tag:
       - C.Location
       - C.Regions
+    clean:
+      # Version 3.0.4
+      - crc: 0xD16C3B49
+        util: SSEEdit v3.2.1
   - name: 'Alternate Start - Live Another Life.esp'
     global_priority: 70
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -498,12 +498,14 @@ plugins:
     tag:
       - C.Location
     dirty:
+      # Version 3.2
       - <<: *dirtyPlugin
         crc: 0xEB5AEFAF
         itm: 1
         udr: 0
         nav: 0
     clean:
+      # Version 3.2
       - crc: 0x1DA470CB
         util: SSEEdit v3.2.1
   - name: 'Undeath.esp'
@@ -527,19 +529,20 @@ plugins:
       - Graphics
       - Sound
     dirty:
+      # Version 3.2
       - <<: *dirtyPlugin
         crc: 0xEB75A960
         itm: 18
         udr: 0
         nav: 0
+      # Version 3.2 without wild edits
       - <<: *dirtyPlugin
         crc: 0x6E988E26
         itm: 17
         udr: 0
         nav: 0
     clean:
-      - crc: 0x8249EC41
-        util: SSEEdit v3.2.1
+      # Version 3.2 Cleaned without wild edits
       - crc: 0xB98044B4
         util: SSEEdit v3.2.1
   - name: 'UndeathClassicalLichdom SSE.esp'
@@ -904,10 +907,10 @@ plugins:
   - name: 'DeadlyCombat.esp'
     msg:
       - type: info
-        condition: 'active("DeadlyCombat.esp") and not active("DeadlyCombat_Ordinator_Patch.esp")'
+        condition: 'active("Ordinator - Perks of Skyrim.esp") and not active("DeadlyCombat_Ordinator_Patch.esp")'
         content:
           - lang: en
-            text: 'An optional compatibility patch, which changes  a few perks to match Deadly Combats design is available on the [Deadly Combat page](https://www.nexusmods.com/skyrimspecialedition/mods/8850/).'
+            text: 'An optional compatibility patch is available for Ordinator. The patch alters a few perks to match Deadly Combats design, it is available on the [Deadly Combat page](https://www.nexusmods.com/skyrimspecialedition/mods/8850/).'
   - name: 'Elemental Destruction.esp'
     msg:
       - <<: *hasPluginPatch
@@ -1328,6 +1331,7 @@ plugins:
     after:
       - 'Open Cities Skyrim.esp'
   - name: 'TheChoiceIsYours.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/3850/']
     after:
       - 'BetterQuestObjectives.esp'
       - 'Book Covers Skyrim.esp'
@@ -1343,5 +1347,6 @@ plugins:
       - Actors.AIPackages
       - Names
     clean:
+      # Version 3.2
       - crc: 0x9F3FDA79
         util: SSEEdit v3.2.1


### PR DESCRIPTION
Removed some implicit USSEP bash tags
- Tags removed were result of changes forwarded from Unofficial Skyrim Special Edition Patch, which was not an explicit master.

DLC Integration SE 
- Add Compatibility patch for Beyond Skyrim Bruma & warning message.
- Clean plugin info added for Compatibility patch
- Moved just below BS Skyrim entry for clarity, since I was adding the Compatibility patch.

Realistic Water Two
- Add bash tag Sound
- Clean plugin info

New Entry's Added
- Serana dialogue Edit
- The Choice is Yours
- DLC Integration Beyond Skyrim Compatibility Patch SE
- RLO - Latest version uses different naming scheme.
- Unlimited bookshelves.

Navigation
- Add Comment where Mod name was not clear from plug-in name.

Cleanup
- indentation fixes
- Replace warn messages with *hasPluginPatch where possible.