### PR TITLE
Load Wildcat after Imperious

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3846,6 +3846,7 @@ plugins:
     after:
       - 'Animal Tweaks.esp'
       - 'Immersive NPC in the dark.esp'
+      - 'Imperious - Races of Skyrim.esp'
       - 'New Weapon Parry.esp'
       - 'SkyRe_Main.esp'
       - 'SkyRe_Combat.esp'


### PR DESCRIPTION
To resolve sorting conflict

"YOT - Wildcat.esp" and "Imperious - Races of Skyrim.esp". Back cycle: Imperious - Races of Skyrim.esp, YOT - Imperious.esp, Wildcat - Combat of Skyrim.esp, YOT - Wildcat.esp