### PR TITLE
Cutting room floor & Bring out your dead - Load after rules

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -686,6 +686,8 @@ plugins:
         name: 'Cutting Room Floor on Bethesda.net'
     global_priority: -90
     after:
+      - 'BetterQuestObjectives.esp'
+      - 'Book Covers Skyrim.esp'
       - 'TouringCarriages.esp'
       - 'WhiterunHoldForest.esp'
     tag:
@@ -955,6 +957,7 @@ plugins:
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/2956453'
         name: 'Bring Out Your Dead on Bethesda.net'
     after:
+      - 'BetterQuestObjectives.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
     global_priority: -90
   - name: 'Darkwater Crossing.esp'


### PR DESCRIPTION
Cutting room floor
- Better quest objectives (Has patch in installer for CRF) & Book covers skyrim(No patch available, lose a few textures) to preserve scripts trigger which are needed for quests.
BOYD

Bring out your dead.
- Load after Better quest objectives to keep no dead body cleanup script trigger on a quest (No patch available, lose one quest description).