### PR TITLE
Add Mirai & Open Cities patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2195,6 +2195,35 @@ plugins:
     clean:
       - crc: 0xAA9D9F35
         util: 'SSEEdit v3.2.44'
+  - name: 'zMirai.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10908/'
+        name: 'Mirai - the Girl with the Dragon Heart on Nexus Mods'
+    group: *addonsGroup
+    after:
+      - 'DragonsKeep.esp'
+      - 'S3DTrees NextGenerationForests.esp'
+    inc:
+      - 'DragonsKeep.esp'
+    msg:
+      - <<: *hasPluginPatch
+        subs:
+          - 'Open Cities Skyrim'
+          - '[SkyMirai OCS](https://www.nexusmods.com/skyrimspecialedition/mods/10908/)'
+        condition: 'active("Open Cities Skyrim.esp") and not active("zMirai_OCS_Patch.esp")'
+    dirty:
+      - <<: *dirtyPlugin
+        crc: 0xB77667C4
+        util: 'SSEEdit v3.2.71 EXPERIMENTAL'
+        itm: 1
+    clean:
+      - crc: 0x6EE1676E
+        util: 'SSEEdit v3.2.71 EXPERIMENTAL'
+  - name: 'zMirai_OCS_Patch.esp'
+    group: *ocsGroup
+    clean:
+      - crc: 0x1F2A30C3
+        util: 'SSEEdit v3.2.71 EXPERIMENTAL'
 ####################################
 ## Environment, Landscape & Flora ##
 ####################################


### PR DESCRIPTION
Load after 3D Trees
https://discordapp.com/channels/471930020454072348/483468767829950464/496534346908434442

hanging moss is removed along with a bunch of other stuff around her fishing campsite, so if 3DTrees reenables it, its probably gonna just be floating in midair.

Incompatible with Dragons keep

Dragon's Keep (conflicts with worldspace cell around Swindler's Den where the Dragon Mound is)