### PR TITLE
Add Majestic Mountains

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2107,11 +2107,11 @@ plugins:
     inc:
       - name: '../d3d11.dll'
         display: '[ENBSeries](http://enbdev.com/download_mod_tesskyrimse.html)'
-    # clean:
-    #   - crc: 0xFA3951AA # v1.82 SUN SOUTH
-    #     util: 'SSEEdit v3.2.40'
-    #   - crc: 0x6D7324C6 # v1.82 SUN NORTH
-    #     util: 'SSEEdit v3.2.40'
+    clean:
+      - crc: 0xFA3951AA # v1.82 SUN SOUTH
+        util: 'SSEEdit v3.2.40'
+      - crc: 0x6D7324C6 # v1.82 SUN NORTH
+        util: 'SSEEdit v3.2.40'
   - name: 'Prometheus_No_snow_Under_the_roof.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/518/' ]
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2100,6 +2100,18 @@ plugins:
     clean:
       - crc: 0x032A023B # v1.82
         util: 'SSEEdit v3.2.40'
+  - name: 'SunDaytime(South|North_MM_default).esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/11052/'
+        name: 'Majestic Mountains on Nexus Mods'
+    inc:
+      - name: '../d3d11.dll'
+        display: '[ENBSeries](http://enbdev.com/download_mod_tesskyrimse.html)'
+    clean:
+      - crc: 0xFA3951AA # v1.82 SUN SOUTH
+        util: 'SSEEdit v3.2.40'
+      - crc: 0x6D7324C6 # v1.82 SUN NORTH
+        util: 'SSEEdit v3.2.40'
   - name: 'Prometheus_No_snow_Under_the_roof.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/518/' ]
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2100,18 +2100,6 @@ plugins:
     clean:
       - crc: 0x032A023B # v1.82
         util: 'SSEEdit v3.2.40'
-  - name: 'SunDaytime(South|North_MM_default).esp'
-    url:
-      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/11052/'
-        name: 'Majestic Mountains on Nexus Mods'
-    inc:
-      - name: '../d3d11.dll'
-        display: '[ENBSeries](http://enbdev.com/download_mod_tesskyrimse.html)'
-    clean:
-      - crc: 0xFA3951AA # v1.82 SUN SOUTH
-        util: 'SSEEdit v3.2.40'
-      - crc: 0x6D7324C6 # v1.82 SUN NORTH
-        util: 'SSEEdit v3.2.40'
   - name: 'Prometheus_No_snow_Under_the_roof.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/518/' ]
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2100,26 +2100,18 @@ plugins:
     clean:
       - crc: 0x032A023B # v1.82
         util: 'SSEEdit v3.2.40'
-  - name: 'SunDaytimeNorth_MM_default.esp'
+  - name: 'SunDaytime(South|North_MM_default).esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/11052/'
         name: 'Majestic Mountains on Nexus Mods'
     inc:
       - name: '../d3d11.dll'
         display: '[ENBSeries](http://enbdev.com/download_mod_tesskyrimse.html)'
-    clean:
-      - crc: 0x6D7324C6 # v1.82 SUN NORTH
-        util: 'SSEEdit v3.2.40'
-  - name: 'SunDaytimeSouth.esp'
-    url:
-      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/11052/'
-        name: 'Majestic Mountains on Nexus Mods'
-    inc:
-      - name: '../d3d11.dll'
-        display: '[ENBSeries](http://enbdev.com/download_mod_tesskyrimse.html)'
-    clean:
-      - crc: 0xFA3951AA # v1.82 SUN SOUTH
-        util: 'SSEEdit v3.2.40'
+    # clean:
+    #   - crc: 0xFA3951AA # v1.82 SUN SOUTH
+    #     util: 'SSEEdit v3.2.40'
+    #   - crc: 0x6D7324C6 # v1.82 SUN NORTH
+    #     util: 'SSEEdit v3.2.40'
   - name: 'Prometheus_No_snow_Under_the_roof.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/518/' ]
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2107,6 +2107,7 @@ plugins:
     inc:
       - name: '../d3d11.dll'
         display: '[ENBSeries](http://enbdev.com/download_mod_tesskyrimse.html)'
+        condition: 'file("../d3d11.dll")'
     clean:
       - crc: 0x6D7324C6 # v1.82 SUN NORTH
         util: 'SSEEdit v3.2.40'
@@ -2117,6 +2118,7 @@ plugins:
     inc:
       - name: '../d3d11.dll'
         display: '[ENBSeries](http://enbdev.com/download_mod_tesskyrimse.html)'
+        condition: 'file("../d3d11.dll")'
     clean:
       - crc: 0xFA3951AA # v1.82 SUN SOUTH
         util: 'SSEEdit v3.2.40'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2107,7 +2107,6 @@ plugins:
     inc:
       - name: '../d3d11.dll'
         display: '[ENBSeries](http://enbdev.com/download_mod_tesskyrimse.html)'
-        condition: 'file("../d3d11.dll")'
     clean:
       - crc: 0x6D7324C6 # v1.82 SUN NORTH
         util: 'SSEEdit v3.2.40'
@@ -2118,7 +2117,6 @@ plugins:
     inc:
       - name: '../d3d11.dll'
         display: '[ENBSeries](http://enbdev.com/download_mod_tesskyrimse.html)'
-        condition: 'file("../d3d11.dll")'
     clean:
       - crc: 0xFA3951AA # v1.82 SUN SOUTH
         util: 'SSEEdit v3.2.40'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2107,11 +2107,11 @@ plugins:
     inc:
       - name: '../d3d11.dll'
         display: '[ENBSeries](http://enbdev.com/download_mod_tesskyrimse.html)'
-    clean:
-      - crc: 0xFA3951AA # v1.82 SUN SOUTH
-        util: 'SSEEdit v3.2.40'
-      - crc: 0x6D7324C6 # v1.82 SUN NORTH
-        util: 'SSEEdit v3.2.40'
+    # clean:
+    #   - crc: 0xFA3951AA # v1.82 SUN SOUTH
+    #     util: 'SSEEdit v3.2.40'
+    #   - crc: 0x6D7324C6 # v1.82 SUN NORTH
+    #     util: 'SSEEdit v3.2.40'
   - name: 'Prometheus_No_snow_Under_the_roof.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/518/' ]
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2069,6 +2069,23 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9005/' ]
     after:
       - 'shor''s stone.esp'
+  - name: 'MajesticMountains.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/11052/' ]
+    after:
+      - 'Dolomite Weathers.esp'
+      - 'NAT.esp'
+    tag:
+      - Graphics
+    msg:
+      - <<: *hascompatibilityIssues
+        subs:
+          - '[MajesticMountains](https://www.nexusmods.com/skyrimspecialedition/mods/11052/)'
+          - '[Moss Rocks](https://www.nexusmods.com/skyrimspecialedition/mods/8838)'
+          - 'Moss Rocks can be used with Majestic Mountains. But Majestic Mountains meshes without snow will not be used. [Source](https://forums.nexusmods.com/index.php?/topic/5838597-majestic-mountains/?p=52271673)'
+        condition: 'active("Moss Rocks.esp")'
+    clean:
+      - crc: 0x70426681 # v1.82
+        util: 'SSEEdit v3.2.40'
   - name: 'Prometheus_No_snow_Under_the_roof.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/518/' ]
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2086,6 +2086,20 @@ plugins:
     clean:
       - crc: 0x70426681 # v1.82
         util: 'SSEEdit v3.2.40'
+  - name: 'MajesticMountains_Moss.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/11052/' ]
+    inc:
+      - 'Moss Rocks.esp'
+    tag:
+      - Graphics
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0x56DB0788 # v1.82
+        util: 'SSEEdit v3.2.40'
+        itm: 2
+    clean:
+      - crc: 0x032A023B # v1.82
+        util: 'SSEEdit v3.2.40'
   - name: 'Prometheus_No_snow_Under_the_roof.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/518/' ]
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2100,18 +2100,26 @@ plugins:
     clean:
       - crc: 0x032A023B # v1.82
         util: 'SSEEdit v3.2.40'
-  - name: 'SunDaytime(South|North_MM_default).esp'
+  - name: 'SunDaytimeNorth_MM_default.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/11052/'
         name: 'Majestic Mountains on Nexus Mods'
     inc:
       - name: '../d3d11.dll'
         display: '[ENBSeries](http://enbdev.com/download_mod_tesskyrimse.html)'
-    # clean:
-    #   - crc: 0xFA3951AA # v1.82 SUN SOUTH
-    #     util: 'SSEEdit v3.2.40'
-    #   - crc: 0x6D7324C6 # v1.82 SUN NORTH
-    #     util: 'SSEEdit v3.2.40'
+    clean:
+      - crc: 0x6D7324C6 # v1.82 SUN NORTH
+        util: 'SSEEdit v3.2.40'
+  - name: 'SunDaytimeSouth.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/11052/'
+        name: 'Majestic Mountains on Nexus Mods'
+    inc:
+      - name: '../d3d11.dll'
+        display: '[ENBSeries](http://enbdev.com/download_mod_tesskyrimse.html)'
+    clean:
+      - crc: 0xFA3951AA # v1.82 SUN SOUTH
+        util: 'SSEEdit v3.2.40'
   - name: 'Prometheus_No_snow_Under_the_roof.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/518/' ]
     dirty:


### PR DESCRIPTION

### Majestic Mountains

Add Load After Rules:
- Dolomite & NAT as they overwrite changes to snow, which can cause visual issues with snow shader.

Add Compatibility Message:
- Moss Rocks changes the default paths for some static meshes. This means Majestic Mountain meshes without snow will not be used. [Source](https://forums.nexusmods.com/index.php?/topic/5838597-majestic-mountains/?p=52271673)

- Add cleaning info.
- Add Bash tags.


### Majestic Mountains Moss

Add Compatibility Warning:
- Moss Rocks is incompatible with Majestic Mountains Moss

- Add cleaning info
- Add Bash tags