### PR TITLE
Legendary Cities: Cleaning info & Incompatibilities

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6671,6 +6671,109 @@ plugins:
       # version: 2.0.2
       - crc: 0x26D5C1B3
         util: 'SSEEdit v3.3.6'
+  - name: 'Tes Arena - Skyrim Frontier Fortress.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/318' ]
+    inc:
+      - 'TES Arena Amol.esp'
+      - 'Tes Arena Nimalten.esp'
+      - 'Tes Arena NorthKeep.esp'
+      - 'TES DunstadGrove.esp'
+      - 'Tes Granite Hall.esp'
+      - 'Tes Pagran Village.esp'
+    dirty:
+      # version: 5.01
+      - <<: *quickClean
+        crc: 0x701ADC3A
+        util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 120
+    clean:
+      # version: 5.01
+      - crc: 0x6684B2FF
+        util: 'SSEEdit v4.0.1'
+  - name: 'TES Arena Amol.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/318' ]
+    dirty:
+      # version: 5.01
+      - <<: *quickClean
+        crc: 0x28F9DAFA
+        util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 13
+    clean:
+      # version: 5.01
+      - crc: 0x36947B49
+        util: 'SSEEdit v4.0.1'
+  - name: 'Tes Arena Nimalten.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/318' ]
+    dirty:
+      # version: 5.01
+      - <<: *quickClean
+        crc: 0xB34448CC
+        util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 26
+    clean:
+      # version: 5.01
+      - crc: 0x9365E227
+        util: 'SSEEdit v4.0.1'
+  - name: 'Tes Arena NorthKeep.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/318' ]
+    dirty:
+      # version: 5.01
+      - <<: *quickClean
+        crc: 0x0EEE0E4B
+        util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 15
+    clean:
+      # version: 5.01
+      - crc: 0x9C623E34
+        util: 'SSEEdit v4.0.1'
+  - name: 'TES DunstadGrove.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/318' ]
+    dirty:
+      # version: 5.01
+      - <<: *quickClean
+        crc: 0x72FE5CB8
+        util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 14
+    clean:
+      # version: 5.01
+      - crc: 0x01D35219
+        util: 'SSEEdit v4.0.1'
+  - name: 'Tes Granite Hall.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/318' ]
+    dirty:
+      # version: 5.01
+      - <<: *quickClean
+        crc: 0x69AAC6DC
+        util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 14
+    clean:
+      # version: 5.01
+      - crc: 0x8B59AB56
+        util: 'SSEEdit v4.0.1'
+  - name: 'Tes Pagran Village.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/318' ]
+    dirty:
+      # version: 5.01
+      - <<: *quickClean
+        crc: 0xF4AB0C61
+        util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 19
+    clean:
+      # version: 5.01
+      - crc: 0x428913E5
+        util: 'SSEEdit v4.0.1'
+  - name: 'Tes Vernim Wood.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/318' ]
+    dirty:
+      # version: 5.01
+      - <<: *quickClean
+        crc: 0x5F6B48AE
+        util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 19
+    clean:
+      # version: 5.01
+      - crc: 0xB5E436EC
+        util: 'SSEEdit v4.0.1'
 
 ###### Location - Overhauls ######
   - name: 'CollegeOfWinterholdImmersive.esp'


### PR DESCRIPTION
Cherry-Picked from #556.

Adds cleaning info and marks the all-in-one version incompatible with the modular one for [Legendary Cities - TES Arena - Skyrim Frontier Fortress](https://www.nexusmods.com/skyrimspecialedition/mods/318/).