### PR TITLE
Group Position Changes for iCitizen & add-ons

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -282,7 +282,7 @@ groups:
 
   - name: &lowPriorityGroup Low Priority Overrides
     after: 
-      - default
+      - *iCitizenGroup
       - *addonsGroup
 
   - name: &coreGroup Core Mods

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -292,7 +292,7 @@ groups:
     after: [ *coreGroup ]
 
   - name: &ocsGroup Open Cities
-    after: [ *iCitizenGroup ]
+    after: [ *altStartGroup ]
 
   - name: &highPriorityGroup High Priority Overrides
     after: [ *ocsGroup ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -272,11 +272,10 @@ groups:
   - name: &overhaulsGroup Large Overhauls
     after: [ *fixesResourcesGroup ]
 
-  - name: &addonsGroup Add-ons & Expansions
+  - name: default
     after: [ *overhaulsGroup ]
 
-  - name: default
-    after: [ *addonsGroup ]
+  - name: &addonsGroup Add-ons & Expansions
 
   - name: &lowPriorityGroup Low Priority Overrides
     after: [ default ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -277,17 +277,19 @@ groups:
 
   - name: &addonsGroup Add-ons & Expansions
 
-  - name: &lowPriorityGroup Low Priority Overrides
+  - name: &iCitizenGroup Immersive Citizens
     after: [ default ]
+
+  - name: &lowPriorityGroup Low Priority Overrides
+    after: 
+      - default
+      - *addonsGroup
 
   - name: &coreGroup Core Mods
     after: [ *lowPriorityGroup ]
 
   - name: &altStartGroup Alternate Start
     after: [ *coreGroup ]
-
-  - name: &iCitizenGroup Immersive Citizens
-    after: [ *altStartGroup ]
 
   - name: &ocsGroup Open Cities
     after: [ *iCitizenGroup ]


### PR DESCRIPTION

- load iCitizens Group directly after Default
- Addons group mods will Load anywhere before Low Priority Overrides