### PR TITLE
Reduce Mod Count in Fixes group

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3924,7 +3924,7 @@ plugins:
         util: 'SSEEdit v3.2.1'
   - name: 'Skyrim Flora Overhaul.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2154/' ]
-    group: *fixesGroup
+    group: *preEarlyGroup
     after:
       - 'SimplyBiggerTreesSE.esp'
   - name: 'S3DTrees NextGenerationForests.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6062,7 +6062,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/3732/'
         name: 'Circlets or Masks with all Robes and Hoods on Nexus Mods'
-    group: *fixesGroup
+    group: *preFixesGroup
     tag:
       - Graphics
       - Names

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1548,7 +1548,7 @@ plugins:
         util: 'SSEEdit v4.0.1'
   - name: 'SkyUI_SE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12604/' ]
-    group: *fixesGroup
+    group: *underridesGroup
     req:
       - *SKSE
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6885,7 +6885,7 @@ plugins:
         util: 'SSEEdit v3.2.2'
   - name: 'Bee Hives.esp'
     url: [ 'https://afkmods.iguanadons.net/index.php?/files/file/1891-bee-hives//' ]
-    group: *fixesGroup
+    group: *preFixesGroup
     clean:
       # version: 2.0
       - crc: 0xD20AF3E4

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2327,7 +2327,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/1841/'
         name: 'Lucidity Sound FX SSE on Nexus Mods'
-    group: *fixesGroup
+    group: *preFixesGroup
     clean:
       # version: v2r
       - crc: 0x8018F548

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3637,6 +3637,8 @@ plugins:
   - name: 'HearthfireGrassFix.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/13461/' ]
     group: *preEarlyGroup
+    after:
+      - 'Landscape Fixes For Grass Mods.esp'
   - name: 'Landscape Fixes For Grass Mods.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9005/' ]
     group: *earlyLoadersGroup

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4063,7 +4063,7 @@ plugins:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
   - name: 'Unbelievable Grass Two.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/4082/' ]
-    group: *fixesGroup
+    group: *preEarlyGroup
   - name: 'p_vegetation_overhaul.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/7627/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3218,7 +3218,7 @@ plugins:
       - Relev
   - name: 'Immersive Wenches.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/595/' ]
-    group: *fixesGroup
+    group: *preEarlyGroup
     clean:
       # version: 1.6
       - crc: 0xA66B30B5

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3565,7 +3565,7 @@ plugins:
         util: 'SSEEdit v4.0.0'
   - name: 'Blowing in the Wind SSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5124' ]
-    group: *fixesGroup
+    group: *preEarlyGroup
     clean:
       # version: 2.04
       - crc: 0x8EF0F5D1

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9057,6 +9057,8 @@ plugins:
     clean:
       - crc: 0xCB4A70D5
         util: 'SSEEdit v3.3.2 BETA'
+  - name: 'Qw_DucksAndSwans_USSEP Patch.esp'
+    group: *preFixesGroup
   - name: 'Qw_GuardDialogueOverhaul(_USSEP|_CRF) Patch\.esp'
     url: [ https://www.nexusmods.com/skyrimspecialedition/mods/18369 ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3599,18 +3599,18 @@ plugins:
       - crc: 0x9B2A145A
         util: 'SSEEdit v3.3.11 BETA'
   - name: 'Enhanced Landscapes - Barren Marsh.esp'
-    group: *fixesGroup
+    group: *preEarlyGroup
   - name: 'Enhanced Landscapes - Dead Marsh.esp'
-    group: *fixesGroup
+    group: *preEarlyGroup
     after:
       - 'Enhanced Landscapes - Barren Marsh.esp'
   - name: 'Enhanced Landscapes - Grass.esp'
-    group: *fixesGroup
+    group: *preEarlyGroup
     after:
       - 'Enhanced Landscapes.esp'
       - 'Skyrim Flora Overhaul.esp'
   - name: 'Enhanced Landscapes - Green Fields.esp'
-    group: *fixesGroup
+    group: *preEarlyGroup
     after:
       - 'Enhanced Landscapes.esp'
       - 'Enhanced Landscapes - Grass.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3054,7 +3054,7 @@ plugins:
 ###### Character Appearance - Presets ######
   - name: 'AsharaSkyrimCharacterPresetsReplacer.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2406/' ]
-    group: *fixesGroup
+    group: *preFixesGroup
     inc:
       - 'Better_Male_Presets.esp'
       - 'Kayla_CharPreset.esp'
@@ -3069,7 +3069,7 @@ plugins:
         condition: 'active("AsharaSkyrimCharacterPresetsReplacer.esp")'
   - name: 'Better_Male_Presets.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2001/' ]
-    group: *fixesGroup
+    group: *preFixesGroup
     inc:
       - 'AsharaSkyrimCharacterPresetsReplacer.esp'
     msg:
@@ -3084,7 +3084,7 @@ plugins:
       - NoMerge
   - name: 'Kayla_CharPreset.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/3851/' ]
-    group: *fixesGroup
+    group: *preFixesGroup
     inc:
       - 'AsharaSkyrimCharacterPresetsReplacer.esp'
       - 'Lagertha_CharPreset.esp'
@@ -3102,7 +3102,7 @@ plugins:
       - NoMerge
   - name: 'Lagertha_CharPreset.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2629/' ]
-    group: *fixesGroup
+    group: *preFixesGroup
     inc:
       - 'Kayla_CharPreset.esp'
       - 'Lydia Face Preset 64bit.esp'
@@ -3119,7 +3119,7 @@ plugins:
       - NoMerge
   - name: 'Lydia Face Preset 64bit.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1080/' ]
-    group: *fixesGroup
+    group: *preFixesGroup
     inc:
       - 'AsharaSkyrimCharacterPresetsReplacer.esp'
       - 'Kayla_CharPreset.esp'
@@ -3136,7 +3136,7 @@ plugins:
     tag:
       - NoMerge
   - name: 'Severa_CharPreset.esp'
-    group: *fixesGroup
+    group: *preFixesGroup
     inc:
       - 'Kayla_CharPreset.esp'
       - 'Lagertha_CharPreset.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3618,7 +3618,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/11008'
         name: 'Enhanced Vanilla Trees on Nexus Mods'
-    group: *fixesGroup
+    group: *preEarlyGroup
     inc:
       - 'SimplyBiggerTreesSE.esp'
       - 'Skyrim Flora Overhaul.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4068,7 +4068,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/7627/'
         name: 'Vanilla Vegetation Overhaul on Nexus Mods'
-    group: *fixesGroup
+    group: *preEarlyGroup
   - name: 'Veydosebrom - Grasses and Groundcover.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10543/' ]
     group: *fixesGroup

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3899,7 +3899,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18046/'
         name: 'Realistic High Altitude Treeline on Nexus Mods'
-    group: *fixesGroup
+    group: *preEarlyGroup
     after:
       - 'Enhanced Landscapes.esp'
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3976,7 +3976,7 @@ plugins:
         util: 'SSEEdit v3.3.11 BETA'
   - name: 'TerrainLodRedone.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9135/' ]
-    group: *fixesGroup
+    group: *preFixesGroup
   - name: 'UniqueLocationsRiverwoodForest.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9258/' ]
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1371,23 +1371,33 @@ plugins:
       - crc: 0x7C9358E6
         util: 'SSEEdit v4.0.0'
   - name: 'Skyrim Project Optimization - Full Version.esm'
-    url:
-      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/14084/'
-        name: 'Skyrim Project Optimization SE on Nexus Mods'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/14084/' ]
     group: *fixesGroup
     clean:
       # version: 1.3
       - crc: 0x45374C76
-        util: 'SSEEdit v3.2.1'
+        util: 'SSEEdit v4.0.1'
   - name: 'Skyrim Project Optimization - Full Version.esp'
-    url:
-      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/14084/'
-        name: 'Skyrim Project Optimization SE on Nexus Mods'
-    group: *fixesGroup
+    url: [ 'Skyrim Project Optimization SE on Nexus Mods' ]
+    group: *preFixesGroup
     clean:
       # version: 1.3
       - crc: 0x137A03B3
-        util: 'SSEEdit v3.2.1'
+        util: 'SSEEdit v4.0.1'
+  - name: 'Skyrim Project Optimization - No Homes - Full Version.esm'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/14084/' ]
+    group: *fixesGroup
+    clean:
+      # version: 1.3
+      - crc: 0xD0948CCF
+        util: 'SSEEdit v4.0.1'
+  - name: 'Skyrim Project Optimization - No Homes - Full Version.esp'
+    url: [ 'Skyrim Project Optimization SE on Nexus Mods' ]
+    group: *preFixesGroup
+    clean:
+      # version: 1.3
+      - crc: 0x81A0DD15
+        util: 'SSEEdit v4.0.1'
   - name: 'static mesh improvement mod se.esp'
     group: *earlyLoadersGroup
   - name: 'SMIM-SE?.*\.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3636,7 +3636,7 @@ plugins:
     group: *ccGroup
   - name: 'HearthfireGrassFix.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/13461/' ]
-    group: *earlyLoadersGroup
+    group: *preEarlyGroup
   - name: 'Landscape Fixes For Grass Mods.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9005/' ]
     group: *earlyLoadersGroup

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4380,7 +4380,7 @@ plugins:
             text: 'Ein optionaler Kompatibilitätspatch, welcher einige Perks abändert, um Deadly Combats Design zu entsprechen, ist auf der [Deadly Combat-Seite](https://www.nexusmods.com/skyrimspecialedition/mods/8850/) verfügbar.'
   - name: 'DLCIntegration.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/8032/' ]
-    group: *fixesGroup
+    group: *underridesGroup
     msg:
       - <<: *patchProvided
         subs: [ 'Beyond Skyrim DLC Integration' ]
@@ -4396,7 +4396,7 @@ plugins:
         util: 'SSEEdit v3.2.1'
   - name: 'DLCIntegration Beyond Skyrim Compatibility Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/8032/' ]
-    group: *fixesGroup
+    group: *underridesGroup
     clean:
       # version: 1.1
       - crc: 0x32F4BBE5

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4041,7 +4041,7 @@ plugins:
         name: 'Verdant - A Skyrim Grass Plugin on Nexus Mods'
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/9005/'
         name: 'Landscape Fixes For Grass Mods - Tweaks for Verdant on Nexus Mods'
-    group: *fixesGroup
+    group: *preEarlyGroup
     inc:
       - name: 'Open Cities Skyrim.esp'
         condition: 'checksum("Verdant - A Skyrim Grass Plugin SSE Version.esp", 9AB5147C)'
@@ -4058,7 +4058,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/14601/'
         name: 'Verdant - Altered Forest Grass on Nexus Mods'
-    group: *fixesGroup
+    group: *preEarlyGroup
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
   - name: 'Unbelievable Grass Two.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3233,7 +3233,7 @@ plugins:
       - Relev
   - name: 'Ducks and Swans.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2149/' ]
-    group: *fixesGroup
+    group: *preFixesGroup
   - name: 'ForgottenCity.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/1179'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3914,7 +3914,7 @@ plugins:
         util: 'SSEEdit v4.0.0'
   - name: 'SimplyBiggerTreesSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5281/' ]
-    group: *fixesGroup
+    group: *preEarlyGroup
     clean:
       # version: 1.0SE
       - crc: 0xADC2F6AF

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4071,7 +4071,7 @@ plugins:
     group: *preEarlyGroup
   - name: 'Veydosebrom - Grasses and Groundcover.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10543/' ]
-    group: *fixesGroup
+    group: *preEarlyGroup
   - name: 'WGT.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/11010/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4090,7 +4090,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/13995/'
         name: 'Viscous Grass Plus Tweaks on Nexus Mods'
-    group: *fixesGroup
+    group: *preEarlyGroup
   - name: 'waterplants.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6092/' ]
     group: 'Creation Club'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3626,7 +3626,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/348/'
         name: 'Gildergreen Regrown on Nexus Mods'
-    group: *earlyLoadersGroup
+    group: *preEarlyGroup
     clean:
       # version: 2.0
       - crc: 0xFFD6E910

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2823,10 +2823,10 @@ plugins:
 ###### Character Appearance - Body,face & hair ######
   - name: 'Hair Replacer.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/7409/' ]
-    group: *fixesGroup
+    group: *preFixesGroup
   - name: 'Hair Replacer Assets.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/7409/' ]
-    group: *fixesGroup
+    group: *preFixesGroup
     after:
       - 'Hair Replacer.esp'
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3953,7 +3953,7 @@ plugins:
         condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Cutting Room Floor.esp") and not active("Qw_S3DLandscapes_USSEP Patch.esp")'      
   - name: 'SkyrimImprovedPuddles-DG-HF-DB.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1462/' ]
-    group: *fixesGroup
+    group: *preEarlyGroup
   - name: 'SkyrimIsWindy - EVT patch.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5836/' ]
     after:


### PR DESCRIPTION
It's mainly to make the main groups easier to manage by cutting down on potential sorting errors and after rules for fixes group.
Any mod that needs to load before everything else, or needs to sort right after a  mod in `Fixes` will be moved to Pre-Fixes.
Any mod that needs to load before `Early Loaders`, or needs to sort right after a  mod in `Early Loaders` will be moved to Pre-Early.
Mods which only need to be before `default` or have a single module in `Fixes` or `Early Loader` groups that sorts after them, will be moved to `Underrides`.
https://github.com/loot/skyrimse/issues/582