### PR TITLE
Update - Default Groups

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -643,6 +643,7 @@ plugins:
         util: SSEEdit v3.2.1
   - name: 'unofficial skyrim survival patch.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/12655/']
+    group: *fixesResourcesGroup
     clean:
       - crc: 0xF7B1A347
         util: SSEEdit v3.2.1
@@ -738,6 +739,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/14084/'
         name: 'Skyrim Project Optimization SE on Nexus Mods'
+    group: *fixesResourcesGroup
     clean:
       # Version 1.3
       - crc: 0x137A03B3
@@ -811,7 +813,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/824/'
         name: 'Improved closefaced helmets on Nexus Mods'
-    group: *fixesResourcesGroup
     after:
       - 'Circlets and Masks with all Robes and Hoods.esp'
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -218,49 +218,41 @@ globals:
     subs: [ '[Achievements Mods Enabler](https://www.nexusmods.com/skyrimspecialedition/mods/245)' ]
     condition: 'file("SKSE/Plugins/AchievementsModsEnabler.dll") and not file("../skse64_loader.exe")'
 
-
-
 groups:
   - name: &dlcGroup DLC
 
-  - name: &unofficialPatchGroup Unofficial Patches
+  - name: &earlyLoadersGroup Early Loaders
     after: [ *dlcGroup ]
 
-  - name: &hairReplacerGroup Hair Replacer
-    after: [ *unofficialPatchGroup ]
+  - name: &fixesResourcesGroup Fixes & Resources
+    after: [ *earlyLoadersGroup ]
 
-  - name: &lowPriorityGroup Low Priority Overrides
-    after: [ *hairReplacerGroup ]
+  - name: &addonsGroup Add-ons & Expansions
+    after: [ *fixesResourcesGroup ]
 
-  - name: &facePresetGroup Face Presets
-    after: [ *lowPriorityGroup ]
+  - name: &overhaulsGroup Large Overhauls
+    after: [ *fixesResourcesGroup ]
 
   - name: default
-    after: [ *facePresetGroup ]
+    after: [ *overhaulsGroup, *addonsGroup ]
 
-  - name: &raceGroup Races
+  - name: &lowPriorityGroup Low Priority Overrides
     after: [ default ]
 
-  - name: &followerGroup Followers
-    after: [ *raceGroup ]
-
-  - name: &mluGroup MorroLoot Ultimate
-    after: [ *followerGroup ]
-
-  - name: &alternateStartGroup Alternate Start
-    after: [ *mluGroup ]
+  - name: &highPriorityGroup High Priority Overrides
+    after: [ *lowPriorityGroup ]
 
   - name: &lateLoadersGroup Late Loaders
-    after: [ *alternateStartGroup ]
+    after: [ *highPriorityGroup ]
 
   - name: &dynamicPatchGroup Dynamic Patches
     after: [ *lateLoadersGroup ]
 
-  - name: &mapMarkersGroup Map Markers
+  - name: &lateChangesGroup Late Fixes & Changes
     after: [ *dynamicPatchGroup ]
 
   - name: &dynamicLODGroup Dynamic LOD
-    after: [ *mapMarkersGroup ]
+    after: [ *lateChangesGroup ]
 
 plugins:
   - name: 'Update.esm'
@@ -636,7 +628,7 @@ plugins:
         name: 'Unofficial Skyrim Special Edition Patch on Afk Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/2947658'
         name: 'Unofficial Skyrim Special Edition Patch on Bethesda.net'
-    group: *unofficialPatchGroup
+    group: *fixesResourcesGroup
     after:
       - 'Lanterns Of Skyrim - All In One - Main.esm'
     clean:
@@ -663,6 +655,7 @@ plugins:
         name: 'Beyond Skyrim - Bruma SE on Nexus Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/4027835'
         name: 'Beyond Skyrim: Bruma SE Assets on Bethesda.net'
+    group: *addonsGroup
     tag:
       - C.Light
       - C.RecordFlags
@@ -677,6 +670,7 @@ plugins:
         name: 'Beyond Skyrim - Bruma SE on Nexus Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/4027831'
         name: 'Beyond Skyrim: Bruma SE on Bethesda.net'
+    group: *addonsGroup
     msg:
       - <<: *hasPluginPatch
         subs:
@@ -723,6 +717,7 @@ plugins:
         name: 'Beyond Skyrim - Bruma SE on Nexus Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/4044167'
         name: 'Beyond Skyrim: Bruma SE DLC Patch on Bethesda.net'
+    group: *addonsGroup
     tag:
       - Delev
       - Invent
@@ -734,6 +729,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/14084/'
         name: 'Skyrim Project Optimization SE on Nexus Mods'
+    group: *fixesResourcesGroup
     clean:
       # Version 1.3
       - crc: 0x45374C76
@@ -752,6 +748,7 @@ plugins:
         name: 'Moon and Star on Nexus Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3107024'
         name: 'Moon And Star on Bethesda.net'
+    group: *addonsGroup
     after:
       - 'AuroraVillage.esp'
     tag:
@@ -771,6 +768,7 @@ plugins:
         name: 'Undeath Remastered SE on Nexus Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3327746'
         name: 'Undeath Remastered on Bethesda.net'
+    group: *addonsGroup
     after:
       - 'MoonAndStar_MAS.esp'
     inc:
@@ -813,9 +811,9 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/824/'
         name: 'Improved closefaced helmets on Nexus Mods'
+    group: *fixesResourcesGroup
     after:
       - 'Circlets and Masks with all Robes and Hoods.esp'
-      - 'MLU.esp'
     msg:
       - type: warn
         condition: 'active("MLU.esp") and not active("MLU - Improved Closefaced Helmets.esp")'
@@ -856,7 +854,6 @@ plugins:
         # ESP Replacer with name changes added.
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10'
         name: 'Another Sorting Mod on Nexus Mods'
-    group: *mluGroup
     tag:
       - Actors.ACBS
       - Actors.AIData
@@ -891,15 +888,15 @@ plugins:
       - crc: 0xB8A1EE4E
         util: SSEEdit v3.2.1
   - name: 'static mesh improvement mod se.esp'
-    group: *lowPriorityGroup
+    group: *overhaulsGroup
   - name: 'SMIM-SE-.*.esp'
   # Static Mesh Improvement Mod - Modular installer
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/659/']
-    group: *lowPriorityGroup
+    group: *overhaulsGroup
   - name: 'SMIM-SE.esp'
   # Static Mesh Improvement Mod SE - BSA version
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/659/']
-    group: *lowPriorityGroup
+    group: *overhaulsGroup
     tag:
       - Graphics
     clean:
@@ -908,7 +905,7 @@ plugins:
         util: SSEEdit v3.2.1
   - name: 'TouringCarriages.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/15948/']
-    group: *lowPriorityGroup
+    group: *earlyLoadersGroup
   - name: 'Cutting Room Floor.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/276/'
@@ -917,7 +914,7 @@ plugins:
         name: 'Cutting Room Floor on Afk Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/2955350'
         name: 'Cutting Room Floor on Bethesda.net'
-    group: *lowPriorityGroup
+    group: *addonsGroup
     after:
       - 'TouringCarriages.esp'
       - 'UnlimitedBookshelves.esp'
@@ -1006,10 +1003,10 @@ plugins:
       - NoMerge
   - name: 'Hair Replacer.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/7409/']
-    group: *hairReplacerGroup
+    group: *fixesResourcesGroup
   - name: 'Hair Replacer Assets.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/7409/']
-    group: *hairReplacerGroup
+    group: *fixesResourcesGroup
     after:
       - 'Hair Replacer.esp'
   - name: 'Better Vampires.esp'
@@ -1095,7 +1092,7 @@ plugins:
         name: 'Open Cities Skyrim on Afk Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/2918135'
         name: 'Open Cities Skyrim on Bethesda.net'
-    group: *alternateStartGroup
+    group: *highPriorityGroup
     inc:
       - 'JKs Skyrim.esp'
       - 'Oblivion Gates in Cities.esp'
@@ -1140,7 +1137,7 @@ plugins:
         name: 'Alternate Start - Live Another Life on Afk Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/2918710'
         name: 'Alternate Start - Live Another Life on Bethesda.net'
-    group: *alternateStartGroup
+    group: *highPriorityGroup
     inc:
       - 'Original Opening Scene.esp'
       - 'Random Alternate Start.esp'
@@ -1365,7 +1362,7 @@ plugins:
         name: 'Bring Out Your Dead on Afk Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/2956453'
         name: 'Bring Out Your Dead on Bethesda.net'
-    group: *lowPriorityGroup
+    group: *addonsGroup
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
     tag:
@@ -1544,7 +1541,7 @@ plugins:
       - 'Bashed Patch.*\.esp'
   - name: 'Dawnguard Map Markers.esp'
     url: ['https://afkmods.iguanadons.net/index.php?/files/file/1896-dawnguard-map-markers/']
-    group: *mapMarkersGroup
+    group: *lateChangesGroup
     after:
       - 'Bashed Patch.*\.esp'
     clean:
@@ -1590,7 +1587,7 @@ plugins:
     # Many mods that were found to trigger the brawl bug come with an included copy of the (obsolete)Brawl Bugs Patch.
     # Load the Modern Brawl Bug Fix after them, preferably at the end of your load order to be sure there is nothing overwriting it.
     # (This will not impede the functionality of said other mods.)
-    group: *mapMarkersGroup
+    group: *lateChangesGroup
     after:
       - 'Bashed Patch.*\.esp'
     msg:
@@ -1663,7 +1660,6 @@ plugins:
         name: 'Imperious - Races of Skyrim on Nexus Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/2985912'
         name: 'Imperious - Races of Skyrim [PC] on Bethesda.net'
-    group: *raceGroup
     tag:
       - Body-Size-F
       - Body-Size-M
@@ -1711,6 +1707,7 @@ plugins:
         # Tweaks for Verdant esp Replacer
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/9005/'
         name: 'Landscape Fixes For Grass Mods on Nexus Mods'
+    group: *earlyLoadersGroup
     after:
       - name: 'Skyrim Flora Overhaul.esp'
         display: 'Skyrim Flora Overhaul'
@@ -1939,6 +1936,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/173/'
         name: 'Immersive Citizens - Open Cities patch on Nexus Mods'
+    group: *highPriorityGroup
     clean:
       # version 0.4
       - crc: 0x6227D18D
@@ -2114,7 +2112,7 @@ plugins:
       - 'SexyMannequinsVyktorVyktoria_SSE.esp'
       - 'SexyMannequinVyktoria_SSE.esp'
   - name: 'Severa_CharPreset.esp'
-    group: *facePresetGroup
+    group: *fixesResourcesGroup
     inc:
       - 'Kayla_CharPreset.esp'
       - 'Lagertha_CharPreset.esp'
@@ -2127,7 +2125,7 @@ plugins:
       - NoMerge
   - name: 'Lydia Face Preset 64bit.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/1080/']
-    group: *facePresetGroup
+    group: *fixesResourcesGroup
     inc:
       - 'AsharaSkyrimCharacterPresetsReplacer.esp'
       - 'Kayla_CharPreset.esp'
@@ -2141,7 +2139,7 @@ plugins:
       - NoMerge
   - name: 'Lagertha_CharPreset.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2629/']
-    group: *facePresetGroup
+    group: *fixesResourcesGroup
     inc:
       - 'Kayla_CharPreset.esp'
       - 'Lydia Face Preset 64bit.esp'
@@ -2154,7 +2152,7 @@ plugins:
       - NoMerge
   - name: 'Kayla_CharPreset.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/3851/']
-    group: *facePresetGroup
+    group: *fixesResourcesGroup
     inc:
       - 'AsharaSkyrimCharacterPresetsReplacer.esp'
       - 'Lagertha_CharPreset.esp'
@@ -2178,7 +2176,7 @@ plugins:
         condition: 'active("AsharaSkyrimCharacterPresetsReplacer.esp")'
   - name: 'Better_Male_Presets.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2001/']
-    group: *facePresetGroup
+    group: *fixesResourcesGroup
     inc:
       - 'AsharaSkyrimCharacterPresetsReplacer.esp'
     msg:
@@ -2191,6 +2189,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/8586/'
         name: 'Relighting Skyrim - SSE on Nexus Mods'
+    group: *overhaulsGroup
     clean:
       # Version 1.0.2
       - crc: 0xAD0407B5
@@ -2199,8 +2198,12 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/2424/'
         name: 'Enhanced Lights and FX on Nexus Mods'
+    group: *highPriorityGroup
     after:
+      - 'Alternate Start - Live Another Life.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
+      - 'Immersive Citizens - OCS patch.esp'
+      - 'Open Cities Skyrim.esp'
   - name: 'ELFX - Hardcore.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/2424/'
@@ -2211,13 +2214,15 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/1377/'
         name: 'Enhanced Lighting for ENB (ELE) - Special Edition on Nexus Mods'
-    group: *alternateStartGroup
+    group: *highPriorityGroup
     after:
       - 'Alternate Start - Live Another Life.esp'
       - 'Ars Metallica.esp'
       - 'Book Covers Skyrim - Lost Library.esp'
       - 'Book Covers Skyrim.esp'
       - 'EmbersHD.esp'
+      - 'Open Cities Skyrim.esp'
+      - 'Immersive Citizens - OCS patch.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'Inigo.esp'
       - 'Ivarstead.esp'
@@ -2324,7 +2329,7 @@ plugins:
       - Invent
   - name: 'Ducks and Swans.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2149/']
-    group: *lowPriorityGroup
+    group: *earlyLoadersGroup
   - name: 'BirdsOfSkyrim_SSE.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/3097/']
     after:
@@ -2342,7 +2347,6 @@ plugins:
       - 'Relationship Dialogue Overhaul.esp'
   - name: 'My Home Is Your Home.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/7096/']
-    group: *followerGroup
     after:
       - 'AmazingFollowerTweaks.esp'
   - name: 'CFTO.esp'
@@ -2361,21 +2365,23 @@ plugins:
         name: 'Sweet as Honeyside on Nexus Mods'
     after:
       - 'ELFX - NoHoneyside.esp'
-      - 'Alternate Start - Live Another Life.esp'
   - name: 'Audio Overhaul Skyrim.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/12466/'
         name: 'Audio Overhaul for Skyrim SE on Nexus Mods'
+    group: *overhaulsGroup
     clean:
       # Version v3.0.0
       - crc: 0x96BF25A6
         util: SSEEdit v3.2.1
   - name: 'Immersive Sounds - Compendium.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/523/']
+    group: *overhaulsGroup
     after:
       - 'Reverb and Ambiance Overhaul - Skyrim.esp'
   - name: 'Landscape Fixes For Grass Mods.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/9005/']
+    group: *fixesResourcesGroup
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
   - name: 'Landscape Fixes For Grass Mods .*\.esp'
@@ -2431,6 +2437,7 @@ plugins:
     url:
       - link: 'http://3dnpc.com/2017/11/20/3dnpc-v3-4-for-oldrim-and-sse/'
         name: 'Interesting NPCs SSE on 3dnpc.com'
+    group: *addonsGroup
     tag:
       - Actors.ACBS
       - Actors.AIPackages
@@ -2471,6 +2478,7 @@ plugins:
       - Sound
   - name: 'DLCIntegration.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/8032/']
+    group: *fixesResourcesGroup
     msg:
       - <<: *hasPluginPatch
         subs:
@@ -2545,7 +2553,6 @@ plugins:
   - name: 'Convenient Horses.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/9519/']
     after:
-      - 'Open Cities Skyrim.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'Relationship Dialogue Overhaul.esp'
   - name: 'KrittaKittyHorsesForSSE.esp'
@@ -2609,7 +2616,7 @@ plugins:
   - name: 'UnlimitedBookshelves.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2885/']
     # Authors instructions: Load directly after Unofficial Skyrim Special Edition Patch.
-    group: *lowPriorityGroup
+    group: *earlyLoadersGroup
     clean:
       # 2.0
       - crc: 0x86CF0F2B
@@ -2723,7 +2730,6 @@ plugins:
   - name: 'Qw_ELE_.*\.esp'
     # Patches for Enhanced Lighting for ENB
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/16923/']
-    group: *alternateStartGroup
   - name: 'TTR_Master_Trader.*\.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/1826/'
@@ -2827,6 +2833,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/364/'
         name: 'Storefront on Nexus Mods'
+    group: *addonsGroup
     clean:
       # v2.0
       - crc: 0xBB8E454A 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1516,6 +1516,9 @@ plugins:
       # Version 1.5.2
       - crc: 0xCF76C1B9
         util: SSEEdit v3.2.1
+      # Version 1.5.3
+      - crc: 0x2BDAE302
+        util: SSEEdit v3.2.1
   # Catch all for Patches included in installer
   - name: 'RealisticWaterTwo.*\.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2182/']


### PR DESCRIPTION
- Changed Mapmarkers group to Late fixes as not all map marker mods should be loaded that late.
- Removed grouping for `mlu.esp`. It was overriding earlier mods with changes that were not relevant to the mod, and in most cases it provides a patch anyway. With the improved patcher `zEdit` & `smash` it should no longer be necessary to have it so high up by default.
- Combined facePresetGroup & Hair replacers with Fixes, renamed to Fixes & Resources.
- Split low priority into 3 new groups, `early loaders`, `Add-ons` for any large mods that add new Lands, Locations & characters. `Overhauls` for any mods that make a large amount of changes, but can be loaded before other mods.