### PR TITLE
Fix early Group order

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -234,7 +234,7 @@ groups:
     after: [ *overhaulsGroup ]
 
   - name: default
-    after: [ *overhaulsGroup, *addonsGroup ]
+    after: [ *addonsGroup ]
 
   - name: &lowPriorityGroup Low Priority Overrides
     after: [ default ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -227,11 +227,11 @@ groups:
   - name: &fixesResourcesGroup Fixes & Resources
     after: [ *earlyLoadersGroup ]
 
-  - name: &addonsGroup Add-ons & Expansions
-    after: [ *fixesResourcesGroup ]
-
   - name: &overhaulsGroup Large Overhauls
     after: [ *fixesResourcesGroup ]
+
+  - name: &addonsGroup Add-ons & Expansions
+    after: [ *overhaulsGroup ]
 
   - name: default
     after: [ *overhaulsGroup, *addonsGroup ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1015,15 +1015,15 @@ plugins:
       - crc: 0xB8A1EE4E
         util: SSEEdit v3.2.1
   - name: 'static mesh improvement mod se.esp'
-    group: *overhaulsGroup
+    group: *fixesResourcesGroup
   - name: 'SMIM-SE-.*\.esp'
   # Static Mesh Improvement Mod - Modular installer
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/659/']
-    group: *overhaulsGroup
+    group: *fixesResourcesGroup
   - name: 'SMIM-SE.esp'
   # Static Mesh Improvement Mod SE - BSA version
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/659/']
-    group: *overhaulsGroup
+    group: *fixesResourcesGroup
     tag:
       - Graphics
     clean:


### PR DESCRIPTION
Better order, ensures audio and lighting overhauls will not alter new locations.