### PR TITLE
Landscape Fixes for Grass Mods - Sorting Rules Change

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4279,6 +4279,9 @@ plugins:
   - name: 'TouringCarriages.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/15948/' ]
     group: *earlyLoadersGroup
+    after:
+      - 'Landscape Fixes For Grass Mods.esp'
+      - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
     clean:
       - crc: 0x07E8D176 # v3.0.0se
         util: 'SSEEdit v3.2.1'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2673,7 +2673,6 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9005/' ]
     group: *overhaulsGroup
     after:
-      - 'Cutting Room Floor.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
   - name: 'Landscape Fixes For Grass Mods .*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9005/' ]


### PR DESCRIPTION
Failed to sort plugins. Details: Cyclic interaction detected between "EBT - skyBirds Patch.esp" and "Cutting Room Floor.esp". Back cycle: Cutting Room Floor.esp, Landscape Fixes For Grass Mods.esp, skyBirds_SSE.esp, EBT - skyBirds Patch.esp

To solve this I'm removing the Load after `Cutting Room Floor` rule from `Landscape Fixes For Grass Mods`. A patch is provided for CRF on Landscape Fixes mod page. However this patch does not cover 3 conflicting records, which could be forwarded to the patch to make the after rule unnecessary.
I think this could be resolved by the author of Landscape Fixes.

Cutting Room Floor & Landscape Fixes Conflicts
![image](https://user-images.githubusercontent.com/1944639/48219985-f5469800-e385-11e8-9d44-8c831e06f492.png)

Cutting Room Floor & Landscape Fixes & Patch
![image](https://user-images.githubusercontent.com/1944639/48220203-99c8da00-e386-11e8-9a36-4b68b45d6843.png)


Another reason for the removal of the load after Cutting room floor rule is a conflict between Touring Carriages & Landscape fixes for Grass mods.

Current Load order

Touring Carriages
Cutting Room Floor
Landscape Fixes for Grass Mods

Cutting Room floor must load after Touring Carriages due to NAMV edit conflicts.

For Reference Comparison of conflicts between TC & LFFGM depending on order.

Grass Mods after Touring Carriages - Conflicts
![image](https://user-images.githubusercontent.com/1944639/48218606-2ae98200-e382-11e8-92d0-625d7a654344.png)

Touring Carriages after Grass Mods - No Conflicts
![image](https://user-images.githubusercontent.com/1944639/48218700-62f0c500-e382-11e8-9f05-1b65a2d27304.png)
