### PR TITLE
Move mods out of Addons

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7287,7 +7287,6 @@ plugins:
         name: 'Telengard on Afk Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/4066247'
         name: 'Telengard on Bethesda.net'
-    group: *addonsGroup
     tag:
       - C.Location
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3092,7 +3092,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/5271/'
         name: 'Rigmor of Bruma on Nexus Mods'
-    group: *addonsGroup
     inc:
       - 'Open Cities Skyrim.esp'
     after:
@@ -4726,7 +4725,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/15829/'
         name: 'The Notice Board - Better Solstheim Quests on Nexus Mods'
-    group: *addonsGroup
     after:
       - 'Alternate Start - Live Another Life.esp'
       - 'Immersive Wenches.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6503,7 +6503,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/8683/'
         name: 'Dragon Bridge on Nexus Mods'
-    group: *addonsGroup
     after:
       - 'Landscape Fixes For Grass Mods.esp'
     inc:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6532,7 +6532,6 @@ plugins:
         util: 'SSEEdit v3.3.6'
   - name: 'Distinct Interiors.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6130/' ]
-    group: *addonsGroup
     after:
       - 'EnhancedLightsandFX.esp'
       - 'ELFX - NoPlayerHomes.esp'
@@ -6570,7 +6569,6 @@ plugins:
         util: 'SSEEdit v3.3.4 BETA'
   - name: 'Distinct Interiors - Guilds.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6130/' ]
-    group: *addonsGroup
     inc:
       - 'OpulentThievesGuild.esp'
     clean:
@@ -6579,7 +6577,6 @@ plugins:
         util: 'SSEEdit v3.2.84 EXPERIMENTAL'
   - name: 'Distinct Interiors - Inns.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6130/' ]
-    group: *addonsGroup
     after:
      - 'EnhancedLightsandFX.esp'
     inc:
@@ -6590,14 +6587,12 @@ plugins:
         util: 'SSEEdit v3.2.84 EXPERIMENTAL'
   - name: 'Distinct Interiors - Miscellaneous.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6130/' ]
-    group: *addonsGroup
     clean:
       # version: Modular - Miscellaneous v1.7
       - crc: 0xE45A43C7
         util: 'SSEEdit v3.2.84 EXPERIMENTAL'
   - name: 'Distinct Interiors - Player Homes.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6130/' ]
-    group: *addonsGroup
     inc:
       - name: 'Enhanced Lights and FX'
         condition: 'active("EnhancedLightsandFX.esp") and not active("ELFX - NoPlayerHomes.esp")'
@@ -6618,7 +6613,6 @@ plugins:
         util: 'SSEEdit v3.3.4 BETA'
   - name: 'Distinct Interiors - Shops.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6130/' ]
-    group: *addonsGroup
     clean:
       # version: Modular - Shops v1.7
       - crc: 0x9DA76663

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6164,7 +6164,7 @@ plugins:
         name: 'Undeath Remastered SE on Nexus Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3327746'
         name: 'Undeath Remastered on Bethesda.net'
-    group: *addonsGroup
+    group: *earlyLoadersGroup
     after:
       - 'MoonAndStar_MAS.esp'
     inc:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7342,7 +7342,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/12811/'
         name: 'Winterhold Restored on Nexus Mods'
-    group: *addonsGroup
     inc:
       - 'ExpandedWinterholdRuins.esp'
       - 'Less desolate Winterhold.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7269,7 +7269,6 @@ plugins:
         name: 'Soljund''s Sinkhole on Afk Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/2959957'
         name: 'Soljund''s Sinkhole on Bethesda.net'
-    group: *addonsGroup
     after:
       - 'Landscape Fixes For Grass Mods.esp'
       - 'Settlements Expanded SE.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6266,7 +6266,6 @@ plugins:
         name: 'Bring Out Your Dead on Afk Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/2956453'
         name: 'Bring Out Your Dead on Bethesda.net'
-    group: *addonsGroup
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7104,7 +7104,6 @@ plugins:
         name: 'Kynesgrove on Afk Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/2948900'
         name: 'Kynesgrove on Bethesda.net'
-    group: *addonsGroup
     after:
       - 'Landscape Fixes For Grass Mods.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6521,7 +6521,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/13607/'
         name: 'Dawnstar on Nexus Mods'
-    group: *addonsGroup
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'Landscape Fixes For Grass Mods.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1346,7 +1346,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10/'
         name: 'Another Sorting Mod on Nexus Mods'
-    group: *addonsGroup
+    group: *earlyLoadersGroup
     tag:
       - Names
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6634,7 +6634,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/13552'
         name: 'Expanded Towns and Cities (SSE) on Nexus Mods'
-    group: *addonsGroup
     inc:
       - 'Darkwater Crossing.esp'
       - 'Dawnstar.esp'
@@ -6704,7 +6703,6 @@ plugins:
         util: 'SSEEdit v3.2.2'
   - name: 'ETaC - Complete LoS Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/13552' ]
-    group: *addonsGroup
     msg:
       - <<: *reqMasterSort
         condition: 'checksum("ETaC - Complete LoS Patch.esp", 54BB4D26)'
@@ -6716,7 +6714,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/13552'
         name: 'Expanded Towns and Cities (SSE) on Nexus Mods'
-    group: *addonsGroup
     inc:
       - 'Darkwater Crossing.esp'
     after:
@@ -6749,7 +6746,6 @@ plugins:
         util: 'SSEEdit v3.2.2'
   - name: 'ETaC - Darkwater Crossing LoS Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/13552' ]
-    group: *addonsGroup
     msg:
       - <<: *reqMasterSort
         condition: 'checksum("ETaC - Darkwater Crossing LoS Patch.esp", 343067D8)'
@@ -6761,7 +6757,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/13552'
         name: 'Expanded Towns and Cities (SSE) on Nexus Mods'
-    group: *addonsGroup
     inc:
       - 'Dawnstar.esp'
     after:
@@ -6808,7 +6803,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/13552'
         name: 'Expanded Towns and Cities (SSE) on Nexus Mods'
-    group: *addonsGroup
     inc:
       - 'Eli_RiverwoodShack.esp'
       - 'HogorTheGiant_V1.esp'
@@ -6862,7 +6856,6 @@ plugins:
         util: 'SSEEdit v3.2.2'
   - name: 'ETaC - Riverwood LoS Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/13552' ]
-    group: *addonsGroup
     msg:
       - <<: *reqMasterSort
         condition: 'checksum("ETaC - Riverwood LoS Patch.esp", C723AA51)'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6452,7 +6452,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/364/'
         name: 'Storefront on Nexus Mods'
-    group: *addonsGroup
     clean:
       # version: 2.0.2
       - crc: 0x26D5C1B3

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3229,7 +3229,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10908/'
         name: 'Mirai - the Girl with the Dragon Heart on Nexus Mods'
-    group: *addonsGroup
     after:
       - 'DragonsKeep.esp'
       - 'S3DTrees NextGenerationForests.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6463,7 +6463,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/17004/'
         name: 'Immersive College of Winterhold on Nexus Mods'
-    group: *addonsGroup
     after:
       - 'Book Covers Skyrim.esp'
       - 'Cutting Room Floor.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6419,7 +6419,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10623/'
         name: 'Provincial Courier Service on Nexus Mods'
-    group: *addonsGroup
     inc:
       - 'Eli_Halla.esp'
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7087,7 +7087,6 @@ plugins:
         name: 'Keld-Nar on Afk Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/4047950'
         name: 'Keld-Nar on Bethesda.net'
-    group: *addonsGroup
     after:
       - 'Landscape Fixes For Grass Mods.esp'
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4012,7 +4012,6 @@ plugins:
     msg: [ *doNotClean ]
   - name: 'The Brotherhood of Old.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/15322/' ]
-    group: *addonsGroup
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'SkyrimSewers.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6296,7 +6296,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10434/'
         name: 'Carriage Stops of Skyrim on Nexus Mods'
-    group: *addonsGroup
+    group: *earlyLoadersGroup
     clean:
       # version: 1.0
       - crc: 0xF036353E

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4621,7 +4621,6 @@ plugins:
         util: 'SSEEdit v4.0.0'
   - name: 'NotSoFast-MageGuild.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5686/' ]
-    group: *addonsGroup
     after:
       - 'CollegeOfWinterholdImmersive.esp'
     clean:
@@ -4629,7 +4628,6 @@ plugins:
         util: 'SSEEdit v3.2.71'
   - name: 'NotSoFast-MainQuest.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2475/' ]
-    group: *addonsGroup
     after:
       - 'Book Covers Skyrim.esp'
       - 'MLU.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6929,7 +6929,6 @@ plugins:
         util: 'SSEEdit v3.3.6'
   - name: 'JK''s Riverwood.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2013/' ]
-    group: *addonsGroup
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
   - name: 'JKs Skyrim_Dawn of Skyrim_Patch.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7068,7 +7068,6 @@ plugins:
         name: 'Karthwasten on Afk Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/2960640'
         name: 'Karthwasten on Bethesda.net'
-    group: *addonsGroup
     inc:
       - 'Karthwasten - Let The Silver Flow.esp'
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3934,7 +3934,6 @@ plugins:
         util: 'SSEEdit v3.2.1'
   - name: 'TheChoiceIsYours.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/3850/' ]
-    group: *addonsGroup
     after:
       - 'BetterQuestObjectives.esp'
       - 'BetterQuestObjectives - BCS Patch.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5370,7 +5370,7 @@ plugins:
         name: 'Book Covers Skyrim - Original on Bethesda.net'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3072082'
         name: 'Book Covers Skyrim - Desaturated on Bethesda.net'
-    group: *addonsGroup
+    group: *earlyLoadersGroup
     msg:
       - <<: *AlreadyInX
         subs: [ 'LegacyoftheDragonborn.esm' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6888,7 +6888,6 @@ plugins:
         name: 'Helarchen Creek on Afk Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3090713'
         name: 'Helarchen Creek on Bethesda.net'
-    group: *addonsGroup
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7240,7 +7240,6 @@ plugins:
         name: 'Shor''s Stone on Afk Mods'
       - link: 'https://bethesda.net/it/mods/skyrim/mod-detail/2958397'
         name: 'Shor''s Stone on Bethesda.net'
-    group: *addonsGroup
     after:
       - 'Landscape Fixes For Grass Mods.esp'
       - 'SoundsofSkyrimComplete.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1410,7 +1410,7 @@ plugins:
         name: 'Even Better Quest Objectives on Nexus Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/2954089'
         name: 'Even Better Quest Objectives on Bethesda.net'
-    group: *addonsGroup
+    group: *earlyLoadersGroup
     msg:
       - <<: *patchIncluded
         subs: [ '[Book Covers Skyrim](https://www.nexusmods.com/skyrimspecialedition/mods/901/)' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6919,7 +6919,6 @@ plugins:
         name: 'Ivarstead on Afk Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/2958352'
         name: 'Ivarstead on Bethesda.net'
-    group: *addonsGroup
     after:
       - 'Landscape For Grass Mods JK''S Skyrim.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6279,7 +6279,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/8379/'
         name: 'Carriage and Ferry Travel Overhaul on Nexus Mods'
-    group: *addonsGroup
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6133,7 +6133,7 @@ plugins:
         name: 'Moon and Star on Nexus Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3107024'
         name: 'Moon And Star on Bethesda.net'
-    group: *addonsGroup
+    group: *earlyLoadersGroup
     after:
       - 'AuroraVillage.esp'
       - 'Landscape Fixes For Grass Mods.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8218,7 +8218,6 @@ plugins:
 ###### Patches - Scoped Bows Compatibility Kit - SBCK ######
   - name: 'ScopedBows_MLU_ZIA Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/19495/' ]
-    group: *addonsGroup
     tag:
       - Graphics
       - Names

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5981,7 +5981,6 @@ plugins:
         name: 'Beyond Skyrim - Bruma SE on Nexus Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/4027835'
         name: 'Beyond Skyrim: Bruma SE Assets on Bethesda.net'
-    group: *addonsGroup
     tag:
       - C.Light
       - C.RecordFlags
@@ -5995,7 +5994,6 @@ plugins:
         name: 'Beyond Skyrim - Bruma SE on Nexus Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/4027831'
         name: 'Beyond Skyrim: Bruma SE on Bethesda.net'
-    group: *addonsGroup
     msg:
       - <<: *patch3rdParty
         subs:
@@ -6042,7 +6040,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19374'
         name: 'Beyond Skyrim - Bruma - Tweaks Enhancements and Patches SSE on Nexus Mods'
-    group: *addonsGroup
     dirty:
       # version: 1.2
       - <<: *quickClean
@@ -6069,7 +6066,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19374'
         name: 'Beyond Skyrim - Bruma - Tweaks Enhancements and Patches SSE on Nexus Mods'
-    group: *addonsGroup
     clean:
       # version: 1.2
       - crc: 0x3332482F
@@ -6085,7 +6081,6 @@ plugins:
         name: 'Beyond Skyrim - Bruma SE on Nexus Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/4044167'
         name: 'Beyond Skyrim: Bruma SE DLC Patch on Bethesda.net'
-    group: *addonsGroup
     tag:
       - Delev
       - Invent

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7189,7 +7189,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/16881/'
         name: 'Rorikstead on Nexus Mods'
-    group: *addonsGroup
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'Landscape Fixes For Grass Mods.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7302,7 +7302,6 @@ plugins:
         name: 'Whistling Mine on AFK Mods'
       - link: 'https://mods.bethesda.net/#en/workshop/skyrim/mod-detail/2959645/'
         name: 'Whistling Mine on Bethesda.net'
-    group: *addonsGroup
     inc:
       - 'TES Arena Amol.esp'
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6488,7 +6488,6 @@ plugins:
         name: 'Darkwater Crossing on Afk Mods'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/2949694'
         name: 'Darkwater Crossing on Bethesda.net'
-    group: *addonsGroup
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
       - 'Immersive Citizens - AI Overhaul.esp'


### PR DESCRIPTION
On review, the idea of this group was to allow mods to load after higher groups if nothing was blocking it. Blocking would occur from mods in default by load after rules or dependent modules. This would mean the user would have to add these blocking dependent modules to the addons group to restore previous sorting. It can appear inconsistent if you're unaware of how this works. And it may not be as intuitive as I had hoped. Another solution for loading mods after the ICAIO -> RDO block of mods is required.