### PR TITLE
Delete wrong cleaning info

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2497,9 +2497,6 @@ plugins:
       # version: 3.0.0
       - crc: 0x96BF25A6
         util: 'SSEEdit v4.0.0'
-      # version: 3.2.0
-      - crc: 0x747BD772
-        util: 'SSEEdit v4.0.2'
   - name: 'Audio Overhaul Skyrim - RealisticWaterTwo Patch.esp'
     after:
       - 'RealisticWaterTwo.esp'
@@ -3455,10 +3452,6 @@ plugins:
           - 'Interesting NPCs'
           - '[ RS Children Patch Compendium ](https://www.nexusmods.com/skyrimspecialedition/mods/13409)'
         condition: 'active("3DNPC.esp") and not active("RSC 3DNPC Patch.esp")'
-    clean:
-      # version: 1.1.2
-      - crc: 0xE8137869
-        util: 'SSEEdit v4.0.2'
 
   - name: 'SimpleChildren.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/22789' ]
@@ -5062,33 +5055,12 @@ plugins:
       - <<: *patchProvided
         subs: [ 'Campfire - Complete Camping System' ]
         condition: 'active("Campfire.esm") and not active("Archery_Campfire_Patch.esp")'
-    clean:
-      # version: 2.5
-      - crc: 0xB2AD660F
-        util: 'SSEEdit v4.0.2'
-      # version: 2.4
-      - crc: 0x0DDC51B6
-        util: 'SSEEdit v4.0.2'
   - name: 'Archery_Bruma_Patch.esp'
     req:
       - 'ArcheryV2.esp'
-    clean:
-      # version: 1.2
-      - crc: 0x0470CE8E
-        util: 'SSEEdit v4.0.2'
-      # version: 1.1 Aleyid Arrows
-      - crc: 0xEF057475
-        util: 'SSEEdit v4.0.2'
   - name: 'Archery_Campfire_Patch.esp'
     req:
       - 'ArcheryV2.esp'
-    clean:
-      # version: 1.2
-      - crc: 0xBE199860
-        util: 'SSEEdit v4.0.2'
-      # version: 1.1 Realisitc Arrows
-      - crc: 0x556C229B
-        util: 'SSEEdit v4.0.2'
   - name: 'Ars Metallica.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/321/' ]
     tag:
@@ -5450,10 +5422,6 @@ plugins:
       - <<: *patchIncluded
         subs: [ 'Weapons Armor Clothing and Clutter Fixes' ]
         condition: 'active("WACCF_Armor and Clothing Extension.esp") and not active("EconomyOverhaul LV - WACCF Patch.esp")'
-    clean:
-      # version: 2.1
-      - crc: 0xBBA1C2CA
-        util: 'SSEEdit v4.0.2'
   - name: 'Elemental Destruction.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/440/' ]
     msg:
@@ -5768,10 +5736,6 @@ plugins:
       - <<: *patchIncluded
         subs: [ 'Wildcat' ]
         condition: 'active("Wildcat - Combat of Skyrim.esp") and not active("Immersive Movement - Wildcat Patch.esp")'
-    clean:
-      # version: 1.3.2
-      - crc: 0xB91C4616
-        util: 'SSEEdit v4.0.2'
   - name: 'Immersive Movement - Mortal Enemies Patch.esp'
     req:
       - 'Immersive Movement.esp'
@@ -5781,26 +5745,14 @@ plugins:
       - 'Mortal Enemies - Rival Remix.esp'
       - 'Mortal Enemies - Rival Remix - NoRunWalkChanges.esp'
       - 'Mortal Enemies - 2.0 Test Version.esp'
-    clean:
-      # version: 1.3.2
-      - crc: 0xDCF50B37
-        util: 'SSEEdit v4.0.2'
   - name: 'Immersive Movement - Smilodon Patch.esp'
     req:
       - 'Immersive Movement.esp'
       - 'Smilodon - Combat of Skyrim.esp'
-    clean:
-      # version: 1.3.2
-      - crc: 0x9906E4A8
-        util: 'SSEEdit v4.0.2'
   - name: 'Immersive Movement - Wildcat Patch.esp'
     req:
       - 'Immersive Movement.esp'
       - 'Wildcat - Combat of Skyrim.esp'
-    clean:
-      # version: 1.3.2
-      - crc: 0x82AA7490
-        util: 'SSEEdit v4.0.2'
   - name: 'Immersive Ingestibles.esp'
     url: [ 'https://bethesda.net/en/mods/skyrim/mod-detail/3587775' ]
     after:
@@ -6958,10 +6910,6 @@ plugins:
     msg:
       - <<: *compatNotes
         subs: [ 'https://www.nexusmods.com/skyrimspecialedition/articles/119' ]
-    clean:
-      # version: 2.00SSE
-      - crc: 0x70092444
-        util: 'SSEEdit v4.0.2'
   - name: 'Wildcat - Combat of Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1368/' ]
     msg:
@@ -7494,25 +7442,12 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/12405/'
         name: 'Improved Closedfaced Helmets Patches'
-  - name: 'imp_helm_Immersive_Armors.esp'
-    clean:
-      # version: 1
-      - crc: 0x5C4A5C28
-        util: 'SSEEdit v4.0.2'
   - name: 'imp_helm_IDPM.esp'
     after:
       - 'imp_helm_USSEP.esp'
-    clean:
-      # version: 1
-      - crc: 0x135E09DE
-        util: 'SSEEdit v4.0.2'
   - name: 'imp_helm_USSEP.esp'
     req:
       - 'Unofficial Skyrim Special Edition Patch.esp'
-    clean:
-      # version: 1
-      - crc: 0x56ED0191
-        util: 'SSEEdit v4.0.2'
   - name: 'Improved closefaced helmets for Undeath SSE.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/14614/'


### PR DESCRIPTION
The CRC checksums added by me need to be all removed. I originally thought "Clean" meant the file was clean in terms of the integrity of the file.  It seems that "Clean" had its own meaning in Skyrim modding context. Sorry about that.