### PR TITLE
Helarchen Creek is Incompatible with Hammet's Dungeon Packs

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4931,6 +4931,8 @@ plugins:
         name: 'Helarchen Creek on Bethesda.net'
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+    inc:
+      - 'HammetDungeons.esp'
     tag:
       - C.Location
     clean:


### PR DESCRIPTION
Location conflict
- Both modify the cells LCTN, references to NPCs and objects etc.
- Exterior object placement.