### PR TITLE
[New] Dragon Bridge - Incompatible with DragonBridgeBoardwalk

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4176,6 +4176,20 @@ plugins:
     clean:
       - crc: 0xAB3D0FFF # v2.0.2
         util: SSEEdit v3.2.2
+  - name: 'Dragon bridge.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/8683/'
+        name: 'Dragon bridge on Nexus Mods'
+    inc:
+      - DragonBridgeBoardwalk.esp
+    tag:
+      - Actors.AIPackages
+      - C.Location
+      - Invent
+      - NpcFaces
+    clean:
+      - crc: 0x6BD4ACD3 # v2.0.2
+        util: SSEEdit v3.2.2
   - name: 'Helarchen Creek.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/4043'


### PR DESCRIPTION
- Incompatible with Dragon Bridge Boardwalk, source https://www.nexusmods.com/skyrimspecialedition/mods/18135
- Added cleaning info
- Added bash tags