### PR TITLE
Use quick auto cleaning for BSHeartland.esm

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4982,14 +4982,15 @@ plugins:
       - Invent
       - Names
     dirty:
-      - <<: *dirtyPlugin
+      - <<: *quickClean
         crc: 0x0B12B4E7 # v1.3.3
-        itm: 485
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
+        itm: 514
         udr: 0
         nav: 0
     clean:
-      - crc: 0x4CC6CB6C # v1.3.3
-        util: 'SSEEdit v3.2.1'
+      - crc: 0xC1BC4783 # v1.3.3
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
   - name: 'BS_DLC_patch.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10917/'


### PR DESCRIPTION
Removes a few more ITMs. I also got annoyed at no longer having that clean mark in LOOT.