### PR TITLE
Seperate Fixes Branch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -547,11 +547,10 @@ groups:
       - *floraGroup
 
   - name: &preFixesGroup Pre Fixes (Patches/Add-ons)
+    after: [ *preEarlyGroup ]
 
   - name: &fixesGroup Fixes & Resources
-    after:
-      - *landscapeGroup
-      - *preFixesGroup
+    after: [ *preFixesGroup ]
 
   - name: &preAddonsGroup Pre Add-ons (Patches/Add-ons)
 
@@ -559,6 +558,7 @@ groups:
     after:
       - *preAddonsGroup
       - *fixesGroup
+      - *landscapeGroup
 
   - name: &underridesGroup Underrides
 


### PR DESCRIPTION
To solve sorting errors like below.
https://github.com/loot/loot/issues/1087

Since The Fixes group doesn't need to be before or after Early Loaders and Landscapes group,
I've separated it into its own branch.
It needs to come after pre-early and before addons.

Audio Overhaul Skyrim - Immersive Sounds Patch.esp
 [Group]
Cutting Room Floor.esp
 [Master]
Landscape Fixes For Grass Mods.esp
 [Group]
Audio Overhaul Skyrim.esp
 [Master]
Audio Overhaul Skyrim - Immersive Sounds Patch.esp