### PR TITLE
Change WACCF Group

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -817,7 +817,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18994/'
         name: 'Weapons Armor Clothing and Clutter Fixes on Nexus Mods'
-    group: *fixesResourcesGroup
+    group: *addonsGroup
     clean:
       - crc: 0x23CE2105 # v1.0
         util: 'SSEEdit v3.2.2'
@@ -835,7 +835,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19002/'
         name: 'Armor and Clothing Extension on Nexus Mods'
-    group: *fixesResourcesGroup
+    group: *addonsGroup
     msg:
       - <<: *requireSKYUI
         subs: [ '[Armor and Clothing Extension](https://www.nexusmods.com/skyrimspecialedition/mods/19002/)' ]


### PR DESCRIPTION
Moved Weapons Armor Clothing and Clutter Fixes &  to prevent keyword changes being overwritten

Armor and Clothing Extension must load after it so it needs to move as well.