### PR TITLE
Add Economy Overhaul and Scarcity Patch to Lvllist Group

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4768,6 +4768,17 @@ plugins:
       - Delev
       - Invent
       - Relev
+  - name: 'EconomyOverhaulandScarcityPatch.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/9542'
+        name: 'Economy Overhaul and Speechcraft Improvements on Nexus Mods'
+    group: *lvlListsGroup
+    tag:
+      - Delev
+      - Relev
+    clean:
+      - crc: 0x9ACEB20B
+        util: 'SSEEdit v3.2.73 EXPERIMENTAL'
   - name: 'Scarcity SE - Less Loot Mod.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/8647/' ]
     group: *lvlListsGroup


### PR DESCRIPTION
issue: https://github.com/loot/loot/issues/1034

07:53:38.710456] [error]: Failed to sort plugins. Details: Cyclic interaction detected between plugins "EconomyOverhaulandScarcityPatch.esp" and "Open Cities Skyrim.esp". Back cycle: Open Cities Skyrim.esp, RealisticWaterTwo - Open Cities.esp, Scarcity SE - Less Loot Mod.esp, EconomyOverhaulandScarcityPatch.esp
[07:53:38.757838] [error]: