### PR TITLE
Serana Dialogue Edit - Load after RDO

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1660,3 +1660,11 @@ plugins:
       # version 2.1
       - crc: 0xDD84DD4C
         util: SSEEdit v3.2.1
+  - name: 'Serana Dialogue Edit.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/16222/']
+    after:
+      - 'Relationship Dialogue Overhaul.esp'
+    clean:
+      # Version 0.9
+      - crc: 0x586D2620
+        util: SSEEdit v3.2.1

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1691,6 +1691,7 @@ plugins:
     clean:
       # Version 0.9
       - crc: 0x586D2620
+        util: SSEEdit v3.2.1
   - name: 'TheChoiceIsYours.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/3850/']
     after:


### PR DESCRIPTION
Relationship Dialogue Overhaul is sorted after Serana Dialogue Edit if Alt Star or Immersive citizens are installed, which breaks functionality in Serana Dialogue Edit.