### PR TITLE
Load Realistic Horse Breeds after Convenient Horses

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1903,6 +1903,23 @@ plugins:
       - 'Open Cities Skyrim.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'Relationship Dialogue Overhaul.esp'
+  - name: 'KrittaKittyHorsesForSSE.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/7685/'
+        name: 'Realistic Horse Breeds by KrittaKitty on Nexus Mods'
+    after:
+      - 'Convenient Horses.esp'
+    dirty:
+        # version 2.4D
+      - crc: 0x6E242E9E
+        <<: *dirtyPlugin
+        itm: 1
+        udr: 0
+        nav: 0
+    clean:
+        # version 2.4D
+      - crc: 0x16CF39A0
+        util: SSEEdit v3.2.1
   - name: 'Book Covers Skyrim.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/901/'


### PR DESCRIPTION
- Reported on Nexus loot page.
- Tested in xEdit and verified.
- Also recommended to load Realistic Horse Breeds after CH in Convenient horse compatibility notes.