### PR TITLE
Beyond Skyrim Bruma - Tweaks: Bash Tags and Cleaning Info

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5092,6 +5092,41 @@ plugins:
     clean:
       - crc: 0xC1BC4783 # v1.3.3
         util: 'SSEEdit v3.2.84 EXPERIMENTAL'
+  - name: 'BSHeartland - Unofficial Patch.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19374'
+        name: 'Beyond Skyrim - Bruma - Tweaks Enhancements and Patches SSE on Nexus Mods'
+    group: *addonsGroup
+    dirty:
+      - <<: *quickClean
+        crc: 0xB283D3E0 # v1.2, esp
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
+        itm: 173
+      - <<: *quickClean
+        crc: 0x76842224 # v1.2, esl
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
+        itm: 173
+    clean:
+      - crc: 0xF838E3BE # v1.2, esp
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
+      - crc: 0xA75B7111 # v1.2, esl
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
+    tag:
+      - C.Location
+      - C.Name
+      - Names
+  - name: 'BS_Campfire.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19374'
+        name: 'Beyond Skyrim - Bruma - Tweaks Enhancements and Patches SSE on Nexus Mods'
+    group: *addonsGroup
+    clean:
+      - crc: 0x3332482F # v1.2, esp
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
+      - crc: 0x4F219DBA # v1.2, esl
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
+    tag:
+      - Names
   - name: 'BS_DLC_patch.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10917/'


### PR DESCRIPTION
Added cleaning information and appropriate bash tags for:
- `BS_Campfire.esp`
- `BSHeartland - Unofficial Patch.esp`

Both of these come from 'Beyond Skyrim - Bruma - Tweaks Enhancements and Patches SSE'.