### PR TITLE
Add BSA version of SMIM - not sorted correctly - different esp name

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -642,6 +642,16 @@ plugins:
   # Static Mesh Improvement Mod - Modular installer
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/659/']
     global_priority: -90
+  - name: 'SMIM-SE.esp'
+  # Static Mesh Improvement Mod SE - BSA version
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/659/']
+    global_priority: -90
+    tag:
+      - Graphics
+    clean:
+      # 2.07
+      - crc: 0x35C26177
+        util: SSEEdit v3.2.1
   - name: 'TouringCarriages.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/15948/']
     global_priority: -90


### PR DESCRIPTION
As it is not being sorted correctly due to name change.