### PR TITLE
Revert WACCF after GDO

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1150,7 +1150,6 @@ plugins:
     group: *fixesGroup
     after:
       - 'Audio Overhaul Skyrim.esp'
-      - 'Guard Dialogue Overhaul.esp'
       - 'Immersive Sounds - Compendium.esp'
       - 'Undeath.esp'
       - 'UnlimitedBookshelves.esp'


### PR DESCRIPTION
It just causes too many issues between weapon mods and Weapons Armour Clothing & Clutter Fixes.