### PR TITLE
[New] Lore Weapon Expansion & Add-on Plug-ins

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3273,6 +3273,32 @@ plugins:
       - Delev
       - Invent
       - Relev
+  - name: 'Lore Weapon Expansion.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/9660/']
+    tag:
+      - Delev
+      - Relev
+    clean:
+      - crc: 0x0D7685E5 # v1.4a
+        util: SSEEdit v3.2.2
+  - name: 'Lore Weapon Expansion - Daedric Crescent.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/9660/']
+    group: *earlyLoadersGroup
+    clean:
+      - crc: 0x524C6138 # v1.0
+        util: SSEEdit v3.2.2
+  - name: 'Lore Weapon Expansion - Goldbrand.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/9660/']
+    group: *earlyLoadersGroup
+    clean:
+      - crc: 0x5587FCE6 # v1.1
+        util: SSEEdit v3.2.2
+  - name: 'Lore Weapon Expansion - Relics of the Crusader.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/9660/']
+    group: *earlyLoadersGroup
+    clean:
+      - crc: 0xA5763C46 # v1.0
+        util: SSEEdit v3.2.2
   - name: 'Summermyst - Enchantments of Skyrim.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/6285/']
     inc:


### PR DESCRIPTION
Added Bash Tags & Cleaning info.

Add-ons can be loaded early as they do not require main plug-in as a master.

They also place new objects in cells, so loading them early will avoid reverting changes made to these cells by other mods.