### PR TITLE
Convenient Horses: Add 'Do Not Clean' warning

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3108,13 +3108,7 @@ plugins:
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'Relationship Dialogue Overhaul.esp'
-    dirty:
-      - <<: *dirtyPlugin
-        crc: 0xAB210158 # v7.0
-        itm: 4
-    clean:
-      - crc: 0x373951A5 # v7.0
-        util: 'SSEEdit v3.2.1'
+    msg: [ *doNotClean ]
   - name: 'The Brotherhood of Old.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/15322/' ]
     group: 'Add-ons & Expansions'


### PR DESCRIPTION
Apparently (according to the author and Arthmoor), these should not be cleaned
because of their MO2T changes (Model Texture Hashes), which will allegedly lead
to crashes if cleaned.

This makes the skyrimse masterlist mirror the skyrim masterlist for this mod.