### PR TITLE
add 'Immersive College of Winterhold' to masterlist

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3162,6 +3162,21 @@ plugins:
 ###########################
 ## Locations - Overhauls ##
 ###########################
+  - name: 'CollegeOfWinterholdImmersive.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/17004/'
+        name: 'Immersive College of Winterhold on Nexus Mods'
+    after:
+      - 'TheWulfPanda - Faction Teleport Spells.esp'
+      - 'TheWulfPanda - Faction Teleport Spells Less Magicka Increased Cast Time.esp'
+    tag:
+      - Factions
+      - Invent
+      - Names
+    clean:
+      # v5.1
+      - crc: 0xDA086763
+        util: SSEEdit v3.2.1
   - name: 'Darkwater Crossing.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/326/'


### PR DESCRIPTION
[Teleport - Faction Spells](https://www.nexusmods.com/skyrimspecialedition/mods/6991) places a book and a teleport marker inside the College of Winterhold.
Unfortunately the mod contains some ITM records and wild edits that overwrite the changes from [Immersive College of Winterhold](https://www.nexusmods.com/skyrimspecialedition/mods/17004).

I already reported the ITMs (but not the wild edits) with the LOOT reporting option in SSEEdit and sent the cleaned ESPs to the author. Hopefully he will release an update.

To prevent conflicts, **Immersive College of Winterhold** should be loaded *after* **Teleport - Faction Spells** (that's also true for the cleaned ESPs). 
No necessary records of **Teleport - Faction Spells** are overwritten by **Immersive College of Winterhold**.

Version 5.1 of **Immersive College of Winterhold** is reported clean by SSEEdit.
I generated the Bash Tags with the auto-detect script from SSEEdit.

--------

I don't know how to generate the CRC checksum of an already clean ESP in SSEEdit, so I generated it with the BOSS report option in Wrye Bash.

That's my first PR for this project. I hope I did no mistakes. 😄 