### PR TITLE
[Meta Data] Beyond Skyrim Bruma  - Update Cleaning Info

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -711,12 +711,10 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x0B12B4E7
         itm: 485
-        udr: 3
+        udr: 0
         nav: 0
     clean:
-      - crc: 0x32285268
-        util: SSEEdit v3.2.1
-      - crc: 0x6F103898
+      - crc: 0x4CC6CB6C
         util: SSEEdit v3.2.1
   - name: 'BS_DLC_patch.esp'
   # Beyond Skyrim - DLC Integration Patch


### PR DESCRIPTION
- Cleaning Info updated.
- xEdit is no longer flagging those 3 UDR, I had reported the issue as it seemed strange that a disabled record was being marked for delete, but assumed it was correct.