### PR TITLE
Add Smilodon and load order for Immersive Movement

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6479,26 +6479,6 @@ plugins:
       # version: 1.7
       - crc: 0x725F1E2E
         util: 'SSEEdit v3.2.1'
-  - name: 'Smilodon - Combat of Skyrim.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2824/' ]
-    inc:
-      - 'Wildcat - Combat of Skyrim.esp'
-    after:
-      - 'Animal Tweaks.esp'
-      - 'Immersive Movement.esp'
-      - 'Immersive NPC in the dark.esp'
-      - 'New Weapon Parry.esp'
-      - 'SkyRe_Main.esp'
-      - 'SkyRe_Combat.esp'
-      - 'SkyRe_EnemyAI.esp'
-    msg:
-      - <<: *compatNotes
-        subs: [ 'https://www.nexusmods.com/skyrimspecialedition/articles/119' ]
-      - *includesMBBF
-    clean:
-      # version: 2.00SSE
-      - crc: 0x70092444
-        util: 'SSEEdit v4.0.2'
   - name: 'SwiftPotion.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12293/' ]
     req:
@@ -6633,10 +6613,7 @@ plugins:
         subs: [ 'Run For Your Lives.esp' ]
         condition: 'active("When Vampires Attack.esp") and active("Run For Your Lives.esp")'
 
-  - name: 'Wildcat - Combat of Skyrim.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1368/' ]
-    inc:
-      - 'Smilodon - Combat of Skyrim.esp'
+  - name: '(Smilodon|Wildcat) - Combat of Skyrim\.esp'
     after:
       - 'Animal Tweaks.esp'
       - 'Immersive Movement.esp'
@@ -6646,14 +6623,29 @@ plugins:
       - 'SkyRe_Combat.esp'
       - 'SkyRe_EnemyAI.esp'
     msg:
+      - <<: *useOnlyOneX
+        subs: [ 'Smilodon or Wildcat' ]
+        condition: 'many("(Smilodon|Wildcat) - Combat of Skyrim\.esp")'
+      - *includesMBBF
+  - name: 'Smilodon - Combat of Skyrim.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2824/' ]
+    msg:
+      - <<: *compatNotes
+        subs: [ 'https://www.nexusmods.com/skyrimspecialedition/articles/119' ]
+    clean:
+      # version: 2.00SSE
+      - crc: 0x70092444
+        util: 'SSEEdit v4.0.2'
+  - name: 'Wildcat - Combat of Skyrim.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1368/' ]
+    msg:
       - <<: *compatNotes
         subs: [ 'https://www.nexusmods.com/skyrimspecialedition/articles/21' ]
-      - *includesMBBF
     clean:
       # version: 7.00SSE
       - crc: 0xE6A87461
         util: 'SSEEdit v3.2.2'
-  - name: 'Wildcat - Realistic Damage Plugin.esp'
+  - name: '(Smilodon|Wildcat) - Realistic Damage Plugin\.esp'
     after:
       - 'Combat Evolved.esp'
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5877,6 +5877,8 @@ plugins:
   - name: 'Mortal Enemies( - No RunWalk Changes| - Rival Remix( - NoRunWalkChanges)?| - 2.0 Test Version)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/4881' ]
     group: *underridesGroup
+    after:
+      - 'Immersive Movement.esp'
     msg:
       - <<: *useOnlyOneX
         subs: [ 'Mortal Enemies' ]
@@ -6483,6 +6485,7 @@ plugins:
       - 'Wildcat - Combat of Skyrim.esp'
     after:
       - 'Animal Tweaks.esp'
+      - 'Immersive Movement.esp'
       - 'Immersive NPC in the dark.esp'
       - 'New Weapon Parry.esp'
       - 'SkyRe_Main.esp'
@@ -6636,6 +6639,7 @@ plugins:
       - 'Smilodon - Combat of Skyrim.esp'
     after:
       - 'Animal Tweaks.esp'
+      - 'Immersive Movement.esp'
       - 'Immersive NPC in the dark.esp'
       - 'New Weapon Parry.esp'
       - 'SkyRe_Main.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6477,6 +6477,25 @@ plugins:
       # version: 1.7
       - crc: 0x725F1E2E
         util: 'SSEEdit v3.2.1'
+  - name: 'Smilodon - Combat of Skyrim.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2824/' ]
+    inc:
+      - 'Wildcat - Combat of Skyrim.esp'
+    after:
+      - 'Animal Tweaks.esp'
+      - 'Immersive NPC in the dark.esp'
+      - 'New Weapon Parry.esp'
+      - 'SkyRe_Main.esp'
+      - 'SkyRe_Combat.esp'
+      - 'SkyRe_EnemyAI.esp'
+    msg:
+      - <<: *compatNotes
+        subs: [ 'https://www.nexusmods.com/skyrimspecialedition/articles/119' ]
+      - *includesMBBF
+    clean:
+      # version: 2.00SSE
+      - crc: 0x70092444
+        util: 'SSEEdit v4.0.2'
   - name: 'SwiftPotion.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12293/' ]
     req:


### PR DESCRIPTION
1. Smilodon is a spin-off of Wildcat and its metadata are almost same as Wildcat.
2. Immersive Movement should be loaded before Wildcat, Smilodon and Mortal Enemies as instructed in the FOMOD installer of Immersive Movement.