### PR TITLE
RealisticWaterTwo Updates

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2968,76 +2968,38 @@ plugins:
   - name: 'RealisticWaterTwo.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2182/' ]
     group: *lateLoadersGroup
+    after:
+      - 'Alternate Start - Live Another Life.esp'
+      - 'Immersive Citizens - AI Overhaul.esp'
+      - 'Immersive Citizens - OCS patch.esp'
+      - 'Open Cities Skyrim.esp'
+      - 'SoundsofSkyrimComplete.esp'
     tag:
       - C.Water
       - Graphics
       - Sound
+    msg:
+      - <<: *patchIncluded
+        subs: [ 'iNeed - Food, Water and Sleep' ]
+        condition: 'active("iNeed.esp") and not active("RealisticWaterTwo - Needs Mod Patch.esp")'
+      - <<: *patchIncluded
+        subs: [ 'Realistic Needs and Diseases' ]
+        condition: 'active("RealisticNeedsandDiseases.esp") and not active("RealisticWaterTwo - Needs Mod Patch.esp")'
+      - <<: *patchIncluded
+        subs: [ 'Open Cities Skyrim' ]
+        condition: 'active("Open Cities Skyrim.esp") and not active("RealisticWaterTwo - Open Cities.esp")'
+      - <<: *patchIncluded
+        subs: [ 'Paper World Map' ]
+        condition: 'active("Paper World Map.esp") and not active("RealisticWaterTwo - Paper Wold Map Patch.esp")'
+      - <<: *patchIncluded
+        subs: [ 'The People Of Skyrim Complete' ]
+        condition: 'active("tpos_ultimate_esm.esp") and not active("RWT - People of Skyrim Patch.esp")'
+      - <<: *patchIncluded
+        subs: [ 'Wyrmstooth' ]
+        condition: 'active("Wyrmstooth.esp") and not active("RealisticWaterTwo - Wyrmstooth.esp")'
     clean:
-      - crc: 0xB2812DAF # v1.4.4
-        util: 'SSEEdit v3.2.1'
-      - crc: 0xCF76C1B9 # v1.5.2
-        util: 'SSEEdit v3.2.1'
-      - crc: 0x2BDAE302 # v1.5.3
-        util: 'SSEEdit v3.2.1'
-  - name: 'RealisticWaterTwo.*\.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2182/' ]
-    group: *lateLoadersGroup
-    after:
-      - 'JK''s Riverwood.esp'
-      - 'JKs Whiterun.esp'
-      - 'JKs Whiterun exterior.esp'
-      - 'Bring Out Your Dead.esp'
-      - 'CWIOCSSEPatch.esp'
-      - 'Darkwater Crossing.esp'
-      - 'Helarchen Creek.esp'
-      - 'Ivarstead.esp'
-      - 'Karthwasten.esp'
-      - 'Kynesgrove.esp'
-      - 'Shor''s Stone.esp'
-      - 'Soljund''s Sinkhole.esp'
-      - 'Whistling Mine.esp'
-      - 'Immersive Citizens - AI Overhaul.esp'
-      - 'Immersive Citizens - OCS patch.esp'
-      - 'SoundsofSkyrimComplete.esp'
-      - 'SoS - The Wilds.esp'
-      - 'SoS - The Dungeons.esp'
-      - 'SoS - Civilization.esp'
-      - 'Alternate Start - Live Another Life.esp'
-      - 'CFTO.esp'
-      - 'Honeyside.esp'
-      - 'Book Covers Skyrim - Lost Library.esp'
-      - 'Book Covers Skyrim.esp'
-      - 'EmbersHD.esp'
-      - 'Gildergreen Regrown.esp'
-      - 'Inigo.esp'
-      - 'Landscape Fixes For Grass Mods.esp'
-      - 'MajesticMountains_Moss.esp'
-      - 'MLU.esp'
-      - 'NotSoFast-MageGuild.esp'
-      - 'NotSoFast-MainQuest.esp'
-      - 'Oblivion Gates Remade - Map Markers.esp'
-      - 'Oblivion Gates Remade.esp'
-      - 'Open Cities Skyrim.esp'
-      - 'PilgrimsDelight.esp'
-      - 'Point The Way.esp'
-      - 'SkyrimImprovedPuddles-DG-HF-DB.esp'
-      - 'The Paarthurnax Dilemma.esp'
-      - 'TheChoiceIsYours.esp'
-      - 'FarmhouseChimneys.esp'
-      - 'FarmhouseChimneysDarkwaterCrossing.esp'
-      - 'FarmhouseChimneysExtrasMerged'
-      - 'FarmhouseChimneysHelarchenCreek.esp'
-      - 'FarmhouseChimneysIvarstead.esp'
-      - 'FarmhouseChimneysKynesgrove.esp'
-      - 'FarmhouseChimneysLAL+CRF.esp'
-      - 'FarmhouseChimneysLAL.esp'
-      - 'FarmhouseChimneysShorsStone.esp'
-      - 'FarmhouseChimneysWhistlingMine.esp'
-  - name: 'RWT.*\.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2182/' ]
-    group: *lateLoadersGroup
-  - name: 'RealisticWaterTwo+-+Verdant+Patch.esp'
-    group: *lateLoadersGroup
+      - crc: 0x4E75FEF9 #v1.8.2
+        util: 'SSEEdit v3.3.8 BETA'
   - name: 'SimplyBiggerTreesSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5281/' ]
     clean:


### PR DESCRIPTION
**Update Cleaning Info**
Latest version 1.8.2
**Remove group assignment from patches.**
Adding patches/addons to a group to prevent cyclic errors was oddly enough,
increasing the chances of a cyclic error for future additions to groups.
It's easier to manage with load after rules between the groups main plugins.

By removing patches/addons from groups and keeping them in default.
Their sorting behaviour becomes consistent.
It will place the patches/addons after their latest master/after rule.
Default sorting will apply between each group plugin.
A clear priority within each group will prevent cyclic errors that can occur when patches/addons in the default group, sort after mods in a higher group.

**Removed excess after rules.**
Most of these were added with the priority system.
Where minor conflicts were more of an issue.
Mainly I'd like the after rules to be a bit more concise and relevant to a group and its neighbours.

**Add patch included messages**
Patches Included with installer.
iNeed
Realistic Needs and Diseases
Open Cities Skyrim
Paper World Map
The People Of Skyrim Complete
Wyrmstooth