### PR TITLE
Change Touring Carriages Group to addonsGroup

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4278,7 +4278,7 @@ plugins:
       - *doNotClean
   - name: 'TouringCarriages.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/15948/' ]
-    group: *earlyLoadersGroup
+    group: *addonsGroup
     after:
       - 'Landscape Fixes For Grass Mods.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'


### PR DESCRIPTION
Cyclic interaction detected between "TouringCarriages.esp" and "Gildergreen Regrown.esp". Back cycle: Gildergreen Regrown.esp, Landscape Fixes For Grass Mods.esp, TouringCarriages.esp

Groups
early loaders -> fixes -> overhauls -> addons

TouringCarriages.esp (early loaders)
Gildergreen Regrown (fixes)
Landscape Fixes For Grass Mods.esp (overhauls)

`TouringCarriages.esp` set to sort after `Landscape Fixes For Grass Mods.esp`