### PR TITLE
v0.10- Trade barter - Add bash tags & Load after rule

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1721,3 +1721,11 @@ plugins:
       # 3.2
       - crc: 0x9F3FDA79
         util: SSEEdit v3.2.1
+  - name: 'TradeBarter.esp'
+    req:
+      - *SkyUI
+    url: ['https://www.nexusmods.com/skyrim/mods/34612/']
+    tag:
+      - Delev
+      - Invent
+      - Relev

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1725,12 +1725,16 @@ plugins:
     req:
       - *SkyUI
     url: ['https://www.nexusmods.com/skyrim/mods/34612/']
+    after:
+      - 'EconomyOverhaulandSpeechcraftImprovements.esp'
     tag:
       - Delev
       - Invent
       - Relev
   - name: 'TradeBarterLite.esp'
     url: ['https://www.nexusmods.com/skyrim/mods/34612/']
+    after:
+      - 'EconomyOverhaulandSpeechcraftImprovements.esp'
     tag:
       - Delev
       - Invent

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1729,3 +1729,9 @@ plugins:
       - Delev
       - Invent
       - Relev
+  - name: 'TradeBarterLite.esp'
+    url: ['https://www.nexusmods.com/skyrim/mods/34612/']
+    tag:
+      - Delev
+      - Invent
+      - Relev


### PR DESCRIPTION
- Oldrim mod but lightweight and easy to convert. It has been used in a few modding guides & step forum mod packs for SSE.
- Bash detection scripts only recommend Delev & Invent, but from research and testing it needs to be tagged with Relev, otherwise the changes by that mod are not preserved in the Bash patch. It also had these tags in Oldrim masterlist.
- Trade barter needs to load after Economy Overhaul for bash patch to successfully preserve and merge changes from both mods,
