### PR TITLE
QUASIPC 2.3.0 Updates

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3085,7 +3085,7 @@ plugins:
     msg:
       - <<: *patch3rdPartyQUASIPC
         subs: [ 'Unofficial Skyrim Special Edition Patch' ]
-        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Cutting Room Floor.esp") and not active("Qw_Diversity_USSEP Patch.esp")'    
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Cutting Room Floor.esp") and not active("Qw_Diversity_USSEP Patch.esp")'
       - <<: *patch3rdPartyQUASIPC
         subs: [ 'AI Overhaul SSE' ]
         condition: 'active("AI Overhaul.esp") and not active("Cutting Room Floor.esp") and not active("Qw_Diversity_AIOverhaul Patch.esp")'
@@ -3108,7 +3108,7 @@ plugins:
     msg:
       - <<: *patch3rdPartyQUASIPC
         subs: [ 'Unofficial Skyrim Special Edition Patch' ]
-        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Cutting Room Floor.esp") and not active("Qw_WICO_USSEP Patch.esp")'    
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Cutting Room Floor.esp") and not active("Qw_WICO_USSEP Patch.esp")'
       - <<: *patch3rdPartyQUASIPC
         subs: [ 'AI Overhaul SSE' ]
         condition: 'active("AI Overhaul.esp") and not active("Cutting Room Floor.esp") and not active("Qw_WICO_AIOverhaul Patch.esp")'
@@ -9532,7 +9532,6 @@ plugins:
   - name: 'Qw_PANNPCs_ICoWinterhold Patch.esp'
     after:
       - 'Qw_PANNPCs_CRF Patch.esp'
-      
 
 ###### Patches - Scoped Bows Compatibility Kit - SBCK ######
   - name: 'ScopedBows_MLU_ZIA Patch.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3078,6 +3078,57 @@ plugins:
       - <<: *patch3rdPartyQUASIPC
         subs: [ 'Immersive College of Winterhold' ]
         condition: 'active("CollegeOfWinterholdImmersive.esp") and not active("Qw_PANNPCs_ICoWinterhold Patch.esp") and not active("Qw_TheOrdinaryWomen_ICoWinterhold Patch.esp")'
+  - name: 'Diversity - An NPC Overhaul.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/5291/'
+        name: 'Diversity - An NPC Overhaul on Nexus Mods'
+    msg:
+      - <<: *patch3rdPartyQUASIPC
+        subs: [ 'Unofficial Skyrim Special Edition Patch' ]
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Cutting Room Floor.esp") and not active("Qw_Diversity_USSEP Patch.esp")'    
+      - <<: *patch3rdPartyQUASIPC
+        subs: [ 'AI Overhaul SSE' ]
+        condition: 'active("AI Overhaul.esp") and not active("Cutting Room Floor.esp") and not active("Qw_Diversity_AIOverhaul Patch.esp")'
+      - <<: *patch3rdPartyQUASIPC
+        subs: [ 'Cutting Room Floor' ]
+        condition: 'active("Cutting Room Floor.esp") and not active("AI Overhaul.esp") and not active("Qw_Diversity_CRF Patch.esp")'
+      - <<: *patch3rdPartyQUASIPC
+        subs: [ 'Cutting Room Floor and AI Overhaul SSE' ]
+        condition: 'active("Cutting Room Floor.esp") and active("AI Overhaul.esp") and not active("Qw_Diversity_AIOverhaul_CRF Patch.esp")'
+      - <<: *patch3rdPartyQUASIPC
+        subs: [ 'Immersive College of Winterhold' ]
+        condition: 'active("CollegeOfWinterholdImmersive.esp") and not active("Qw_Diversity_ICoWinterhold Patch.esp")'
+      - <<: *patch3rdPartyQUASIPC
+        subs: [ 'Interesting NPCs' ]
+        condition: 'active("3DNPC.esp") and not active("Qw_Diversity_3DNPC Patch.esp")'
+  - name: 'WICO - Immersive People.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/2136/'
+        name: 'WICO - Windsong Immersive Character Overhaul on Nexus Mods'
+    msg:
+      - <<: *patch3rdPartyQUASIPC
+        subs: [ 'Unofficial Skyrim Special Edition Patch' ]
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Cutting Room Floor.esp") and not active("Qw_WICO_USSEP Patch.esp")'    
+      - <<: *patch3rdPartyQUASIPC
+        subs: [ 'AI Overhaul SSE' ]
+        condition: 'active("AI Overhaul.esp") and not active("Cutting Room Floor.esp") and not active("Qw_WICO_AIOverhaul Patch.esp")'
+      - <<: *patch3rdPartyQUASIPC
+        subs: [ 'Cutting Room Floor' ]
+        condition: 'active("Cutting Room Floor.esp") and not active("AI Overhaul.esp") and not active("Qw_WICO_CRF Patch.esp")'
+      - <<: *patch3rdPartyQUASIPC
+        subs: [ 'Cutting Room Floor and AI Overhaul SSE' ]
+        condition: 'active("Cutting Room Floor.esp") and active("AI Overhaul.esp") and not active("Qw_WICO_AIOverhaul_CRF Patch.esp")'
+      - <<: *patch3rdPartyQUASIPC
+        subs: [ 'Interesting NPCs' ]
+        condition: 'active("3DNPC.esp") and not active("Qw_WICO_3DNPC Patch.esp")'
+  - name: 'SPTConsistentOlderPeopleSE.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/2977/'
+        name: 'Consistent Older People on Nexus Mods'
+    msg:
+      - <<: *patch3rdPartyQUASIPC
+        subs: [ 'AI Overhaul SSE' ]
+        condition: 'active("AI Overhaul.esp") and not active("Qw_ConsistentOlderPeople_AIOverhaul Patch.esp")'
   - name: 'RSkyrimChildren.esm'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2650' ]
     group: *earlyLoadersGroup
@@ -4774,7 +4825,7 @@ plugins:
     msg:
       - <<: *patch3rdPartyQUASIPC
         subs: [ 'Cutting Room Floor' ]
-        condition: 'active("Cutting Room Floor.esp") and not active("PAN_NPCs.esp") and not active("The Ordinary Women.esp") and not active("Qw_AIOverhaul_CRF Patch.esp")'
+        condition: 'active("Cutting Room Floor.esp") and not active("PAN_NPCs.esp") and not active("The Ordinary Women.esp") and not active("WICO - Immersive People.esp") and not active("Diversity - An NPC Overhaul.esp") and not active("Qw_AIOverhaul_CRF Patch.esp")'
       - <<: *patch3rdPartyQUASIPC
         subs: [ 'RS Children Overhaul' ]
         condition: 'active("RSChildren.esp") and not active("Qw_RSChildren_AIOverhaul Patch.esp")'
@@ -9408,10 +9459,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10495/'
         name: 'Bells of Skyrim on Nexus Mods'
-  - name: 'Qw_ELE_.*\.esp'
-    url:
-      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/16923/'
-        name: 'Qwinn''s Bottomless Bag of Patches on Nexus Mods'
   - name: 'Unique Loot Compatibility Patch.esp'
     tag:
       - Delev
@@ -9476,6 +9523,16 @@ plugins:
       - 'Qw_ISC_USSEP Patch.esp'
     tag:
       - Sound
+  - name: 'Qw_TheOrdinaryWomen_ICoWinterhold Patch.esp'
+    after:
+      - 'Qw_TheOrdinaryWomen_CRF Patch.esp'
+  - name: 'Qw_Diversity_ICoWinterhold Patch.esp'
+    after:
+      - 'Qw_Diversity_CRF Patch.esp'
+  - name: 'Qw_PANNPCs_ICoWinterhold Patch.esp'
+    after:
+      - 'Qw_PANNPCs_CRF Patch.esp'
+      
 
 ###### Patches - Scoped Bows Compatibility Kit - SBCK ######
   - name: 'ScopedBows_MLU_ZIA Patch.esp'


### PR DESCRIPTION
Update for QUASIPC 2.3.0.  Eleven new patches for WICO and Diversity, and one for Consistent Older People.  Cleaned out some obsolete stuff re: my old "Bottomless Bag of Patches".  Set order for a couple of my ICOW and CRF patches with 3 replacer mods.