### PR TITLE
[New] SAFO & CSOS

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2737,6 +2737,7 @@ plugins:
     after:
       - 'Phenderix Magic Evolved.esp'
       - 'Phenderix Magic World.esp'
+      - 'SAFO.esp'
       - 'Undeath.esp'
     inc:
       - 'ScopedBows_EagleEyeTweak.esp'
@@ -2943,6 +2944,73 @@ plugins:
       - crc: 0xAE9687E1 # v1.65 No survival mode
         util: SSEEdit v3.2.2
       - crc: 0x9F375906 # v1.65 CC Survival mode
+        util: SSEEdit v3.2.2
+  - name: 'SAFO.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/12343/'
+        name: 'Skyrim Alchemy and Food Overhaul on Nexus Mods'
+    after:
+      - 'Betterfoodeffects.esp'
+    inc:
+      - 'Cooking_In_Skyrim.esp'
+      - 'Cooking_In_Skyrim_v_2_0.esp'
+      - 'Cooking_In_Skyrim_v_2_0_Salty_Edition.esp'
+    tag:
+      - Delev
+      - Invent
+      - Names
+      - Relev
+      - Stats
+    msg:
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Another Sorting Mod](https://www.nexusmods.com/skyrimspecialedition/mods/10/)'
+          - '[Skyrim Alchemy and Food Overhaul](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("AnotherSortingMod_2017-SSE.esp") and not active("SAFO - Another Sorting Mod.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[AWESOME POTIONS](https://www.nexusmods.com/skyrimspecialedition/mods/5077/)'
+          - '[Skyrim Alchemy and Food Overhaul](https://www.nexusmods.com/skyrimspecialedition/mods/12343/)'
+        condition: 'active("Potions.esp") and not file("SAFO - Awesome Potions.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Frostfall](https://www.nexusmods.com/skyrimspecialedition/mods/671/)'
+          - '[SAFO - Frostfall Patch](https://www.nexusmods.com/skyrimspecialedition/mods/12343/)'
+        condition: 'active("Frostfall.esp") and not file("SAFO - Frostfall.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Imperious - Races of Skyrim](https://www.nexusmods.com/skyrimspecialedition/mods/1315/)'
+          - '[Skyrim Alchemy and Food Overhaul](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("Imperious - Races of Skyrim.esp") and not active("SAFO - Imperious.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[iNeed](https://www.nexusmods.com/skyrimspecialedition/mods/645/)'
+          - '[Skyrim Alchemy and Food Overhaul](https://www.nexusmods.com/skyrimspecialedition/mods/12343/)'
+        condition: 'active("iNeed - Extended.esp") and not file("SAFO - iNeed.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Realistic Needs and Diseases](https://www.nexusmods.com/skyrimspecialedition/mods/3487/)'
+          - '[Skyrim Alchemy and Food Overhaul](https://www.nexusmods.com/skyrimspecialedition/mods/12343/)'
+        condition: 'active("RealisticNeedsandDiseases.esp") and not file("SAFO - RND.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[SkyTEST - Realistic Animals and Predators](https://www.nexusmods.com/skyrimspecialedition/mods/1104/)'
+          - '[Skyrim Alchemy and Food Overhaul](https://www.nexusmods.com/skyrimspecialedition/mods/12343/)'
+        condition: 'active("SkyTEST-RealisticAnimals&Predators.esp") and not file("SAFO - SkyTEST RAP.esp")'
+      - <<: *hasPluginPatch
+        subs:
+          - 'Creation Club Survival Mode'
+          - '[SAFO - Survival Overhaul Patch](https://www.nexusmods.com/skyrimspecialedition/mods/11802)'
+        condition: 'active("ccqdrsse001-survivalmode.esp") and not active("SAFO - Survival Overhaul.esp")'
+      - <<: *hasPatchIncluded
+        subs:
+          - '[Valdacil''s Item Sorting](https://www.nexusmods.com/skyrimspecialedition/mods/5224/)'
+          - '[Skyrim Alchemy and Food Overhaul](https://www.nexusmods.com/skyrimspecialedition/mods/12343/)'
+        condition: 'active("ValdacilsItemSorting.esp") and not file("SAFO - Valdacil.esp")'
+    clean:
+      - crc: 0x71C54257 # v2.5 No Regen
+        util: SSEEdit v3.2.2
+      - crc: 0xBB12DA56 # v2.5 With Health Regen
         util: SSEEdit v3.2.2
   - name: 'Skyrim Alchemy Fixed.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/2262/']

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3940,6 +3940,14 @@ plugins:
         util: SSEEdit v3.2.1
       - crc: 0xBE63BEB8 # v4.0.4
         util: SSEEdit v3.2.2
+  - name: 'simpleCarriageExpansion.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10434/'
+        name: 'Carriage Stops of Skyrim on Nexus Mods'
+    group: *fixesResourcesGroup
+    clean:
+      - crc: 0xF036353E # v1.0
+        util: SSEEdit v3.2.2
   - name: 'Cutting Room Floor.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/276/'


### PR DESCRIPTION
 #### Carriage Stops of Skyrim
Load Order
Put it high in the load order. If you have any water, weather, outdoor lighting mods, put it above those.

#### Skyrim Alchemy and Food Overhaul.

Source for rules:
Mod description page

Load After:
- Better food effects.
Incompatible with:
- Cooking in Skyrim, both do the same thing.
Added bash Tag suggestions.

Added patch check & messages:
- Another Sorting Mod
- AWESOME POTIONS
- Frostfall
- Imperious
- iNeed
- Realistic Needs and Diseases
- SkyTEST - Realistic Animals and Predators
- Creation Club Survival Mode
- Valdacil's Item Sorting

Added cleaning info for Main plug-ins.

Ordinator must load after SAFO, Perk conflict.

