### PR TITLE
[Meta Data] Add catch all for Realistic Water Two Patches included in…

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1390,6 +1390,13 @@ plugins:
       # Version 1.4.4
       - crc: 0xB2812DAF
         util: SSEEdit v3.2.1
+  # Catch all for Patches included in installer
+  - name: 'RealisticWaterTwo.*\.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2182/']
+    group: *alternateStartGroup
+  - name: 'RWT.*\.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2182/']
+    group: *alternateStartGroup
   - name: 'RealisticWaterTwo+-+Verdant+Patch.esp'
     group: *alternateStartGroup
   - name: 'SSEMerged.esp'


### PR DESCRIPTION
… installer

Patches included
- iNeed 'RealisticWaterTwo - iNeed.esp'
- Open Cities 'RealisticWaterTwo - Open Cities.esp'
- 'RealisticWaterTwo - Watercolor.esp'
- People of Skyrim 'RWT - People of Skyrim Patch.esp'