### PR TITLE
[New] Deadly Spell Impacts

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1166,6 +1166,12 @@ plugins:
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/12466/']
     after:
       - 'RealisticWaterTwo.esp'
+  - name: 'DeadlySpellImpacts.esp'
+    url: ['https://www.nexusmods.com/skyrimspecialedition/mods/12939/']
+    group: *earlyLoadersGroup
+    clean:
+      - crc: 0x72B9103C # v1.70
+        util: SSEEdit v3.2.2
   - name: 'Immersive Sounds - Compendium.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/523/']
     group: *overhaulsGroup


### PR DESCRIPTION
Moved to early loaders so that all audio mods can overwrite its audio changes, only a few conflicts and patches are available.

Compatible with all mods. Load order doesn't matter.
Source: mod [description](https://www.nexusmods.com/skyrimspecialedition/mods/12939) page.