### PR TITLE
Armor Rating Redux: Load After Wildcat & Cleaning Info

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4368,6 +4368,11 @@ plugins:
       # version: 2.3 - Dangerous Edition
       - crc: 0xF718BAC1
         util: 'SSEEdit v3.2.1'
+  - name: 'J42_ArmorRatingRedux.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/17932/' ]
+    after:
+      - 'Wildcat - Combat of Skyrim.esp'
+    msg: [ *doNotClean ]
   - name: 'KS Dragon Overhaul.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12641/' ]
     after:


### PR DESCRIPTION
As noted in https://github.com/loot/skyrimse/issues/497#issuecomment-443562267, this mod should not be cleaned and must be loaded after Wildcat.