### PR TITLE
Fixed SkyrimIsWindy patch order

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1339,9 +1339,10 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2829' ]
     after:
       - 'JKs Whiterun.esp'
-  - name: 'SkyrimIsWindy.esp'
+  - name: 'SkyrimIsWindy - EVT patch.esp'
     after:
-      - 'SkyrimIsWindy - EVT patch.esp'
+      - 'SkyrimIsWindy.esp'
+      - 'SRG Enhanced Trees Activator.esp'
   - name: 'Convenient Horses.esp'
     after:
       - 'Open Cities Skyrim.esp'


### PR DESCRIPTION
Fixed an Issue where loot tried to load the "SkyrimIsWindy - EVT patch.esp" before the patched file "SkyrimIsWindy.esp".