### PR TITLE
Update SKSE64 Latest Version

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -330,10 +330,10 @@ globals:
   # SKSE 64 Version
   - <<: *hasOldVersionOfX
     subs: [ '[SKSE 64](http://skse.silverlock.org)' ]
-    condition: 'version("../skse64_loader.exe", "0.2.0.11", <) and file("../SkyrimSE.exe") and file("../skse64_loader.exe")'
+    condition: 'version("../skse64_loader.exe", "0.2.0.12", <) and file("../SkyrimSE.exe") and file("../skse64_loader.exe")'
   - <<: *hasLatestVersionOfX
     subs: [ '[SKSE 64](http://skse.silverlock.org)' ]
-    condition: 'version("../skse64_loader.exe", "0.2.0.11", ==) and file("../SkyrimSE.exe") and file("../skse64_loader.exe")'
+    condition: 'version("../skse64_loader.exe", "0.2.0.12", ==) and file("../SkyrimSE.exe") and file("../skse64_loader.exe")'
   # SKSE VR Version
   - <<: *hasOldVersionOfX
     subs: [ '[SKSE VR](http://skse.silverlock.org)' ]


### PR DESCRIPTION
### [Skyrim Script Extender (SKSE)](https://skse.silverlock.org) 
Current SE build 2.0.12 (runtime 1.5.62)