### PR TITLE
Add Apocalypse compatibility patch for Vokrii

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4880,6 +4880,9 @@ plugins:
       - <<: *patchProvided
         subs: [ 'Ordinator - Perks of Skyrim' ]
         condition: 'active("Ordinator - Perks of Skyrim.esp") and not active("Apocalypse - Ordinator Compatibility Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Vokrii - Minimalistic Perks of Skyrim' ]
+        condition: 'active("Vokrii - Minimalistic Perks of Skyrim.esp") and not active("Apocalypse - Vokrii Compatibility Patch.esp")'
     clean:
       # version: 9.45SSE
       - crc: 0x266B3B3B


### PR DESCRIPTION
A patch for the new perks mod Vokrii is provided by Apocalypse.