### PR TITLE
Refactoring: Removed all unnecessary itm:, udr: and nav: entries

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1368,8 +1368,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0xDD00738B  # v3.06
         itm: 2
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x52C7CD69 # v3.06
         util: 'SSEEdit v3.2.1'
@@ -1444,9 +1442,7 @@ plugins:
     dirty:
       - <<: *dirtyPlugin
         crc: 0x181ECD13  # v3.06
-        itm: 0
         udr: 1
-        nav: 0
     clean:
       - crc: 0xB39F6E89 # v3.06
         util: 'SSEEdit v3.2.1'
@@ -1581,8 +1577,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0xFAB62250  # v1.0.5
         itm: 3
-        udr: 0
-        nav: 0
     clean:
       - crc: 0xAD0407B5 # v1.0.2
         util: 'SSEEdit v3.2.1'
@@ -1671,8 +1665,6 @@ plugins:
         crc: 0x4A185E27 # v3.0.0
         util: 'SSEEdit 3.2.84 EXPERIMENTAL'
         itm: 37
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x93126285 # v3.0.0
         util: 'SSEEdit 3.2.84 EXPERIMENTAL'
@@ -1691,8 +1683,6 @@ plugins:
         crc: 0x4ED7C6DC # v3.2
         util: 'SSEEdit v3.2.2'
         itm: 3
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x2E0270B6 # v3.2
         util: 'SSEEdit v3.2.2'
@@ -1918,8 +1908,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x8377D03C # 0.4.2c
         itm: 19
-        udr: 0
-        nav: 0
     clean:
       - crc: 0xD36DA497 # v0.4.2c
         util: 'SSEEdit v3.2.2'
@@ -2038,8 +2026,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0xD3211EB7 # v1.01 No Fog
         itm: 1
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x49921FB9 # v1.01
         util: 'SSEEdit v3.2.2'
@@ -2113,8 +2099,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x6065FD6C # v2.30
         itm: 6
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x676197A6 # v2.30
         util: 'SSEEdit v3.2.2'
@@ -2124,8 +2108,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0xF1A0B710 # v2.30
         itm: 18
-        udr: 0
-        nav: 0
     clean:
       - crc: 0xF7A0E586 # v2.30
         util: 'SSEEdit v3.2.2'
@@ -2514,8 +2496,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x6E242E9E # v2.4D
         itm: 1
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x16CF39A0 # v2.4D
         util: 'SSEEdit v3.2.1'
@@ -2651,7 +2631,6 @@ plugins:
         crc: 0xDC6B06E4 # v1.4.a
         itm: 18
         udr: 45
-        nav: 0
     clean:
       - crc: 0x441524FC # v1.4.a
         util: 'SSEEdit v3.2.1'
@@ -2734,7 +2713,6 @@ plugins:
         crc: 0x87D18F2B # v3.2
         itm: 59
         udr: 5
-        nav: 0
     clean:
       - crc: 0xA314B458 # v3.2
         util: 'SSEEdit v3.2.1'
@@ -2859,23 +2837,15 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x730EF406 # v1.5 - main file
         itm: 11
-        udr: 0
-        nav: 0
       - <<: *dirtyPlugin
         crc: 0x05D653F7 # v1.5 - OCS Version
         itm: 13
-        udr: 0
-        nav: 0
       - <<: *dirtyPlugin
         crc: 0x0040F980 # v1.5 - W.A.T.E.R version
         itm: 11
-        udr: 0
-        nav: 0
       - <<: *dirtyPlugin
         crc: 0x93E44E78 # v1.5 - Tweaks for Verdant
         itm: 11
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x102BBC11 # v1.5
         util: 'SSEEdit v3.2.1'
@@ -3089,8 +3059,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0xAB210158 # v7.0
         itm: 4
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x373951A5 # v7.0
         util: 'SSEEdit v3.2.1'
@@ -3788,8 +3756,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0xF7A45327 # v5.0.0
         itm: 1
-        udr: 0
-        nav: 0
     clean:
       - crc: 0xF923DCE1 # v5.0.0
         util: 'SSEEdit v3.2.1'
@@ -3980,8 +3946,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x93553BD1 # v5.11SSE
         itm: 20
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x7443BF2E # v5.11SSE
         util: 'SSEEdit v3.2.1'
@@ -4360,8 +4324,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0xBEA0B2DA # v2.1
         itm: 3
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x8757A209 # v2.1
         util: 'SSEEdit v3.2.2'
@@ -4604,8 +4566,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x8491D752 # v1.58
         itm: 5
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x17CF8EB8 # v1.58
         util: 'SSEEdit v3.2.1'
@@ -4772,8 +4732,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0xEC89CAD3 # v1.01
         itm: 19
-        udr: 0
-        nav: 0
     clean:
       - crc: 0xB63A3D6B # v1.01 Without wild edits
         util: 'SSEEdit v3.2.1'
@@ -4799,8 +4757,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x5AE957AB # v1.01
         itm: 19
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x65674DC4 # v1.01 Without wild edits
         util: 'SSEEdit v3.2.1'
@@ -4829,8 +4785,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x6DA7BCF5 # v1.03
         itm: 30
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x2A2CF491 # v1.03 Without wild edits
         util: 'SSEEdit v3.2.1'
@@ -4859,8 +4813,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x3BEDC8A5 # v1.03
         itm: 30
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x7BD6C78A # v1.03 Without wild edits
         util: 'SSEEdit v3.2.1'
@@ -4885,8 +4837,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0xE614F5D7 # v1.00
         itm: 17
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x6C66613A # v1.00 Without wild edits
         util: 'SSEEdit v3.2.1'
@@ -4911,8 +4861,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x2393970C # v1.00
         itm: 17
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x711550A4 # v1.00 Without wild edits
         util: 'SSEEdit v3.2.1'
@@ -4937,8 +4885,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x24B9E639 # v4.06SE
         itm: 2
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x16736E69 # v4.06SE
         util: 'SSEEdit v3.2.2'
@@ -5109,8 +5055,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0xEB5AEFAF # v3.2
         itm: 1
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x1DA470CB # v3.2
         util: 'SSEEdit v3.2.1'
@@ -5136,13 +5080,9 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0xEB75A960 # v1.7
         itm: 18
-        udr: 0
-        nav: 0
       - <<: *dirtyPlugin
         crc: 0x6E988E26 # v1.7
         itm: 17
-        udr: 0
-        nav: 0
     clean:
       - crc: 0xB98044B4 # v1.7
         util: 'SSEEdit v3.2.1'
@@ -6097,13 +6037,9 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x9E66B431 # v2.2
         itm: 1
-        udr: 0
-        nav: 0
       - <<: *dirtyPlugin
         crc: 0x600E8FE9
         itm: 1
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x4735D188 # v2.2 no master sort
         util: 'SSEEdit v3.2.1'
@@ -6392,8 +6328,6 @@ plugins:
       - <<: *dirtyPlugin
         crc: 0x2AE17DBF # v1.0
         itm: 2
-        udr: 0
-        nav: 0
     clean:
       - crc: 0x4DDE110A # v1.0
         util: 'SSEEdit v3.2.1'
@@ -6406,7 +6340,6 @@ plugins:
         crc: 0x7AADCF10 # v1.0
         itm: 4
         udr: 14
-        nav: 0
     clean:
       - crc: 0xD943D95A # v1.0
         util: 'SSEEdit v3.2.1'
@@ -6417,9 +6350,7 @@ plugins:
     dirty:
       - <<: *dirtyPlugin
         crc: 0x79F28EB3 # v1.0
-        itm: 0
         udr: 63
-        nav: 0
     clean:
       - crc: 0x9F433E43 # v1.0
         util: 'SSEEdit v3.2.1'
@@ -6432,7 +6363,6 @@ plugins:
         crc: 0x64A2DD93 # v1.0
         itm: 15
         udr: 9
-        nav: 0
     clean:
       - crc: 0x967FE323 # v1.0
         util: 'SSEEdit v3.2.1'
@@ -6445,7 +6375,6 @@ plugins:
         crc: 0xA46DFEE0 # v1.0
         itm: 21
         udr: 18
-        nav: 0
     clean:
       - crc: 0x4304D27F # v1.0
         util: 'SSEEdit v3.2.1'


### PR DESCRIPTION
They're redundant and made searching through the list for entries with deleted navmeshes difficult.

While I'm at it, I also marked the three mods with deleted navmeshes on the list as dirty:
- The Haven From The Cold And Dark.esp
- Distinct Interiors.esp
- Eli_Breezehome.esp

That said, as the TODO comments in the PR imply, we might want to wait with this until `*noAutomaticFix` is added.