### PR TITLE
Obscure's COW - Sort after Enlightened COW

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7149,6 +7149,7 @@ plugins:
     after:
       - 'Cutting Room Floor.esp'
       - 'EnhancedLightsandFX.esp'
+      - 'Enlightened College of Winterhold.esp'
       - 'Weapons Armor Clothing & Clutter Fixes.esp'
       - 'WACCF_Armor and Clothing Extension.esp'
     inc:


### PR DESCRIPTION
ECOW reverts USSEP changes. No conflicts if OCOW is loaded after it.