### PR TITLE
 Book Covers Skyrim Moved Before Default

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3804,6 +3804,7 @@ plugins:
         name: 'Book Covers Skyrim - Original on Bethesda.net'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3072082'
         name: 'Book Covers Skyrim - Desaturated on Bethesda.net'
+    group: *addonsGroup
     msg:
       - <<: *AlreadyInX
         subs: [ 'LegacyoftheDragonborn.esm' ]


### PR DESCRIPTION
Book Covers Skyrim
- Shouldn't be overwriting mods because it's just texture replacement.