### PR TITLE
Inns and Taverns SE: Cleaning Info & Incompatibilities

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7113,6 +7113,46 @@ plugins:
       # version: 0.0.8
       - crc: 0xA849CAA4
         util: 'SSEEdit v3.2.84 EXPERIMENTAL'
+  - name: 'Inns and Taverns.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12223' ]
+    dirty:
+      # version: 1.2
+      - <<: *quickClean
+        crc: 0xC354E06E
+        util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 91
+    clean:
+      # version: 1.2
+      - crc: 0x78A014E6
+        util: 'SSEEdit v4.0.1'
+  - name: 'Inns and Taverns - Heartwood Inn.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12223' ]
+    inc:
+      - 'Inns and Taverns.esp'
+    dirty:
+      # version: 1.2
+      - <<: *quickClean
+        crc: 0x358FD05D
+        util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 11
+    clean:
+      # version: 1.2
+      - crc: 0xC59F7380
+        util: 'SSEEdit v4.0.1'
+  - name: 'Inns and Taverns - The Ghostly View.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12223' ]
+    inc:
+      - 'Inns and Taverns.esp'
+    dirty:
+      # version: 1.2
+      - <<: *quickClean
+        crc: 0x1EB28610
+        util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 13
+    clean:
+      # version: 1.2
+      - crc: 0xA309051E
+        util: 'SSEEdit v4.0.1'
   - name: 'Ivarstead.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/349'


### PR DESCRIPTION
Cherry-Picked from #556.

Adds cleaning info and marks the all-in-one version incompatible with the modular one for [Inns and Taverns SE](https://www.nexusmods.com/skyrimspecialedition/mods/12223/).