### PR TITLE
DLC - Quick Auto Cleaning Info

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -427,8 +427,8 @@ plugins:
         itm: 4
         nav: 57
     clean:
-      - crc: 0xBB5C7D7C # v1.5.50.0 - Auto + Manual Cleaning
-        util: 'SSEEdit v3.2.54'
+      - crc: 0x37A33247 # v1.5.50.0 - Wild Edits Cleaned
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
       - crc: 0xCF2F6C14 # v1.5.53.0 - Wild Edits Cleaned
         util: 'SSEEdit v3.2.84 EXPERIMENTAL'
   - name: 'Hearthfires.esm'
@@ -475,7 +475,7 @@ plugins:
         nav: 1
     clean:
       - crc: 0x7996AF1B # v1.5.50.0 - Quick Auto Clean
-        util: 'SSEEdit v3.2.54'
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
       - crc: 0x0EDA7DF8 # v1.5.53.0 - Quick Auto Clean
         util: 'SSEEdit v3.2.84 EXPERIMENTAL'
   - name: 'SkyrimVR.esm'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -122,14 +122,11 @@ common:
     util: '[SSEEdit](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
     info: 'A cleaning guide is available [here](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#Apendix-B).'
   - &quickClean
-    util: '[SSEEdit Experimental](https://github.com/TES5Edit/TES5Edit/releases)'
+    util: '[SSEEdit](https://github.com/TES5Edit/TES5Edit/releases) **Quick Auto Clean**'
     info: |+
 
-          >**Quick Clean** is a xEdit startup option which will automatically clean a selected plugin.
-          >
-          >A guide for running **Quick Clean** can be found [here](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#Apendix-C).
-          >
-          >The latest version of [SSEEdit Experimental](https://github.com/TES5Edit/TES5Edit/releases) is required to use **Quick Clean**.
+          >A guide for running **Quick Auto Clean** can be found [here](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#quickautoclean).
+          >The latest version of [SSEEdit Experimental](https://github.com/TES5Edit/TES5Edit/releases) is required to use **Quick Auto Clean**.
 
   - &hasWildEdits
     type: warn

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -390,9 +390,9 @@ plugins:
         itm: 239
         udr: 91
         nav: 2
-      - <<: *dirtyPlugin
-        crc: 0x2B2E516B # v1.5.53.0
-        itm: 246
+      - <<: *quickClean
+        crc: 0x2B2E516B # v1.5.53.0 - Quick Auto Clean
+        itm: 275
         udr: 91
         nav: 2
     clean:
@@ -400,8 +400,8 @@ plugins:
         util: 'SSEEdit v3.2.1'
       - crc: 0x03649E73 # v1.5.50.0 - Auto Clean
         util: 'SSEEdit v3.2.54'
-      - crc: 0x5B1B2D50 # v1.5.53.0 - Auto Clean
-        util: 'SSEEdit v3.2.72'
+      - crc: 0x708AB774 # v1.5.53.0 - Quick Auto Clean
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
   - name: 'Dawnguard.esm'
     group: *dlcGroup
     tag:
@@ -413,7 +413,7 @@ plugins:
     msg:
       - <<: *hasWildEdits
         subs: [ '[Manual Cleaning Guide](https://afkmods.iguanadons.net/index.php?/topic/4110-manual-cleaning-skyrim-and-skyrim-se-master-files/)' ]
-        condition: 'checksum("Dawnguard.esm", 6061bcff) or checksum("Dawnguard.esm", 1CF3CECB) or checksum("Dawnguard.esm", F596786A)'
+        condition: 'checksum("Dawnguard.esm", 6061bcff) or checksum("Dawnguard.esm", 1CF3CECB) or checksum("Dawnguard.esm", 15DFF74A)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x81a481e8 # v1.5.39.0
@@ -435,23 +435,22 @@ plugins:
         itm: 6
         udr: 0
         nav: 57
-      - <<: *dirtyPlugin
-        crc: 0x07CE5FCE # v1.5.53.0
-        itm: 626
+      - <<: *quickClean
+        crc: 0x07CE5FCE # v1.5.53.0 - Quick Auto Clean
+        itm: 763
         udr: 82
         nav: 57
-      - <<: *dirtyPlugin
-        crc: 0xEBF57FD9 # v1.5.53.0 - Auto Clean First pass
-        itm: 6
-        udr: 0
+      - <<: *quickClean
+        crc: 0x98134D3A # v1.5.53.0 - Quick Auto Clean
+        itm: 4
         nav: 57
     clean:
       - crc: 0x141be1e5 # v1.5.39.0 - Auto + Manual Cleaning
         util: 'SSEEdit v3.2.1'
       - crc: 0xBB5C7D7C # v1.5.50.0 - Auto + Manual Cleaning
         util: 'SSEEdit v3.2.54'
-      - crc: 0x86C558B7 # v1.5.53.0 - Auto + Manual Cleaning
-        util: 'SSEEdit v3.2.72'
+      - crc: 0xCF2F6C14 # v1.5.53.0 - Wild Edits Cleaned
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
   - name: 'Hearthfires.esm'
     group: *dlcGroup
     after:
@@ -470,9 +469,9 @@ plugins:
         itm: 178
         udr: 11
         nav: 5
-      - <<: *dirtyPlugin
-        crc: 0x463D25B7 # v1.5.53.0
-        itm: 178
+      - <<: *quickClean
+        crc: 0x463D25B7 # v1.5.53.0 - Quick Auto Clean
+        itm: 221
         udr: 11
         nav: 5
     clean:
@@ -480,8 +479,8 @@ plugins:
         util: 'SSEEdit v3.2.1'
       - crc: 0x22840A68 # v1.5.50.0 - Auto Clean
         util: 'SSEEdit v3.2.54'
-      - crc: 0xD569B4AC # v1.5.53.0 - Auto Clean
-        util: 'SSEEdit v3.2.72'
+      - crc: 0xD7EFB0D4 # v1.5.53.0 - Quick Auto Clean
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
   - name: 'Dragonborn.esm'
     group: *dlcGroup
     after:
@@ -501,9 +500,9 @@ plugins:
         itm: 69
         udr: 8
         nav: 1
-      - <<: *dirtyPlugin
-        crc: 0xE0B5DB91 # v1.5.53.0
-        itm: 69
+      - <<: *quickClean
+        crc: 0xE0B5DB91 # v1.5.53.0 - Quick Auto Clean
+        itm: 81
         udr: 8
         nav: 1
     clean:
@@ -511,8 +510,8 @@ plugins:
         util: 'SSEEdit v3.2.1'
       - crc: 0xE6E5895B # v1.5.50.0 - Auto Clean
         util: 'SSEEdit v3.2.54'
-      - crc: 0xC2F4AD77 # v1.5.53.0 - Auto Clean
-        util: 'SSEEdit v3.2.72'
+      - crc: 0x0EDA7DF8 # v1.5.53.0 - Quick Auto Clean
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
   - name: 'SkyrimVR.esm'
     group: *dlcGroup
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -120,7 +120,7 @@ common:
 # Cleaning data
   - &dirtyPlugin
     util: '[SSEEdit](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
-    info: 'A cleaning guide is available [here](https://www.creationkit.com/index.php?title=TES5Edit_Cleaning_Guide_-_TES5Edit).'
+    info: 'A cleaning guide is available [here](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#Apendix-B).'
   - &quickClean
     util: '[SSEEdit Experimental](https://github.com/TES5Edit/TES5Edit/releases)'
     info: |+

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -385,9 +385,9 @@ plugins:
         itm: 239
         udr: 91
         nav: 2
-      - <<: *dirtyPlugin
-        crc: 0xE95F6A98 # v1.5.50.0
-        itm: 239
+      - <<: *quickClean
+        crc: 0xE95F6A98 # v1.5.50.0 - Quick Auto Clean
+        itm: 256
         udr: 91
         nav: 2
       - <<: *quickClean
@@ -398,8 +398,8 @@ plugins:
     clean:
       - crc: 0xc18ee18c # v1.5.39.0 - Auto Clean
         util: 'SSEEdit v3.2.1'
-      - crc: 0x03649E73 # v1.5.50.0 - Auto Clean
-        util: 'SSEEdit v3.2.54'
+      - crc: 0x49BFB6A9 # v1.5.50.0 - Quick Auto Clean
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
       - crc: 0x708AB774 # v1.5.53.0 - Quick Auto Clean
         util: 'SSEEdit v3.2.84 EXPERIMENTAL'
   - name: 'Dawnguard.esm'
@@ -413,7 +413,7 @@ plugins:
     msg:
       - <<: *hasWildEdits
         subs: [ '[Manual Cleaning Guide](https://afkmods.iguanadons.net/index.php?/topic/4110-manual-cleaning-skyrim-and-skyrim-se-master-files/)' ]
-        condition: 'checksum("Dawnguard.esm", 6061bcff) or checksum("Dawnguard.esm", 1CF3CECB) or checksum("Dawnguard.esm", 15DFF74A)'
+        condition: 'checksum("Dawnguard.esm", 6061bcff) or checksum("Dawnguard.esm", 51982F10) or checksum("Dawnguard.esm", 15DFF74A)'
     dirty:
       - <<: *dirtyPlugin
         crc: 0x81a481e8 # v1.5.39.0
@@ -425,15 +425,14 @@ plugins:
         itm: 6
         udr: 0
         nav: 57
-      - <<: *dirtyPlugin
-        crc: 0xCFBEE94B # v1.5.50.0
-        itm: 621
+      - <<: *quickClean
+        crc: 0xCFBEE94B # v1.5.50.0 - Quick Auto Clean
+        itm: 764
         udr: 82
         nav: 57
-      - <<: *dirtyPlugin
-        crc: 0x2F6EF0B8 # v1.5.50.0 - Auto Clean First pass
-        itm: 6
-        udr: 0
+      - <<: *quickClean
+        crc: 0xFCDA9FA7 # v1.5.50.0 - Quick Auto Clean
+        itm: 4
         nav: 57
       - <<: *quickClean
         crc: 0x07CE5FCE # v1.5.53.0 - Quick Auto Clean
@@ -464,9 +463,9 @@ plugins:
         itm: 178
         udr: 11
         nav: 5
-      - <<: *dirtyPlugin
-        crc: 0x20B605D1 # v1.5.50.0
-        itm: 178
+      - <<: *quickClean
+        crc: 0x20B605D1 # v1.5.50.0 - Quick Auto Clean
+        itm: 221
         udr: 11
         nav: 5
       - <<: *quickClean
@@ -477,8 +476,8 @@ plugins:
     clean:
       - crc: 0x0ED37282 # v1.5.39.0 - Auto Clean
         util: 'SSEEdit v3.2.1'
-      - crc: 0x22840A68 # v1.5.50.0 - Auto Clean
-        util: 'SSEEdit v3.2.54'
+      - crc: 0xA3A830A4 # v1.5.50.0 - Quick Auto Clean
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
       - crc: 0xD7EFB0D4 # v1.5.53.0 - Quick Auto Clean
         util: 'SSEEdit v3.2.84 EXPERIMENTAL'
   - name: 'Dragonborn.esm'
@@ -495,9 +494,9 @@ plugins:
         itm: 69
         udr: 8
         nav: 1
-      - <<: *dirtyPlugin
-        crc: 0xA1BF01BD # v1.5.50.0
-        itm: 69
+      - <<: *quickClean
+        crc: 0xA1BF01BD # v1.5.50.0 - Quick Auto Clean
+        itm: 81
         udr: 8
         nav: 1
       - <<: *quickClean
@@ -508,7 +507,7 @@ plugins:
     clean:
       - crc: 0x5eb9eade # v1.5.39.0 - Auto Clean
         util: 'SSEEdit v3.2.1'
-      - crc: 0xE6E5895B # v1.5.50.0 - Auto Clean
+      - crc: 0x7996AF1B # v1.5.50.0 - Quick Auto Clean
         util: 'SSEEdit v3.2.54'
       - crc: 0x0EDA7DF8 # v1.5.53.0 - Quick Auto Clean
         util: 'SSEEdit v3.2.84 EXPERIMENTAL'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -380,11 +380,6 @@ plugins:
       - C.Water
       - Delev
     dirty:
-      - <<: *dirtyPlugin
-        crc: 0xfe610a99 # v1.5.39.0
-        itm: 239
-        udr: 91
-        nav: 2
       - <<: *quickClean
         crc: 0xE95F6A98 # v1.5.50.0 - Quick Auto Clean
         itm: 256
@@ -396,8 +391,6 @@ plugins:
         udr: 91
         nav: 2
     clean:
-      - crc: 0xc18ee18c # v1.5.39.0 - Auto Clean
-        util: 'SSEEdit v3.2.1'
       - crc: 0x49BFB6A9 # v1.5.50.0 - Quick Auto Clean
         util: 'SSEEdit v3.2.84 EXPERIMENTAL'
       - crc: 0x708AB774 # v1.5.53.0 - Quick Auto Clean
@@ -413,18 +406,8 @@ plugins:
     msg:
       - <<: *hasWildEdits
         subs: [ '[Manual Cleaning Guide](https://afkmods.iguanadons.net/index.php?/topic/4110-manual-cleaning-skyrim-and-skyrim-se-master-files/)' ]
-        condition: 'checksum("Dawnguard.esm", 6061bcff) or checksum("Dawnguard.esm", 51982F10) or checksum("Dawnguard.esm", 15DFF74A)'
+        condition: 'checksum("Dawnguard.esm", 51982F10) or checksum("Dawnguard.esm", 15DFF74A)'
     dirty:
-      - <<: *dirtyPlugin
-        crc: 0x81a481e8 # v1.5.39.0
-        itm: 621
-        udr: 82
-        nav: 57
-      - <<: *dirtyPlugin
-        crc: 0x6f162d5e # v1.5.39.0 - Auto Clean First pass
-        itm: 6
-        udr: 0
-        nav: 57
       - <<: *quickClean
         crc: 0xCFBEE94B # v1.5.50.0 - Quick Auto Clean
         itm: 764
@@ -444,8 +427,6 @@ plugins:
         itm: 4
         nav: 57
     clean:
-      - crc: 0x141be1e5 # v1.5.39.0 - Auto + Manual Cleaning
-        util: 'SSEEdit v3.2.1'
       - crc: 0xBB5C7D7C # v1.5.50.0 - Auto + Manual Cleaning
         util: 'SSEEdit v3.2.54'
       - crc: 0xCF2F6C14 # v1.5.53.0 - Wild Edits Cleaned
@@ -458,11 +439,6 @@ plugins:
       - C.Location
       - Invent
     dirty:
-      - <<: *dirtyPlugin
-        crc: 0xa631401b # v1.5.39.0
-        itm: 178
-        udr: 11
-        nav: 5
       - <<: *quickClean
         crc: 0x20B605D1 # v1.5.50.0 - Quick Auto Clean
         itm: 221
@@ -474,8 +450,6 @@ plugins:
         udr: 11
         nav: 5
     clean:
-      - crc: 0x0ED37282 # v1.5.39.0 - Auto Clean
-        util: 'SSEEdit v3.2.1'
       - crc: 0xA3A830A4 # v1.5.50.0 - Quick Auto Clean
         util: 'SSEEdit v3.2.84 EXPERIMENTAL'
       - crc: 0xD7EFB0D4 # v1.5.53.0 - Quick Auto Clean
@@ -489,11 +463,6 @@ plugins:
       - Invent
       - Relev
     dirty:
-      - <<: *dirtyPlugin
-        crc: 0x64625bcd # v1.5.39.0
-        itm: 69
-        udr: 8
-        nav: 1
       - <<: *quickClean
         crc: 0xA1BF01BD # v1.5.50.0 - Quick Auto Clean
         itm: 81
@@ -505,8 +474,6 @@ plugins:
         udr: 8
         nav: 1
     clean:
-      - crc: 0x5eb9eade # v1.5.39.0 - Auto Clean
-        util: 'SSEEdit v3.2.1'
       - crc: 0x7996AF1B # v1.5.50.0 - Quick Auto Clean
         util: 'SSEEdit v3.2.54'
       - crc: 0x0EDA7DF8 # v1.5.53.0 - Quick Auto Clean


### PR DESCRIPTION

[Quick Clean](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#Apendix-B)

- Removes Identical to master records for complex records types such at navigational mesh and landscape.
---
Changes
- Updated SSE versions 1.5.53.0 + 1.5.50.0 Downloadable content cleaning info.
- Removed 1.5.39.0 cleaning info.
- Updated cleaning guide link to point to the [Tome of xEdit](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html) mod cleaning section.
- Updated Quick Clean Message - Link now points directly to Quick Auto Clean section.