### PR TITLE
 Add Quick Clean message for latest xEdit.

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -125,9 +125,11 @@ common:
     util: '[SSEEdit Experimental](https://github.com/TES5Edit/TES5Edit/releases)'
     info: |+
 
-          > **Quick Clean** is a xEdit startup option which will automatically clean a selected plugin.  
-          > A guide for running **Quick Clean** can be found [here](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#Apendix-C).  
-          > The latest version of [SSEEdit Experimental](https://github.com/TES5Edit/TES5Edit/releases) is required to use **Quick Clean**.  
+          >**Quick Clean** is a xEdit startup option which will automatically clean a selected plugin.
+          >
+          >A guide for running **Quick Clean** can be found [here](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#Apendix-C).
+          >
+          >The latest version of [SSEEdit Experimental](https://github.com/TES5Edit/TES5Edit/releases) is required to use **Quick Clean**.
 
   - &hasWildEdits
     type: warn

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -127,7 +127,7 @@ common:
 
           > **Quick Clean** is a xEdit startup option which will automatically clean a selected plugin.  
           > A guide for running **Quick Clean** can be found [here](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#Apendix-C).  
-          > The latest verion of [SSEEdit Experimental](https://github.com/TES5Edit/TES5Edit/releases) is required to use **Quick Clean**.  
+          > The latest version of [SSEEdit Experimental](https://github.com/TES5Edit/TES5Edit/releases) is required to use **Quick Clean**.  
 
   - &hasWildEdits
     type: warn

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -121,6 +121,14 @@ common:
   - &dirtyPlugin
     util: '[SSEEdit](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
     info: 'A cleaning guide is available [here](https://www.creationkit.com/index.php?title=TES5Edit_Cleaning_Guide_-_TES5Edit).'
+  - &quickClean
+    util: '[SSEEdit Experimental](https://github.com/TES5Edit/TES5Edit/releases)'
+    info: |+
+
+          > **Quick Clean** is a xEdit startup option which will automatically clean a selected plugin.  
+          > A guide for running **Quick Clean** can be found [here](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#Apendix-C).  
+          > The latest verion of [SSEEdit Experimental](https://github.com/TES5Edit/TES5Edit/releases) is required to use **Quick Clean**.  
+
   - &hasWildEdits
     type: warn
     content:


### PR DESCRIPTION
I've added a seperate message for Quick cleaning rather than replacing manual cleaning completely.
So that it can be phased in to get users used to the change.
Plus the older cleaning information needs to be updated as it might be incorrect for Quick Clean.