### PR TITLE
[New Groups] Realistic Water & Enhanced Lighting

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -245,8 +245,14 @@ groups:
   - name: &lateLoadersGroup Late Loaders
     after: [ *highPriorityGroup ]
 
-  - name: &dynamicPatchGroup Dynamic Patches
+  - name: &eleGroup Enhanced Lighting
     after: [ *lateLoadersGroup ]
+
+  - name: &rwtGroup Realistic Water
+    after: [ *eleGroup ]
+
+  - name: &dynamicPatchGroup Dynamic Patches
+    after: [ *lateLoadersGroup, *rwtGroup ]
 
   - name: &lateChangesGroup Late Fixes & Changes
     after: [ *dynamicPatchGroup ]
@@ -1267,6 +1273,7 @@ plugins:
       - 'Open Cities Skyrim.esp'
       - 'My Home Is Your Home.esp'
       - 'Landscape Fixes For Grass Mods.esp'
+      - 'ELFX - Hardcore.esp'
     tag:
       - C.Location
       - Names
@@ -1578,7 +1585,6 @@ plugins:
       - 'Immersive Citizens - AI Overhaul.esp'
   - name: 'RealisticWaterTwo.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2182/']
-    group: *lateLoadersGroup
     after:
       - 'JK''s Riverwood.esp'
       - 'JKs Whiterun.esp'
@@ -1627,6 +1633,7 @@ plugins:
       - 'FarmhouseChimneysLAL.esp'
       - 'FarmhouseChimneysShorsStone.esp'
       - 'FarmhouseChimneysWhistlingMine.esp'
+    group: *rwtGroup
     tag:
       - C.Water
       - Graphics
@@ -1644,12 +1651,13 @@ plugins:
   # Catch all for Patches included in installer
   - name: 'RealisticWaterTwo.*\.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2182/']
-    group: *lateLoadersGroup
+    group: *rwtGroup
   - name: 'RWT.*\.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2182/']
-    group: *lateLoadersGroup
+    group: *rwtGroup
   - name: 'RealisticWaterTwo+-+Verdant+Patch.esp'
-    group: *lateLoadersGroup
+    group: *rwtGroup
+
   - name: 'SSEMerged.esp'
     group: *dynamicPatchGroup
     tag:
@@ -2096,7 +2104,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/173/'
         name: 'Immersive Citizens - ELE patch on Nexus Mods'
-    group: *highPriorityGroup
+    group: *eleGroup
     clean:
       # version 0.4
       - crc: 0x9F0CBF8B
@@ -2105,7 +2113,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/173/'
         name: 'Immersive Citizens - ELFXEnhancer patch on Nexus Mods'
-    group: *highPriorityGroup
+    group: *eleGroup
     clean:
       # version 0.4
       - crc: 0x4865A412
@@ -2344,7 +2352,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/2424/'
         name: 'Enhanced Lights and FX on Nexus Mods'
-    group: *highPriorityGroup
+    group: *eleGroup
     after:
       - 'Alternate Start - Live Another Life.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
@@ -2354,13 +2362,11 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/2424/'
         name: 'Enhanced Lights and FX on Nexus Mods'
-    after:
-      - 'Immersive Citizens - AI Overhaul.esp'
+    group: *highPriorityGroup
   - name: 'ELE_SSE.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/1377/'
         name: 'Enhanced Lighting for ENB (ELE) - Special Edition on Nexus Mods'
-    group: *highPriorityGroup
     after:
       - 'Alternate Start - Live Another Life.esp'
       - 'Ars Metallica.esp'
@@ -2382,6 +2388,7 @@ plugins:
       - 'Soljund''s Sinkhole.esp'
       - 'TheChoiceIsYours.esp'
       - 'Whistling Mine.esp'
+    group: *eleGroup
     inc:
       - 'ELFXEnhancer.esp'
       - 'ELFX - Hardcore.esp'


### PR DESCRIPTION
Both will load after late loaders, just to be sure that they win against any thing that could be placed in Late Loaders.

ELFX - Hardcore.esp has not been added to the enhanced lighting group because of its conflict with Alt start, if the starting room bounds are fixed in ELFX - Hardcore.esp, it should be placed in the eleGroup.