### PR TITLE
Blowing in the Wind - Add to Fixes & Resources Group

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3286,6 +3286,13 @@ plugins:
       # version: 1.45 REALly Blended Roads, ESL
       - crc: 0x05762FC2
         util: 'SSEEdit v4.0.0'
+  - name: 'Blowing in the Wind SSE.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5124' ]
+    group: *fixesGroup
+    clean:
+      # version: 2.04
+      - crc: 0x8EF0F5D1
+        util: 'SSEEdit v4.0.0'
   - name: 'Enhanced Landscapes.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18162/' ]
     group: *earlyLoadersGroup


### PR DESCRIPTION
Quote from mod description page.
https://www.nexusmods.com/skyrimspecialedition/mods/5124

Place "Blowing in the Wind.esp" as high in the load order as possible, before any mods that alters signs and lanterns.

Example:
Blowing in the Wind.esp
CLARALUX.esp
Blowing in the Wind - CLARALUX Patch.esp
SMIM-Merged-All.esp
Blowing in the Wind - SMIM Merged All Patch.esp