### PR TITLE
USSEP - Remove Load after Gray Fox Cowl MajesticMountains_Landscape

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -710,9 +710,7 @@ plugins:
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/2947658'
         name: 'Unofficial Skyrim Special Edition Patch on Bethesda.net'
     after:
-      - 'Gray Fox Cowl.esm'
       - 'Lanterns Of Skyrim - All In One - Main.esm'
-      - 'MajesticMountains_Landscape.esm'
       - 'RSkyrimChildren.esm'
     tag:
       - C.Acoustic


### PR DESCRIPTION

Minor region overwrites by both, but causing sorting issues with other mods if load before USSEP.