### PR TITLE
Immersive Citizens - Load after rules Updated

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2016,6 +2016,9 @@ plugins:
       - 'breezehome enhanced SSE.esp'
       - 'Simpler Breezehome.esp'
       - 'Wind District Breezehome - Replacer.esp'
+      - 'breezehome_basement.esp'
+      - 'BreezehomeSB.esp'
+      - 'breeze2.esp'
     msg:
       - <<: *hasPatchIncluded
         subs:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2011,6 +2011,11 @@ plugins:
       - 'Skyrim Sewers.esp'
       - 'TouringCarriages.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ASLAO - Front Porch (Breezehome).esp'
+      - 'BHTNFBP.esp'
+      - 'breezehome enhanced SSE.esp'
+      - 'Simpler Breezehome.esp'
+      - 'Wind District Breezehome - Replacer.esp'
     msg:
       - <<: *hasPatchIncluded
         subs:


### PR DESCRIPTION
Add Breezehome Player Homes which have conflicts and should be loaded before Immersive citizens.

### Navmesh conflicts
- Breezehome Front Porch - A Simple Little Add-On (SE Edition)
- Breezehome TNF Beds Plus
- Breezehome Enhanced SE
- Simpler Breezehome
- Wind District Breezehome SSE Lore Friendly Personal Version

### Conflicts in placement of objects
- breezehome_basement.esp
- BreezehomeSB.esp

### minor conflicts
- Breeze2, reverts USSEP changes, better to load it before ICAIO.


### 27 Plug-ins tested for conflicts with Immersive citizens.
Wind District Breezehome - Replacer.esp
CynnsBreezehome.esp
BreezehomeByLupus.esp
BHTNFBP.esp
My BreezeHome1.esp
BreezehomeSB.esp
NovaBreezehome.esp
SimplyBreezehome.esp
Simpler Breezehome.esp
breezehome enhanced SSE.esp
breezehome_basement.esp
Breezehome Firepit Removed.esp
BreezehomeBasement.esp
BreezehomeCellarGetaway.esp
ASLAO - Front Porch (Breezehome).esp
Immersive Citizens - AI Overhaul.esp
breeze 2.esp
breezehome-darkdream.esp
BreezehomePlanters.esp
BreezehomeBackyardStorage.esp
Alex's Breezehome Mapmarker.esp
Breezehome upgrades free.esp
Breezehome free.esp
BreezehomeAlchemyRoom.esp
Eli_Breezehome Additional Shrines by Amnesiac - v1.0.esp
DSC_Breezehome_Mannequins.esp
JEM Eli_Breezehome Additional Armour Container 1.0.esp