### PR TITLE
Thunderchild - Mark as do not clean.

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4274,15 +4274,9 @@ plugins:
         util: 'SSEEdit v3.2.1'
   - name: 'Thunderchild - Epic Shout Package.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1460/' ]
-    msg: [ *includesMBBF ]
-    dirty:
-      - <<: *quickClean
-        crc: 0x5D3C94B4 # v4.11SSE
-        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
-        itm: 62
-    clean:
-      - crc: 0xE23961C7 # v4.11SSE
-        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
+    msg:
+      - *includesMBBF
+      - *doNotClean
   - name: 'TouringCarriages.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/15948/' ]
     group: *earlyLoadersGroup


### PR DESCRIPTION
- Added until Author has time to test and confirm removal of ITMs have no side effect.

Discussion can be found on SSE Thunderchild posts.

Quote from author

"The location reference is nonexistent in the vanilla game but Thunderchild adds it, apparently as a result of updating the High Hrothgar navmesh. Will the navmesh still work without them? Maybe, maybe not, but I assume the CK added them for a reason. The last time I deleted a "useless ITM" from Thunderchild, it resulted in wolf and bear spawns migrating to High Hrothgar, and experimenting with a mod that isn't in a hurry to be updated anyway could end up being a timesink with uncertain benefits.

I added this to the list of things to do for Thunderchild, though. When the list gets big enough to warrant an update, then I'll play around with it."