### PR TITLE
Add tags for Diverse Skyrim SSE

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2067,3 +2067,8 @@ plugins:
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/12466/']
     after:
       - 'RealisticWaterTwo.esp'
+  - name: 'DIVERSE SKYRIM.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/7707/']
+    tag:
+      - Delev
+      - Relev


### PR DESCRIPTION
adds Diverse Skyrim SSE and the relev and delev tags needed for wrye bash to respect its list changes. No sorting data because the mod has no known conflicts.