### PR TITLE
Rigmor of Bruma - Sorting Rules & Cleaning Info (#432)

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2519,13 +2519,36 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/5271/'
         name: 'Rigmor of Bruma on Nexus Mods'
+    group: *addonsGroup
+    inc:
+      - 'Open Cities Skyrim.esp'
+    after:
+      - 'Cutting Room Floor.esp'
+      - 'ETaC - Complete.esp'
+      - 'ETaC - Dawnstar.esp'
+      - 'ETaC - Riverwood.esp'
+      - 'Immersive Citizens - AI Overhaul.esp'
+      - 'PyP_Legendary.esp'
     dirty:
       - <<: *quickClean
-        crc: 0x216656CE # v1.0
+        crc: 0x216656CE # v1.0 Full
         util: 'SSEEdit v3.2.84 EXPERIMENTAL'
         itm: 411
+      - <<: *quickClean
+        crc: 0x0FECA474 # v1.0 Just Rigmor
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
+        itm: 2
+      - <<: *quickClean
+        crc: 0xE2D1C53F # v1.0 BS Bruma
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
+        itm: 413
+        udr: 1
     clean:
-      - crc: 0xE3C4DFFF # v1.0
+      - crc: 0xE3C4DFFF # v1.0 Full Version
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
+      - crc: 0xD5B7810F # v1.0 Just Rigmor
+        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
+      - crc: 0xBDDE731D # v1.0 BS Bruma
         util: 'SSEEdit v3.2.84 EXPERIMENTAL'
   - name: 'Skyrim Immersive Creatures Special Edition.esp'
     url:
@@ -3715,10 +3738,12 @@ plugins:
         display: 'JKs Skyrim'
       - 'Oblivion Gates in Cities.esp'
       - 'OutlawsRefuges.esp'
+      - 'Rigmor.esp'
     after:
       - 'Alternate Start - Live Another Life.esp'
       - 'Complete Alchemy & Cooking Overhaul.esp'
       - 'Ordinator - Perks of Skyrim.esp'
+      - 'Rigmor.esp'
       - 'Unique Region Names.esp'
       - 'URN+CoT Patch.esp'
       - 'Atlas Map Markers.esp'


### PR DESCRIPTION
* Rigmor of Bruma - Update Cleaning Info

3 versions of Rigmor.esp
- Main
- Standalone follower Just Rigmor
- BS Bruma

* Incompatible with Open Cities Skyrim

- Added to both
- Open Cities will Sort after even if this is ignored, a patch is really required.

* Add to addons group

* Load after Expanded Towns & Cities

Load order taken from ETAC description.
Patches for Rigmor provided in ETAC installer.

* Load after Immersive Citizens

- Must be loaded after due to an NPC Angi which Rigmor uses extensively. ICAIO alias script will interfere with how the mod works.

* Load after Cutting Room Floor

- Some minor conflicts, nothing a small patch or bash patch can't handle. But this should be added in combination with the other load rules.

* Sort after Protect your people