### PR TITLE
Replaced all instances of tags: with tag:

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1041,7 +1041,7 @@ plugins:
           - '[MajesticMountains](https://www.nexusmods.com/skyrimspecialedition/mods/11052/)'
           - 'Snow''s shader conflict: If the Better Dynamic Snow''s shader is preferred to the Majestic Mountain''s shader. Then set a rule to load Better Dynamic Snow after Majestic Mountain''s. [Source](https://www.nexusmods.com/skyrimspecialedition/mods/9121?tab=description)'
         condition: 'active("MajesticMountains.esp")'
-    tags:
+    tag:
       - Graphics
     clean:
       - crc: 0xE0DFD47C # v2.7.2
@@ -1050,7 +1050,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/9121/'
         name: 'Better Dynamic Snow SE - No snow under the roof Patch on Nexus Mods'
-    tags:
+    tag:
       - Graphics
     clean:
       - crc: 0xA81E5289 # v2.7.2
@@ -3327,7 +3327,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/17592/'
         name: 'Improved Traps on Nexus Mods'
-    tags:
+    tag:
       - Graphics
       - Stats
     clean:
@@ -3531,7 +3531,7 @@ plugins:
         name: 'MorrowLoot Ultimate on Nexus Mods'
     after:
       - 'MLU - Immersive Armors.esp'
-    tags:
+    tag:
       - Invent
     clean:
       - crc: 0x448DF62B # v1.1
@@ -4425,7 +4425,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/3732/'
         name: 'Circlets or Masks with all Robes and Hoods on Nexus Mods'
-    tags:
+    tag:
       - Graphics
       - Names
     clean:


### PR DESCRIPTION
There were several instances of `tags:` in the masterlist, which is not actually recognized by LOOT - those should be `tag:`.

Affected Entries:
 - Better Dynamic Snow.esp
 - Better Dynamic Snow - NSUTR Patch.esp
 - Improved Traps.esp
 - MLU - AAE Ultimate Edition.esp
 - Circlets and Masks with all Robes and Hoods.esp

Already tested locally, works as expected.