### PR TITLE
Add load order for Skyrim Revamped Complete Enemy Overhaul

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6457,9 +6457,11 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/14598/' ]
     after:
       - 'Cloaks.esp'
+      - 'Combat Evolved.esp'
       - 'Immersive Weapons.esp'
       - 'Skyrim Immersive Creatures Special Edition.esp'
       - 'WICO - Immersive People.esp'
+      - 'Wildcat - Combat of Skyrim.esp'
     msg:
       - <<: *patchProvided
         subs: [ 'Skyrim Immersive Creatures' ]


### PR DESCRIPTION
Wildcat and Combat Evolved should not overwrite combat styles of Skyrim Revamped Complete Enemy Overhaul. Or boss fight will not work as SRCEO intended.

Source: https://www.nexusmods.com/skyrimspecialedition/mods/14598?tab=description