### PR TITLE
Load Convenient Horses after Immersive Citizens & Relationship Dialogue Overhaul

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1699,6 +1699,8 @@ plugins:
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/9519/']
     after:
       - 'Open Cities Skyrim.esp'
+      - 'Immersive Citizens - AI Overhaul.esp'
+      - 'Relationship Dialogue Overhaul.esp'
   - name: 'Book Covers Skyrim.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/901/'


### PR DESCRIPTION
Relationship Dialogue Overhaul & Immersive Citizens overwrite a stables quest important to the functionality of convenient horses.