### PR TITLE
Remove Redundant Patch Messages

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2617,7 +2617,7 @@ plugins:
         subs:
           - 'Unofficial Skyrim Special Edition Patch'
           - '[ Qwinn''s Unified Automated Self Installing Patch Compendium ](https://www.nexusmods.com/skyrimspecialedition/mods/18369)'
-        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Qw_BijinAIO_USSEP Patch.esp")'
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Cutting Room Floor.esp") and not active("Qw_BijinAIO_USSEP Patch.esp")'
   - name: 'Bijin( AIO|_AIO 2018|_AIO-SV 2018| Warmaidens)\.esp'
     after:
       - 'BUVARP.esp'
@@ -4809,7 +4809,7 @@ plugins:
         condition: 'active("Cutting Room Floor.esp") and not active("RDO - CRF + USSEP Patch.esp")'
       - <<: *patchProvided
         subs: [ 'Unofficial Skyrim Special Edition Patch' ]
-        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("RDO - USSEP Patch.esp") and not active("RDO - CRF + USSEP Patch.esp")'
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp")  and not active("Cutting Room Floor.esp") and not active("RDO - USSEP Patch.esp")'
     clean:
       # version: Final
       - crc: 0x20DC9B97
@@ -5386,7 +5386,7 @@ plugins:
         subs:
           - 'Unofficial Skyrim Special Edition Patch'
           - '[ Qwinn''s Unified Automated Self Installing Patch Compendium ](https://www.nexusmods.com/skyrimspecialedition/mods/18369)'
-        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Qw_BookCoversSkyrim_USSEP Patch.esp")'
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Cutting Room Floor.esp") and not active("Qw_BookCoversSkyrim_USSEP Patch.esp")'
     after:
       - 'UnlimitedBookshelves.esp'
       - 'Weightless Books.esp'


### PR DESCRIPTION
Hide USSEP patch messages if Cutting room floor is active.
For patches where USSEP changes are included in the CRF patch.