### PR TITLE
Metadata Update - BCS & BCS Lost Library - URL, Bash tags, Clean plug-in info & Load After Rules

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1346,3 +1346,36 @@ plugins:
   - name: 'Convenient Horses.esp'
     after:
       - 'Open Cities Skyrim.esp'
+  - name: 'Book Covers Skyrim.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/901/'
+        name: 'Book Covers Skyrim on Nexus Mods'
+      - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3071870/'
+        name: 'Book Covers Skyrim - Original on Bethesda.net'
+      - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3072082'
+        name: 'Book Covers Skyrim - Desaturated on Bethesda.net'
+    after:
+      - 'UnlimitedBookshelves.esp'
+      - 'Weightless Books.esp'
+      - 'WeightlessOV - Book.esp'
+    tag:
+      - Graphics
+      - Names
+    clean:
+      # version 4.2
+      - crc: 0x32587221
+        util: SSEEdit v3.2.1
+  - name: 'Book Covers Skyrim - Lost Library.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/902/'
+        name: 'Book Covers Skyrim on Nexus Mods'
+      - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3203152'
+        name: 'BCS Lost Library - Original on Bethesda.net'
+      - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3203032'
+        name: 'BCS Lost Library - Desaturated on Bethesda.net'
+    tag:
+      - Delev
+    clean:
+      # version 2.1
+      - crc: 0xDD84DD4C
+        util: SSEEdit v3.2.1


### PR DESCRIPTION
Book Covers Skyrim
- Load after rules taken from checking compatibility notes & conflicts in xEdit
- Unlimited Bookshelves, weightless books

BCS: Lost Library
- Delev tag, alters level list for merchants.

- Clean plugin info verified for both in xEdit