### PR TITLE
add 'A Quality World Map' to masterlist

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -812,6 +812,36 @@ plugins:
 #############################
 ## AudioVisual - Interface ##
 #############################
+  - name: 'IcePenguinWorldMap.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/5804/'
+        name: 'A Quality World Map on Nexus Mods'
+    inc:
+      - 'icepenguinworldmapclassic.esp'
+      - 'IcePenguinWorldMapPaper.esp'
+    clean:
+      - crc: 0xAC5D1C02 # v9.0.1
+        util: SSEEdit v3.2.1
+  - name: 'icepenguinworldmapclassic.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/5804/'
+        name: 'A Quality World Map on Nexus Mods'
+    inc:
+      - 'IcePenguinWorldMap.esp'
+      - 'IcePenguinWorldMapPaper.esp'
+    clean:
+      - crc: 0xC1050661 # v8.4
+        util: SSEEdit v3.2.1
+  - name: 'IcePenguinWorldMapPaper.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/5804/'
+        name: 'A Quality World Map on Nexus Mods'
+    inc:
+      - 'IcePenguinWorldMap.esp'
+      - 'icepenguinworldmapclassic.esp'
+    clean:
+      - crc: 0x09706810 # v9.0P
+        util: SSEEdit v3.2.1
   - name: 'SkyUI_SE.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/12604/']
     req:


### PR DESCRIPTION
The various versions of [A Quality World Map](https://www.nexusmods.com/skyrimspecialedition/mods/5804/) are all clean but the ESPs are copied over from Oldrim. I wanted to add the CRC for the converted plugins too but then I realized that saving them in the CK changes the file's modification date so the CRC will be different for everyone.

I think™ it should be safe to load the Oldrim versions in SE because the plugins don't touch NPC data or stuff like that.