### PR TITLE
RDO - Update load after rules - Add Compatibilty checks & Cleaning info

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1862,7 +1862,7 @@ plugins:
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/1187/']
     inc:
       - name: 'Immersive Horses.esp'
-        condition: 'active("Immersive Horses.esp") and not active("Relationship Dialogue Overhaul - Immersive Horses Patch.esp" and not active("RDO - Immersive Horses Patch.esp")'
+        condition: 'active("Immersive Horses.esp") and not active("Relationship Dialogue Overhaul - Immersive Horses Patch.esp") and not active("RDO - Immersive Horses Patch.esp")'
       - name: 'Amazing Follower Tweaks'
         condition: 'checksum("AmazingFollowerTweaks.esp",88F9C8B8) and not active("RDO - AFT v1.66 Patch.esp")'
       - name: 'Immersive Amazing Follower Tweaks'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1860,31 +1860,94 @@ plugins:
       - 'Landscape Fixes For Grass Mods.esp'
   - name: 'Relationship Dialogue Overhaul.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/1187/']
+    inc:
+      - name: 'Immersive Horses.esp'
+        condition: 'active("Immersive Horses.esp") and not active("Relationship Dialogue Overhaul - Immersive Horses Patch.esp" and not active("RDO - Immersive Horses Patch.esp")'
+      - name: 'Amazing Follower Tweaks'
+        condition: 'checksum("AmazingFollowerTweaks.esp",88F9C8B8) and not active("RDO - AFT v1.66 Patch.esp")'
+      - name: 'Immersive Amazing Follower Tweaks'
+        condition: 'checksum("AmazingFollowerTweaks.esp",88C2EA38) and not active("RDO - iAFT Patch.esp")'
+      - name: 'Extensible Follower Framework'
+        condition: 'checksum("EFFDialogue.esp",E0305B2C) and not active("RDO - EFF v4.0.2 Patch.esp")'
     after:
-      - 'Alternate Start - Live Another Life.esp'
       - 'AmazingFollowerTweaks.esp'
-      - 'BijinAIO_SSE-3.1.1.esp'
-      - 'Cutting Room Floor.esp'
+      - 'FCO - Follower Commentary Overhaul.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
-      - 'Immersive Horses.esp'
-      - 'Open Cities Skyrim.esp'
-      - 'Unofficial Skyrim Legendary Edition Path.esp'
+    msg:
+      - <<: *hasPluginPatch
+        subs:
+          - 'Amazing Follower Tweaks'
+          - '[RDO - AFT SE Patch Final](https://www.nexusmods.com/skyrimspecialedition/mods/1187/)'
+        condition: 'checksum("AmazingFollowerTweaks.esp",88F9C8B8) and not active("RDO - AFT v1.66 Patch.esp")'
+      - <<: *hasPluginPatch
+        subs:
+          - 'Immersive Amazing Follower Tweaks'
+          - '[RDO - iAFT SE Patch Final](https://www.nexusmods.com/skyrimspecialedition/mods/1187/)'
+        condition: 'checksum("AmazingFollowerTweaks.esp",88C2EA38) and not active("RDO - iAFT Patch.esp")'
+      - <<: *hasPluginPatch
+        subs:
+          - 'Extensible Follower Framework'
+          - '[RDO - EFF v4.0.3 Patch Final](https://www.nexusmods.com/skyrimspecialedition/mods/1187/)'
+        condition: 'active("EFFDialogue.esp") and not active("RDO - EFF v4.0.2 Patch.esp")'
+      - <<: *hasPluginPatch
+        subs:
+          - 'Immersive Horses'
+          - '[Miscellaneous Patches](https://www.nexusmods.com/skyrimspecialedition/mods/17700/)'
+        condition: 'active("Immersive Horses.esp") and not active("Relationship Dialogue Overhaul - Immersive Horses Patch.esp") and not active("RDO - Immersive Horses Patch.esp")'
+      - <<: *hasPluginPatch
+        subs:
+          - 'Cutting Room Floor'
+          - '[RDO - CRF and USSEP Patches Final](https://www.nexusmods.com/skyrimspecialedition/mods/1187/)'
+        condition: 'active("Cutting Room Floor.esp") and not active("RDO - CRF + USSEP Patch.esp")'
+      - <<: *hasPluginPatch
+        subs:
+          - 'Unofficial Skyrim Special Edition Patch'
+          - '[RDO - CRF and USSEP Patches Final](https://www.nexusmods.com/skyrimspecialedition/mods/1187/)'
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("RDO - USSEP Patch.esp") and not active("RDO - CRF + USSEP Patch.esp")'
+    clean:
+      # Version Final
+      - crc: 0x20DC9B97
+        util: SSEEdit v3.2.1
   - name: 'RDO - CRF + USSEP Patch.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/1187/']
     after:
       - 'Relationship Dialogue Overhaul.esp'
     inc:
       - 'RDO - USSEP Patch.esp'
+    clean:
+      # Version Final
+      - crc: 0xA2753357
+        util: SSEEdit v3.2.1
   - name: 'RDO - USSEP Patch.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/1187/']
     after:
       - 'Relationship Dialogue Overhaul.esp'
     inc:
       - 'RDO - CRF + USSEP Patch.esp'
+    clean:
+      # Version Final
+      - crc: 0x44DE71B0
+        util: SSEEdit v3.2.1
   - name: 'RDO - AFT v1.66 Patch.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/1187/']
     after:
       - 'Relationship Dialogue Overhaul.esp'
+    clean:
+      # Version Final
+      - crc: 0x88F9C8B8
+        util: SSEEdit v3.2.1
+  - name: 'RDO - iAFT Patch.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/1187/']
+    clean:
+      # Version Final
+      - crc: 0x88C2EA38
+        util: SSEEdit v3.2.1
+  - name: 'RDO - EFF v4.0.2 Patch.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/1187/']
+    clean:
+      # Version Final
+      - crc: 0xAE1B1EDF
+        util: SSEEdit v3.2.1
   - name: 'SexyMannequinVyktoria_SSE.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2128/']
     inc:


### PR DESCRIPTION
## Relationship Dialogue Overhaul - RDO SE

- Added incompatibility check if patch is not present for follower mods.
- Added available patch messages.

Removed load after rules that were not mandatory.
- USSEP & Cutting Room Floor patches are available, plug-in order does not matter for patch to function correctly.
- Open Cities Skyrim, no conflicts in xEdit and there are no recommendations in mod note to load it after OCS.
- Alternate Start, not a mandatory load after, only 4 records conflict. And it does not break anything to load either way. I think it's best to leave this one to the user as it can have a knock on effect for other mods.

- BijinAIO , Same as Alt start, can be loaded either way, so a load after rule is not required.

-Immersive Horses , plug-in order does not matter between mods. However the compatibility patch is mandatory.

- Extensible Follower Framework, plug-in order RDO -> EFF -> Patch. The compatibility patch is mandatory.

- FCO - Follower Commentary Overhaul. required load after rule.

Add clean plug-in info for main file and patches.
