### PR TITLE
WACCF - Add Sort After Rules

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -937,10 +937,16 @@ plugins:
     inc:
       - 'Race Scale Remover.esp'
     after:
+      - 'Audio Overhaul Skyrim.esp'
+      - 'Cutting Room Floor.esp'
+      - 'DLCIntegration.esp'
       - 'Hothtrooper44_ArmorCompilation.esp'
+      - 'Immersive Sounds - Compendium.esp'
       - 'Joy of Perspective.esp'
+      - 'Lore Weapon Expansion.esp'
       - 'ScopedBows_ArrowTweaks.esp'
       - 'UnlimitedBookshelves.esp'
+      - 'unofficial skyrim survival patch.esp'
     msg:
       - type: say
         content:
@@ -948,8 +954,6 @@ plugins:
             text: '[WACCF Compatibility Notes & Patches](https://forums.nexusmods.com/index.php?/topic/6871717-waccf-compatibility/?p=62448162)'
           - lang: de
             text: '[WACCF-Kompatibilitätsnotizen & Patches](https://forums.nexusmods.com/index.php?/topic/6871717-waccf-compatibility/?p=62448162)'
-    tag:
-      - Sound
     clean:
       - crc: 0x23CE2105 # v1.0
         util: 'SSEEdit v3.2.2'


### PR DESCRIPTION
### [Weapons Armor Clothing and Clutter Fixes](https://www.nexusmods.com/skyrimspecialedition/mods/18994)

**[Cutting Room Floor](https://www.nexusmods.com/skyrimspecialedition/mods/276)**
- Keyword & Outfit Conflicts, patch required.
- Only the winning Keywords will be forwarded by bash patch. WACCF has a lot more keyword changes.
- Both mods have tags for Delev, Graphics, Invent, Names, Relev, Stats. So a bash patch may not forward WACCF changes fully if sorted above Cutting Room Floor.

**[Lore Weapon Expansion](https://www.nexusmods.com/skyrimspecialedition/mods/9660)**
- Level List conflicts, patch required to integrate LWE.
- WACCF after LWE produces a bash patch more in line with WACCF balance changes.

**[Unofficial Survival patch](https://www.nexusmods.com/skyrimspecialedition/mods/12655)**
- Unofficial Survival patch reverts a lot more changes if sorted after WACCF.
- Only several records from Unofficial Survival patch are reverted by WACCF.
- WACCF also has it's own changes to balance for Survival mode, so it's better to keep it's changes over the Unofficial Survival patch.

**[DLC Integration](https://www.nexusmods.com/skyrimspecialedition/mods/8032)**
- Similar reasons as Survival patch. Reverts less with WACCF after DLC Integration, and Balance changes are forwarded correctly to Bash patch with this order.

**[Audio Overhaul for Skyrim](https://www.nexusmods.com/skyrimspecialedition/mods/12466) + [Immersive Sound Compendium](https://www.nexusmods.com/skyrimspecialedition/mods/523)**
- Due to Keywords(Not fully supported yet), Bash patch only generates correctly with audio mods before WACCF.
Remove Sound Tag
- Since WACCF is set to sort after Audio mods it no longer requires the SOUND tag.