### PR TITLE
BandolierForNPC.esp added

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3858,29 +3858,31 @@ plugins:
       - crc: 0x65AFCE11 # v4.06SE
         util: 'SSEEdit v3.2.2'
   - name: 'BandolierForNPC.esp'
-    req:
-      - 'Dr_Bandolier.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19093'
         name: Bandolier - Bags and Pouches for NPC
-    tag:
-      - Invent
-  - name: 'BandolierForNPC - Realistic Enchantements.esp'
-    req:
-      - 'Dr_Bandolier.esp'
-    after:
-      - '1nivWICCloaks.esp'
-      - 'Cloaks.esp'
-      - '1nivWICSkyCloaksPatch.esp'
-      - 'BandolierForNPC - Winter is Coming and Cloaks of Skyrim Patch.esp'
-      - 'BandolierForNPC - Winter is Coming.esp'
+    inc:
       - 'BandolierForNPC - Cloaks of Skyrim Patch.esp'
+      - 'BandolierForNPC - Winter is Coming Patch.esp'
+      - 'BandolierForNPC - Winter is Coming and Cloaks of Skyrim Patch.esp'
+    tag:
+      - Names
+      - Stats
+  - name: 'BandolierForNPC - Realistic Enchantements.esp'
+    after:
+      - 'Cloaks.esp'
+      - '1nivWICCloaks.esp'
+      - '1nivWICSkyCloaksPatch.esp'
       - 'BandolierForNPC.esp'
+      - 'BandolierForNPC - Cloaks of Skyrim Patch.esp'
+      - 'BandolierForNPC - Winter is Coming.esp'
+      - 'BandolierForNPC - Winter is Coming and Cloaks of Skyrim Patch.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19093'
         name: Bandolier - Bags and Pouches for NPC - Realistic Enchantements
     tag:
-      - Invent
+      - Names
+      - Stats
 ###################
 ## Leveled Lists ##
 ###################
@@ -5485,32 +5487,37 @@ plugins:
       - Invent
       - Relev
   - name: 'BandolierForNPC - Cloaks of Skyrim Patch.esp'
-    req:
-      - 'Dr_Bandolier.esp'
-      - 'Cloaks.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19093'
         name: Bandolier - Bags and Pouches for NPC - Cloaks of Skyrim Patch
+    inc:
+      - 'BandolierForNPC - Cloaks of Skyrim Patch.esp'
+      - 'BandolierForNPC - Winter is Coming Patch.esp'
+      - 'BandolierForNPC - Winter is Coming and Cloaks of Skyrim Patch.esp'
     tag:
-      - Invent
+      - Names
+      - Stats
   - name: 'BandolierForNPC - Winter is Coming Patch.esp'
-    req:
-      - 'Dr_Bandolier.esp'
-      - '1nivWICCloaks.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19093'
         name: Bandolier - Bags and Pouches for NPC - Winter is Coming Patch
+    inc:
+      - 'BandolierForNPC - Cloaks of Skyrim Patch.esp'
+      - 'BandolierForNPC - Winter is Coming Patch.esp'
+      - 'BandolierForNPC - Winter is Coming and Cloaks of Skyrim Patch.esp'
     tag:
-      - Invent
+      - Names
+      - Stats
   - name: 'BandolierForNPC - Winter is Coming and Cloaks of Skyrim Patch.esp'
-    req:
-      - 'Dr_Bandolier.esp'
-      - '1nivWICCloaks.esp'
-      - 'Cloaks.esp'
     after:
       - '1nivWICSkyCloaksPatch.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19093'
         name: Bandolier - Bags and Pouches for NPC - Winter is Coming and Cloaks of Skyrim Patch
+    inc:
+      - 'BandolierForNPC - Cloaks of Skyrim Patch.esp'
+      - 'BandolierForNPC - Winter is Coming Patch.esp'
+      - 'BandolierForNPC - Winter is Coming and Cloaks of Skyrim Patch.esp'
     tag:
-      - Invent
+      - Names
+      - Stats

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3857,6 +3857,33 @@ plugins:
     clean:
       - crc: 0x65AFCE11 # v4.06SE
         util: 'SSEEdit v3.2.2'
+  - name: 'BandolierForNPC.esp'
+    req:
+      - 'Dr_Bandolier.esp'
+    after:
+      - 'Dr_Bandolier.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19093'
+        name: Bandolier - Bags and Pouches for NPC
+    tag:
+      - Invent
+  - name: 'BandolierForNPC - Realistic Enchantements.esp'
+    req:
+      - 'Dr_Bandolier.esp'
+    after:
+      - 'Dr_Bandolier.esp'
+      - '1nivWICCloaks.esp'
+      - 'Cloaks.esp'
+      - '1nivWICSkyCloaksPatch.esp'
+      - 'BandolierForNPC - Winter is Coming and Cloaks of Skyrim Patch.esp'
+      - 'BandolierForNPC - Winter is Coming.esp'
+      - 'BandolierForNPC - Cloaks of Skyrim Patch.esp'
+      - 'BandolierForNPC.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19093'
+        name: Bandolier - Bags and Pouches for NPC - Realistic Enchantements
+    tag:
+      - Invent
 ###################
 ## Leveled Lists ##
 ###################
@@ -5460,3 +5487,42 @@ plugins:
       - Delev
       - Invent
       - Relev
+  - name: 'BandolierForNPC - Cloaks of Skyrim Patch.esp'
+    req:
+      - 'Dr_Bandolier.esp'
+      - 'Cloaks.esp'
+    after:
+      - 'Dr_Bandolier.esp'
+      - 'Cloaks.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19093'
+        name: Bandolier - Bags and Pouches for NPC - Cloaks of Skyrim Patch
+    tag:
+      - Invent
+  - name: 'BandolierForNPC - Winter is Coming Patch.esp'
+    req:
+      - 'Dr_Bandolier.esp'
+      - '1nivWICCloaks.esp'
+    after:
+      - 'Dr_Bandolier.esp'
+      - '1nivWICCloaks.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19093'
+        name: Bandolier - Bags and Pouches for NPC - Winter is Coming Patch
+    tag:
+      - Invent
+  - name: 'BandolierForNPC - Winter is Coming and Cloaks of Skyrim Patch.esp'
+    req:
+      - 'Dr_Bandolier.esp'
+      - '1nivWICCloaks.esp'
+      - 'Cloaks.esp'
+    after:
+      - 'Dr_Bandolier.esp'
+      - '1nivWICCloaks.esp'
+      - 'Cloaks.esp'
+      - '1nivWICSkyCloaksPatch.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19093'
+        name: Bandolier - Bags and Pouches for NPC - Winter is Coming and Cloaks of Skyrim Patch
+    tag:
+      - Invent

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3860,8 +3860,6 @@ plugins:
   - name: 'BandolierForNPC.esp'
     req:
       - 'Dr_Bandolier.esp'
-    after:
-      - 'Dr_Bandolier.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19093'
         name: Bandolier - Bags and Pouches for NPC
@@ -3871,7 +3869,6 @@ plugins:
     req:
       - 'Dr_Bandolier.esp'
     after:
-      - 'Dr_Bandolier.esp'
       - '1nivWICCloaks.esp'
       - 'Cloaks.esp'
       - '1nivWICSkyCloaksPatch.esp'
@@ -5491,9 +5488,6 @@ plugins:
     req:
       - 'Dr_Bandolier.esp'
       - 'Cloaks.esp'
-    after:
-      - 'Dr_Bandolier.esp'
-      - 'Cloaks.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19093'
         name: Bandolier - Bags and Pouches for NPC - Cloaks of Skyrim Patch
@@ -5501,9 +5495,6 @@ plugins:
       - Invent
   - name: 'BandolierForNPC - Winter is Coming Patch.esp'
     req:
-      - 'Dr_Bandolier.esp'
-      - '1nivWICCloaks.esp'
-    after:
       - 'Dr_Bandolier.esp'
       - '1nivWICCloaks.esp'
     url:
@@ -5517,9 +5508,6 @@ plugins:
       - '1nivWICCloaks.esp'
       - 'Cloaks.esp'
     after:
-      - 'Dr_Bandolier.esp'
-      - '1nivWICCloaks.esp'
-      - 'Cloaks.esp'
       - '1nivWICSkyCloaksPatch.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19093'


### PR DESCRIPTION
I added my mod : [BandolierForNPC.esp](https://www.nexusmods.com/skyrimspecialedition/mods/19093) - and 4 others .esp to the list.

All of them required Dr_Bandolier.esp.
BandolierForNPC.esp is the main .esp but :
 - 3 of them are standalone compatibility patch, all the required .esp has been placed.
 - The last one is an optional add-on to my mod or Dr_Bandolier.esp.
