### PR TITLE
Unofficial High Definition Audio Project

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1326,9 +1326,10 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18115/'
         name: 'Unofficial High Definition Audio Project on Nexus Mods'
-    inc:
-      - 'UHDAP - MusicUHQ.esp'
     group: *eslmGroup
+    inc:
+      - 'UHDAP - MusicUHQ1.esp'
+      - 'UHDAP - MusicUHQ2.esp'
 ###########################
 ## AudioVisual - Weather ##
 ###########################

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1322,6 +1322,13 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18115/'
         name: 'Unofficial High Definition Audio Project on Nexus Mods'
     group: *eslmGroup
+  - name: 'UHDAP - MusicHQ.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18115/'
+        name: 'Unofficial High Definition Audio Project on Nexus Mods'
+    inc:
+      - 'UHDAP - MusicUHQ.esp'
+    group: *eslmGroup
 ###########################
 ## AudioVisual - Weather ##
 ###########################

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1319,7 +1319,7 @@ plugins:
         util: SSEEdit v3.2.1
   - name: 'UHDAP -.*\.esp'
     url:
-      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/8091/'
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18115/'
         name: 'Unofficial High Definition Audio Project on Nexus Mods'
     group: *eslmGroup
 ###########################

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -221,8 +221,11 @@ globals:
 groups:
   - name: &dlcGroup DLC
 
-  - name: &earlyLoadersGroup Early Loaders
+  - name: &eslmGroup Light Masters # Non DLC - Has Header Flags (ESM & ESL)
     after: [ *dlcGroup ]
+
+  - name: &earlyLoadersGroup Early Loaders
+    after: [ *eslmGroup ]
 
   - name: &fixesResourcesGroup Fixes & Resources
     after: [ *earlyLoadersGroup ]
@@ -1314,6 +1317,11 @@ plugins:
     clean:
       - crc: 0xB8611F94 # v1.23
         util: SSEEdit v3.2.1
+  - name: 'UHDAP -.*\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/8091/'
+        name: 'Unofficial High Definition Audio Project on Nexus Mods'
+    group: *eslmGroup
 ###########################
 ## AudioVisual - Weather ##
 ###########################


### PR DESCRIPTION
[Unofficial High Definition Audio Project](https://www.nexusmods.com/skyrimspecialedition/mods/18115)

Uses empty Light Master esp to load bsa archives.

```
Skyrim.esm
Update.esm
Dawnguard.esm
HearthFires.esm
Dragonborn.esm
UHDAP - MusicHQ.esp OR UHDAP - MusicUHQ.esp
UHDAP - en0.esp // replace en0 as necessary with respective language
UHDAP - enX.esp // replace X with the rest of the language .esp
... // Any other mods that the authors state should be above USSEP
Unofficial Skyrim Special Edition Patch.esp
... // Rest of your load order
```