### PR TITLE
Add Underrides Group

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -540,8 +540,12 @@ groups:
   - name: &addonsGroup Add-ons & Expansions
     after: [ *earlyLoadersGroup ]
 
+  - name: &underridesGroup Underrides
+
   - name: default
-    after: [ *earlyLoadersGroup ]
+    after: 
+      - *earlyLoadersGroup
+      - *underridesGroup
 
   - name: &coreGroup Core Mods
     after: [ default ]


### PR DESCRIPTION
Underrides will be used to store plug-ins that should generally lose to conflicting modules.

#582 