### PR TITLE
Majestic Mountains: Updated cleaning info

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2899,13 +2899,13 @@ plugins:
         condition: 'active("MajesticMountains.esp") and active("Moss Rocks.esp")'
     clean:
       - crc: 0x70426681 # v1.82
-        util: 'SSEEdit v3.2.40'
+        util: 'SSEEdit v3.3.10 BETA'
   - name: 'MajesticMountains_Landscape.esm'
     after:
       - 'BSHeartland.esm'
     clean:
       - crc: 0x191C70BB # v1.82
-        util: 'SSEEdit v3.2.70 EXPERIMENTAL'
+        util: 'SSEEdit v3.3.10 BETA'
   - name: 'MajesticMountains_Moss.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/11052/' ]
     inc:
@@ -2913,13 +2913,13 @@ plugins:
     tag:
       - Graphics
     dirty:
-      - <<: *dirtyPlugin
+      - <<: *quickClean
         crc: 0x56DB0788 # v1.82
-        util: 'SSEEdit v3.2.40'
-        itm: 2
+        util: '[SSEEdit v3.3.10 BETA](https://github.com/TES5Edit/TES5Edit/releases)'
+        itm: 5
     clean:
-      - crc: 0x032A023B # v1.82
-        util: 'SSEEdit v3.2.40'
+      - crc: 0x2138ED5A # v1.82
+        util: 'SSEEdit v3.3.10 BETA'
   - name: 'Prometheus_No_snow_Under_the_roof.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/518/' ]
     group: *earlyLoadersGroup


### PR DESCRIPTION
- Updated all `util:` info to xEdit 3.3.10
- MajesticMountains_Moss.esp now has 5 ITMs cleaned