### PR TITLE
add 'Teleport - City Spells' to masterlist

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2895,6 +2895,45 @@ plugins:
       - Delev
       - Invent
       - Relev
+  - name: 'TheWulfPanda - City Teleport Spells.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/7015/'
+        name: 'Teleport - City Spells on Nexus Mods'
+    inc:
+      - 'TheWulfPanda - City Teleport Spells Less Magicka Increase Cast Time.esp'
+    dirty:
+      # v1.01
+      - crc: 0xEC89CAD3
+        <<: *dirtyPlugin
+        itm: 19
+        udr: 0
+        nav: 0
+    clean:
+      # v1.01 ~ remove wild edits after cleaning:
+      #   - parent sub-block of 0000939D
+      #   - 00042249
+      #   - 00020EE7
+      #   - 0001A27F
+      #   - 00037EE9
+      - crc: 0xB63A3D6B
+        util: SSEEdit v3.2.1
+  - name: 'TheWulfPanda - City Teleport Spells Less Magicka Increase Cast Time.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/7015/'
+        name: 'Teleport - City Spells Less Magicka Increase Cast Time on Nexus Mods'
+    inc:
+      - 'TheWulfPanda - City Teleport Spells.esp'
+    dirty:
+      # v1.01
+      - crc: 0x5AE957AB
+        <<: *dirtyPlugin
+        itm: 19
+        udr: 0
+        nav: 0
+    clean:
+      # v1.01 ~ for wild edits see 'TheWulfPanda - City Teleport Spells.esp'
+      - crc: 0x65674DC4
+        util: SSEEdit v3.2.1
 ###################
 ## Leveled Lists ##
 ###################

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2901,21 +2901,29 @@ plugins:
         name: 'Teleport - City Spells on Nexus Mods'
     inc:
       - 'TheWulfPanda - City Teleport Spells Less Magicka Increase Cast Time.esp'
+    msg:
+      - <<: *hasWildEdits
+        subs:
+          - '[TheWulfPanda - City Teleport Spells.esp](https://www.nexusmods.com/skyrimspecialedition/mods/7015/)'
+          - |+
+
+              #### Remove the following records with xEdit
+              - Parent Sub-Block 2,-2 of MorthalExterior04 [CELL:0000939D]
+              - SolitudeOrigin [CELL:00037EE9]
+              - WhiterunOrigin [CELL:0001A27F]
+              - MarkarthOrigin [CELL:00020EE7]
+              - RiftenCityNorth [CELL:00042249]
+        condition: 'checksum("TheWulfPanda - City Teleport Spells.esp",F4169312)'
     dirty:
-      # v1.01
-      - crc: 0xEC89CAD3
-        <<: *dirtyPlugin
+      - <<: *dirtyPlugin
+        crc: 0xEC89CAD3 # v1.01
         itm: 19
         udr: 0
         nav: 0
     clean:
-      # v1.01 ~ remove wild edits after cleaning:
-      #   - parent sub-block of 0000939D
-      #   - 00042249
-      #   - 00020EE7
-      #   - 0001A27F
-      #   - 00037EE9
-      - crc: 0xB63A3D6B
+      - crc: 0xF4169312 # v1.01 With wild edits
+        util: SSEEdit v3.2.1
+      - crc: 0xB63A3D6B # v1.01 Without wild edits
         util: SSEEdit v3.2.1
   - name: 'TheWulfPanda - City Teleport Spells Less Magicka Increase Cast Time.esp'
     url:
@@ -2923,16 +2931,30 @@ plugins:
         name: 'Teleport - City Spells Less Magicka Increase Cast Time on Nexus Mods'
     inc:
       - 'TheWulfPanda - City Teleport Spells.esp'
+    msg:
+      - <<: *hasWildEdits
+        subs:
+          - '[TheWulfPanda - City Teleport Spells Less Magicka Increase Cast Time.esp](https://www.nexusmods.com/skyrimspecialedition/mods/7015/)'
+          - |+
+
+              #### Remove the following records with xEdit
+              - Parent Sub-Block 2,-2 of MorthalExterior04 [CELL:0000939D]
+              - SolitudeOrigin [CELL:00037EE9]
+              - WhiterunOrigin [CELL:0001A27F]
+              - MarkarthOrigin [CELL:00020EE7]
+              - RiftenCityNorth [CELL:00042249]
+        condition: 'checksum("TheWulfPanda - City Teleport Spells Less Magicka Increase Cast Time.esp",DE73AD5C)'
     dirty:
-      # v1.01
-      - crc: 0x5AE957AB
-        <<: *dirtyPlugin
+      - <<: *dirtyPlugin
+        crc: 0x5AE957AB # v1.01
+        util: SSEEdit v3.2.1
         itm: 19
         udr: 0
         nav: 0
     clean:
-      # v1.01 ~ for wild edits see 'TheWulfPanda - City Teleport Spells.esp'
-      - crc: 0x65674DC4
+      - crc: 0xDE73AD5C # v1.01 With wild edits
+        util: SSEEdit v3.2.1
+      - crc: 0x65674DC4 # v1.01 Without wild edits
         util: SSEEdit v3.2.1
 ###################
 ## Leveled Lists ##


### PR DESCRIPTION
Hi! Here's the first of the three teleport spell mods from TheWulfPanda: [Teleport - City Spells](https://www.nexusmods.com/skyrimspecialedition/mods/7015/)

I didn't have the motivation to write a user friendly cleaning guide for the wild edits and upload it somewhere, so I just added a comment with the dirty records. I still hope that the author will read my message eventually and upload the cleaned ESPs.

Thanks to @CptMcSplody's suggestion I now checked the Bash Tags with the [Generate Tags for Wrye Bash.pas](https://github.com/fireundubh/xedit-scripts/blob/master/all/Generate%20Tags%20for%20Wrye%20Bash.pas) script. It suggested **C.Regions** but I omitted the tag because those changes are not relevant for the mod.