### PR TITLE
Viscous Grass Sorting Updates

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3608,6 +3608,7 @@ plugins:
       - 'Enhanced Landscapes.esp'
       - 'Enhanced Landscapes - Grass.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
   - name: 'SRG Enhanced Trees Activator.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/11008'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8110,6 +8110,7 @@ plugins:
       - 'Landscape Fixes For Grass Mods.esp'
       - 'SoundsofSkyrimComplete.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
     clean:
       # version: 2.0.2
       - crc: 0x1E57B75A

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7852,6 +7852,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2259/' ]
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
   - name: 'Karthwasten.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/350/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8164,6 +8164,7 @@ plugins:
       - 'TES Arena Amol.esp'
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
     clean:
       # version: 2.0.5

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7897,6 +7897,7 @@ plugins:
     after:
       - 'Landscape Fixes For Grass Mods.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
     clean:
       # version: 2.0.4
       - crc: 0x2147A134

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3644,6 +3644,7 @@ plugins:
       - 'S3DLandscapes NextGenerationForests.esp'
       - 'Whiterun Forest Borealis.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
     msg:
       - <<: *patchProvided
         subs: [ 'Alternate Start' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7645,6 +7645,7 @@ plugins:
         name: 'Helarchen Creek on Bethesda.net'
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
     tag:
       - C.Location
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7239,6 +7239,7 @@ plugins:
         name: 'Darkwater Crossing on Bethesda.net'
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'Landscape Fixes For Grass Mods.esp'
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3601,6 +3601,7 @@ plugins:
       - 'Enhanced Landscapes.esp'
       - 'Skyrim Flora Overhaul.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
   - name: 'Enhanced Landscapes - Green Fields.esp'
     group: *fixesGroup
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3758,6 +3758,7 @@ plugins:
     after:
       - 'Dolomite Weathers.esp'
       - 'NAT.esp'
+      - 'ViscousGrass.esp'
     tag:
       - Graphics
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6914,6 +6914,7 @@ plugins:
         name: 'Bring Out Your Dead on Bethesda.net'
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
     tag:
       - C.Location
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8085,6 +8085,7 @@ plugins:
       - 'Landscape Fixes For Grass Mods.esp'
       - 'SoundsofSkyrimComplete.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
     clean:
       # version: 2.0.3
       - crc: 0x69F4FE74

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7417,6 +7417,7 @@ plugins:
       - 'S3DLandscapes NextGenerationForests.esp'
       - 'UniqueLocationsRiverwoodForest.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
     msg:
       - <<: *patchIncluded
         subs: [ '[Better Docks](https://www.nexusmods.com/skyrimspecialedition/mods/2384/)' ]
@@ -7487,6 +7488,7 @@ plugins:
       - 'QaxeQuestorium.esp'
       - 'S3DLandscapes NextGenerationForests.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
     msg:
       - <<: *patchIncluded
         subs: [ '[CLARALUX SSE](https://www.nexusmods.com/skyrimspecialedition/mods/2371)' ]
@@ -7532,6 +7534,7 @@ plugins:
       - 'QaxeQuestorium.esp'
       - 'S3DLandscapes NextGenerationForests.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
     msg:
       - <<: *patchIncluded
         subs: [ '[Better Docks](https://www.nexusmods.com/skyrimspecialedition/mods/2384/)' ]
@@ -7582,6 +7585,7 @@ plugins:
       - 'S3DLandscapes NextGenerationForests.esp'
       - 'UniqueLocationsRiverwoodForest.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
     msg:
       - <<: *patchIncluded
         subs: [ '[CLARALUX SSE](https://www.nexusmods.com/skyrimspecialedition/mods/2371)' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7845,6 +7845,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2259/' ]
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
     tag:
       - C.Location
       - C.Water

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3567,6 +3567,7 @@ plugins:
       - 'Dolomite Weathers.esp'
       - 'MajesticMountains.esp'
       - 'NAT.esp'
+      - 'ViscousGrass.esp'
     msg:
       - <<: *includesX
         subs: [ '[ Blended Roads ](https://www.nexusmods.com/skyrimspecialedition/mods/8834/)' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7866,6 +7866,7 @@ plugins:
       - 'Landscape Fixes For Grass Mods.esp'
       - 'SoundsofSkyrimComplete.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
     clean:
       # version: 2.0.3
       - crc: 0x4C61FC8C

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4055,6 +4055,7 @@ plugins:
     group: *fixesGroup
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
   - name: 'Unbelievable Grass Two.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/4082/' ]
     group: *fixesGroup

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3923,6 +3923,8 @@ plugins:
   - name: 'S3DTrees NextGenerationForests.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12371/' ]
     group: *underridesGroup
+    after:
+      - 'ViscousGrass.esp'
     inc:
       - 'Enhanced Landscapes.esp'
       - 'SimplyBiggerTreesSE.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3578,6 +3578,8 @@ plugins:
   - name: 'Enhanced Landscapes.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18162/' ]
     group: *earlyLoadersGroup
+    after:
+      - 'ViscousGrass.esp'
     inc:
       - name: 'tpos_ultimate_esm.esp'
         display: 'The People Of Skyrim Complete SSE'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7724,6 +7724,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2013/' ]
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
   - name: 'JKs Skyrim_Dawn of Skyrim_Patch.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/16852/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7753,6 +7753,7 @@ plugins:
     after:
       - 'Landscape Fixes For Grass Mods.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
       - 'WhiterunHoldForest.esp'
     msg:
       - type: warn

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4068,6 +4068,7 @@ plugins:
     group: *fixesGroup
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
   - name: 'WGT.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/11010/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4598,6 +4598,7 @@ plugins:
       - 'Skyrim Sewers.esp'
       - 'TouringCarriages.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
       - 'ASLAO - Front Porch (Breezehome).esp'
       - 'BHTNFBP.esp'
       - 'breezehome enhanced SSE.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7716,6 +7716,7 @@ plugins:
     after:
       - 'Landscape For Grass Mods JK''S Skyrim.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
     clean:
       # version: 2.0.4
       - crc: 0x04788D6B

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4050,6 +4050,7 @@ plugins:
     inc:
       - name: 'Open Cities Skyrim.esp'
         condition: 'checksum("Verdant - A Skyrim Grass Plugin SSE Version.esp", 9AB5147C)'
+      - 'ViscousGrass.esp'
     after:
       - 'Enhanced Landscapes.esp'
       - 'Skyrim Flora Overhaul.esp'
@@ -4101,6 +4102,8 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/13995/'
         name: 'Viscous Grass Plus Tweaks on Nexus Mods'
     group: *fixesGroup
+    inc:
+      - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
   - name: 'waterplants.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6092/' ]
     group: 'Creation Club'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3636,6 +3636,10 @@ plugins:
     group: *earlyLoadersGroup
     after:
       - 'ViscousGrass.esp'
+  - name: 'HearthFires Roads.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/786/' ]
+    after:
+      - 'ViscousGrass.esp'
   - name: 'Landscape Fixes For Grass Mods.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9005/' ]
     group: *earlyLoadersGroup

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5562,6 +5562,7 @@ plugins:
     after:
       - 'Landscape Fixes For Grass Mods.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
+      - 'ViscousGrass.esp'
     clean:
       # version: 3.0.0se
       - crc: 0x07E8D176

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3634,6 +3634,8 @@ plugins:
   - name: 'HearthfireGrassFix.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/13461/' ]
     group: *earlyLoadersGroup
+    after:
+      - 'ViscousGrass.esp'
   - name: 'Landscape Fixes For Grass Mods.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9005/' ]
     group: *earlyLoadersGroup


### PR DESCRIPTION
Viscous Grass is basically an older version of Verdant with some tweaks.
The key difference between the two is that Viscous Grass does not alter vanilla landscapes.
This means that it will not load after the same mods as Verdant, as it would revert landscape height
changes made by other landscape mods.
So it will generally need to sort before any mods Verdant sorts after or before.

I've also marked Viscous Grass and Verdant as incompatible.