### PR TITLE
add TheWulfPanda's teleport spell mods to masterlist

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3046,6 +3046,64 @@ plugins:
         util: SSEEdit v3.2.1
       - crc: 0x7BD6C78A # v1.03 Without wild edits
         util: SSEEdit v3.2.1
+  - name: 'TheWulfPanda - Teleport Spells Towns and Villages.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/7267/'
+        name: 'Teleport - Towns and Villages on Nexus Mods'
+    inc:
+      - 'TheWulfPanda - Teleport Spells Towns and Villages Less Magicka Increase Cast Time.esp'
+    msg:
+      - <<: *hasWildEdits
+        subs:
+          - '[TheWulfPanda - Teleport Spells Towns and Villages.esp](https://www.nexusmods.com/skyrimspecialedition/mods/7267/)'
+          - |+
+
+            #### Remove the following records with xEdit
+            - `DragonBridgeExterior03 [CELL:00009349]`
+            - `Riverwood [CELL:00009732]`
+            - Parent Sub-Block 2,-3 of `IvarsteadExterior02 [CELL:000097BF]`
+            - Remove the **XCWT** attribute of `Riverwood04 [CELL:00009731]`
+        condition: 'checksum("TheWulfPanda - Teleport Spells Towns and Villages.esp",B63A3D6B)'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0xE614F5D7 # v1.00
+        itm: 17
+        udr: 0
+        nav: 0
+    clean:
+      - crc: 0xB63A3D6B # v1.00 With wild edits
+        util: SSEEdit v3.2.1
+      - crc: 0x6C66613A # v1.00 Without wild edits
+        util: SSEEdit v3.2.1
+  - name: 'TheWulfPanda - Teleport Spells Towns and Villages Less Magicka Increase Cast Time.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/7267/'
+        name: 'Teleport - Towns and Villages Less Magicka Increase Cast Time on Nexus Mods'
+    inc:
+      - 'TheWulfPanda - Teleport Spells Towns and Villages.esp'
+    msg:
+      - <<: *hasWildEdits
+        subs:
+          - '[TheWulfPanda - Teleport Spells Towns and Villages Less Magicka Increase Cast Time.esp](https://www.nexusmods.com/skyrimspecialedition/mods/7267/)'
+          - |+
+
+            #### Remove the following records with xEdit
+            - `DragonBridgeExterior03 [CELL:00009349]`
+            - `Riverwood [CELL:00009732]`
+            - Parent Sub-Block 2,-3 of `IvarsteadExterior02 [CELL:000097BF]`
+            - Remove the **XCWT** attribute of `Riverwood04 [CELL:00009731]`
+        condition: 'checksum("TheWulfPanda - Teleport Spells Towns and Villages Less Magicka Increase Cast Time.esp",0A2034F1)'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x2393970C # v1.00
+        itm: 17
+        udr: 0
+        nav: 0
+    clean:
+      - crc: 0x0A2034F1 # v1.00 With wild edits
+        util: SSEEdit v3.2.1
+      - crc: 0x711550A4 # v1.00 Without wild edits
+        util: SSEEdit v3.2.1
 ###################
 ## Leveled Lists ##
 ###################

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2992,15 +2992,15 @@ plugins:
           - '[TheWulfPanda - Faction Teleport Spells.esp](https://www.nexusmods.com/skyrimspecialedition/mods/6991/)'
           - |+
 
-            #### Edit the following records with xEdit
-            - remove `[REFR:02010521]`
-            - remove `[REFR:02007320]`
-            - remove `[REFR:000CA72C]`
-            - remove `[REFR:000B3434]`
-            - remove `DBSanc_WestHall [REFR:000C0291]`
-            - remove Top Group `Worldspace [GRUP:WRLD]`
-            - remove the **XEZN** attribute in RiftenRaggedFlagon `[CELL:00016BCF]`
-            - add the value `WeatherPineForest [REGN:0002A72D]` to the **XCCM** attribute in DarkBrotherhoodSanctuary `[CELL:000AD5A1]`
+              #### Edit the following records with xEdit
+              - remove `[REFR:02010521]`
+              - remove `[REFR:02007320]`
+              - remove `[REFR:000CA72C]`
+              - remove `[REFR:000B3434]`
+              - remove `DBSanc_WestHall [REFR:000C0291]`
+              - remove Top Group `Worldspace [GRUP:WRLD]`
+              - remove the **XEZN** attribute in RiftenRaggedFlagon `[CELL:00016BCF]`
+              - add the value `WeatherPineForest [REGN:0002A72D]` to the **XCCM** attribute in DarkBrotherhoodSanctuary `[CELL:000AD5A1]`
         condition: 'checksum("TheWulfPanda - Faction Teleport Spells.esp",BCE75EB1)'
     dirty:
       - <<: *dirtyPlugin
@@ -3025,15 +3025,15 @@ plugins:
           - '[TheWulfPanda - Faction Teleport Spells Less Magicka Increased Cast Time.esp](https://www.nexusmods.com/skyrimspecialedition/mods/6991/)'
           - |+
 
-            #### Edit the following records with xEdit
-            - remove `[REFR:02010521]`
-            - remove `[REFR:02007320]`
-            - remove `[REFR:000CA72C]`
-            - remove `[REFR:000B3434]`
-            - remove `DBSanc_WestHall [REFR:000C0291]`
-            - remove Top Group `Worldspace [GRUP:WRLD]`
-            - remove the **XEZN** attribute in RiftenRaggedFlagon `[CELL:00016BCF]`
-            - add the value `WeatherPineForest [REGN:0002A72D]` to the **XCCM** attribute in DarkBrotherhoodSanctuary `[CELL:000AD5A1]`
+              #### Edit the following records with xEdit
+              - remove `[REFR:02010521]`
+              - remove `[REFR:02007320]`
+              - remove `[REFR:000CA72C]`
+              - remove `[REFR:000B3434]`
+              - remove `DBSanc_WestHall [REFR:000C0291]`
+              - remove Top Group `Worldspace [GRUP:WRLD]`
+              - remove the **XEZN** attribute in RiftenRaggedFlagon `[CELL:00016BCF]`
+              - add the value `WeatherPineForest [REGN:0002A72D]` to the **XCCM** attribute in DarkBrotherhoodSanctuary `[CELL:000AD5A1]`
         condition: 'checksum("TheWulfPanda - Faction Teleport Spells Less Magicka Increased Cast Time.esp",BAD78620)'
     dirty:
       - <<: *dirtyPlugin

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2980,6 +2980,72 @@ plugins:
         util: SSEEdit v3.2.1
       - crc: 0x65674DC4 # v1.01 Without wild edits
         util: SSEEdit v3.2.1
+  - name: 'TheWulfPanda - Faction Teleport Spells.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/6991/'
+        name: 'Teleport - Faction Spells on Nexus Mods'
+    inc:
+      - 'TheWulfPanda - Faction Teleport Spells Less Magicka Increased Cast Time.esp'
+    msg:
+      - <<: *hasWildEdits
+        subs:
+          - '[TheWulfPanda - Faction Teleport Spells.esp](https://www.nexusmods.com/skyrimspecialedition/mods/6991/)'
+          - |+
+
+            #### Edit the following records with xEdit
+            - remove `[REFR:02010521]`
+            - remove `[REFR:02007320]`
+            - remove `[REFR:000CA72C]`
+            - remove `[REFR:000B3434]`
+            - remove `DBSanc_WestHall [REFR:000C0291]`
+            - remove Top Group `Worldspace [GRUP:WRLD]`
+            - remove the **XEZN** attribute in RiftenRaggedFlagon `[CELL:00016BCF]`
+            - add the value `WeatherPineForest [REGN:0002A72D]` to the **XCCM** attribute in DarkBrotherhoodSanctuary `[CELL:000AD5A1]`
+        condition: 'checksum("TheWulfPanda - Faction Teleport Spells.esp",BCE75EB1)'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x6DA7BCF5 # v1.03
+        itm: 30
+        udr: 0
+        nav: 0
+    clean:
+      - crc: 0xBCE75EB1 # v1.03 With wild edits
+        util: SSEEdit v3.2.1
+      - crc: 0x2A2CF491 # v1.03 Without wild edits
+        util: SSEEdit v3.2.1
+  - name: 'TheWulfPanda - Faction Teleport Spells Less Magicka Increased Cast Time.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/6991/'
+        name: 'Teleport - Faction Spells Less Magicka Increased Cast Time on Nexus Mods'
+    inc:
+      - 'TheWulfPanda - Faction Teleport Spells.esp'
+    msg:
+      - <<: *hasWildEdits
+        subs:
+          - '[TheWulfPanda - Faction Teleport Spells Less Magicka Increased Cast Time.esp](https://www.nexusmods.com/skyrimspecialedition/mods/6991/)'
+          - |+
+
+            #### Edit the following records with xEdit
+            - remove `[REFR:02010521]`
+            - remove `[REFR:02007320]`
+            - remove `[REFR:000CA72C]`
+            - remove `[REFR:000B3434]`
+            - remove `DBSanc_WestHall [REFR:000C0291]`
+            - remove Top Group `Worldspace [GRUP:WRLD]`
+            - remove the **XEZN** attribute in RiftenRaggedFlagon `[CELL:00016BCF]`
+            - add the value `WeatherPineForest [REGN:0002A72D]` to the **XCCM** attribute in DarkBrotherhoodSanctuary `[CELL:000AD5A1]`
+        condition: 'checksum("TheWulfPanda - Faction Teleport Spells Less Magicka Increased Cast Time.esp",BAD78620)'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x3BEDC8A5 # v1.03
+        itm: 30
+        udr: 0
+        nav: 0
+    clean:
+      - crc: 0xBAD78620 # v1.03 With wild edits
+        util: SSEEdit v3.2.1
+      - crc: 0x7BD6C78A # v1.03 Without wild edits
+        util: SSEEdit v3.2.1
 ###################
 ## Leveled Lists ##
 ###################


### PR DESCRIPTION
Hi! Here's the second mod of the Teleport Spells: [Teleport - Faction Spells](https://www.nexusmods.com/skyrimspecialedition/mods/6991/)

I guess you could argue about the cleaning instructions because the last item in the list isn't a wild edit but a fix from [USSEP](https://www.nexusmods.com/skyrimspecialedition/mods/266). I thought there's no harm in adding it anyway.

The author added the flag `Don't Havok Settle` on the following references:
- `[REFR:02010521]`
- `[REFR:000CA72C]`
- `[REFR:000B3434]`

I don't understand why mists and walls would benefit from this flag, so I removed those references too.


**Edit:**
I added the last teleport mod, too: [Teleport - Towns and Villages](https://www.nexusmods.com/skyrimspecialedition/mods/7267/)