### PR TITLE
Load Audio Overhaul 2 -RWT patch after Realistic Water Two

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1948,3 +1948,7 @@ plugins:
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'Stealth Skills Rebalanced_COMPLETE.esp'
       - 'Thief skills rebalance for Ordinator.esp'
+  - name: 'Audio Overhaul Skyrim - RealisticWaterTwo Patch.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/12466/']
+    after:
+      - 'RealisticWaterTwo.esp'


### PR DESCRIPTION
- missing master in Audio Overhaul 2 -RWT patch causes it to load above Realistic water two.