### PR TITLE
[Update] RDO & patches - Group change

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2774,6 +2774,7 @@ plugins:
       - 'Thief skills rebalance for Ordinator.esp'
   - name: 'Relationship Dialogue Overhaul.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/1187/']
+    group: *iCitizenGroup
     inc:
       - name: 'Immersive Horses.esp'
         condition: 'active("Immersive Horses.esp") and not active("Relationship Dialogue Overhaul - Immersive Horses Patch.esp") and not active("RDO - Immersive Horses Patch.esp")'
@@ -2820,6 +2821,10 @@ plugins:
     clean:
       - crc: 0x20DC9B97 # vFinal
         util: SSEEdit v3.2.1
+  - name: '(RDO|Relationship Dialogue Overhaul) - *\Patch.esp'
+    group: *iCitizenGroup
+    after:
+      - 'Relationship Dialogue Overhaul.esp'
   - name: 'RDO - CRF + USSEP Patch.esp'
     url: ['https://www.nexusmods.com/skyrimspecialedition/mods/1187/']
     after:


### PR DESCRIPTION
- Move RDO to iCitizen Group
- Add Catch all for patches.

Patches should be in same group as master. This prevents some group conflicts which occur when patches are in default.