### PR TITLE
update 'Better Vampires' list entry

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1991,6 +1991,16 @@ plugins:
     after:
       - 'EBM_UnlimitedPower.esp'
       - 'EBM_UnlimitedPower_Vampire.esp'
+      - 'Tainted_Blood.esp'
+    tag:
+      - Graphics
+      - Names
+      - Relev
+      - Sound
+      - Stats
+    clean:
+      - crc: 0xEC44246A # v8.2
+        util: SSEEdit v3.2.1
   - name: 'CFTO.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/8379/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1991,6 +1991,7 @@ plugins:
     after:
       - 'EBM_UnlimitedPower.esp'
       - 'EBM_UnlimitedPower_Vampire.esp'
+      - 'Sacrosanct - Vampires of Skyrim.esp'
       - 'Tainted_Blood.esp'
     tag:
       - Graphics
@@ -2668,7 +2669,9 @@ plugins:
   - name: 'Sacrosanct - Vampires of Skyrim.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/3928']
     inc:
-      - 'better vampires.esp'
+      - name: 'better vampires.esp'
+        condition: 'active("better vampires.esp") and not active("BVandSacrosanct_Patch.esp")'
+        display: '[Better Vampires](https://www.nexusmods.com/skyrimspecialedition/mods/1925/)'
       - 'mslVampiricThirst.esp'
       - 'SanguinairVampirism.esp'
       - 'VampireLordPerksExpanded.esp'
@@ -2680,6 +2683,10 @@ plugins:
       - Graphics
       - Names
       - Sound
+    msg:
+      - type: warn
+        content: 'Better Vampires and Sacrosanct Patch is not recommended or supported by the Author of [Sacrosanct - Vampires of Skyrim](https://www.nexusmods.com/skyrimspecialedition/mods/3928)'
+        condition: 'active("better vampires.esp") and active("BVandSacrosanct_Patch.esp")'
     dirty:
         # version 5.11SSE
       - crc: 0x93553BD1


### PR DESCRIPTION
Version 8.2 of [Better Vampires](https://www.nexusmods.com/skyrimspecialedition/mods/1925) is clean. The Bash Tags were generated with [Generate Tags for Wrye Bash.pas](https://github.com/fireundubh/xedit-scripts/blob/master/all/Generate%20Tags%20for%20Wrye%20Bash.pas).

There's a minor conflict with [Tainted Blood](https://www.nexusmods.com/skyrimspecialedition/mods/9312).
Tainted Blood removes a race check from the Night Cloak spell while Better Vampires completely overhauls this spell. So Better Vampires should have precedence over Tainted Blood and should be loader after it.