### PR TITLE
Merge immersive Citizens group into Alt Start Group.

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -226,9 +226,6 @@ groups:
   - name: &raceGroup Races
     after: [ default ]
 
-  - name: &immersiveCitizensGroup Immersive Citizens
-    after: [ default ]
-
   - name: &followerGroup Followers
     after: [ *raceGroup ]
 
@@ -1614,7 +1611,7 @@ plugins:
         name: 'Immersive Citizens - AI Overhaul SE on Nexus Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3016198'
         name: 'Immersive Citizens - AI Overhaul [PC] on Bethesda.net'
-    group: *immersiveCitizensGroup
+    group: *alternateStartGroup
     after:
       - '3DNPC.esp'
       - 'Alternate Start - Live Another Life.esp'
@@ -1793,7 +1790,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/1377/'
         name: 'Enhanced Lighting for ENB (ELE) - Special Edition on Nexus Mods'
-    group: *immersiveCitizensGroup
+    group: *alternateStartGroup
     after:
       - 'Alternate Start - Live Another Life.esp'
       - 'Ars Metallica.esp'


### PR DESCRIPTION
- ELE_SSE & ICAIO are the only mods in immersiveCitizensGroup, both are set to load after alt start.