### PR TITLE
Remove Implicit USSEP Bash tags & RWT Clean plug-in info

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1021,10 +1021,9 @@ plugins:
       - 'CFTO.esp'
       - 'Honeyside.esp'
     tag:
-      - C.Location
-      - C.Regions
       - C.Water
       - Graphics
+      - Sound
   - name: 'SSEMerged.esp'
     global_priority: 80
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -493,7 +493,6 @@ plugins:
       - 'AuroraVillage.esp'
     tag:
       - C.Location
-      - C.Water
     dirty:
       - <<: *dirtyPlugin
         crc: 0xEB5AEFAF
@@ -520,11 +519,7 @@ plugins:
           - lang: en
             text: 'This mod contains wild edits. A manual [SSEEdit](http://www.nexusmods.com/skyrimspecialedition/mods/164) cleaning guide is available [here](https://linnsmusings.wordpress.com/2017/08/27/undeathcleaningguideforle/)'
     tag:
-      - C.Regions
-      - C.Water
       - Graphics
-      - Invent
-      - -Names
       - Sound
     dirty:
       - <<: *dirtyPlugin
@@ -602,11 +597,6 @@ plugins:
       - Actors.ACBS
       - Actors.AIData
       - Actors.Stats
-      - C.Location
-      - C.Name
-      - C.RecordFlags
-      - C.Regions
-      - C.Water
       - Delev
       - Graphics
       - Invent
@@ -1061,9 +1051,6 @@ plugins:
           - 'Ordinator - Perks of Skyrim'
           - '[Apocalypse - Ordinator Compatibility Patch](https://www.nexusmods.com/skyrimspecialedition/mods/1090/)'
         condition: 'active("Ordinator - Perks of Skyrim.esp") and not active("Apocalypse - Ordinator Compatibility Patch.esp")'
-    tag:
-      - C.Water
-      - C.Regions
     clean:
       # Version 9.45SSE
       - crc: 0x266B3B3B
@@ -1111,7 +1098,6 @@ plugins:
       - 'PerkusMaximus_CombatPlus.esp'
     tag:
       - C.Regions
-      - C.Water
       - Graphics
       - Names
       - Sound

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1024,6 +1024,10 @@ plugins:
       - C.Water
       - Graphics
       - Sound
+    clean:
+      # Version 1.4.4
+      - crc: 0xB2812DAF
+        util: SSEEdit v3.2.1
   - name: 'SSEMerged.esp'
     global_priority: 80
     tag:


### PR DESCRIPTION
Removed some implicit USSEP bash tags

Tags removed were result of changes forwarded from Unofficial Skyrim Special Edition Patch, which was not an explicit master.

Realistic water two
- Added sound tag as it modifies audio. Attenuation Values (ANAM)
- clean plug-in info added.