### PR TITLE
Add messages for iNeed compatibility patches

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5318,6 +5318,16 @@ plugins:
           - 'iNeed'
           - 'Disable iNeed''s option to alter food weight, as this can result in some odd weight values when used with CACO. iNeed''s degradation system is not recognized by CACO''s food portion system, which results in some slight inconsistencies.'
         condition: 'active("iNeed.esp")'
+      - <<: *patch3rdParty
+        subs:
+          - 'iNeed'
+          - '[ Be a Milk Drinker - iNeed CACO-Frostfall Patches ](https://www.nexusmods.com/skyrimspecialedition/mods/15301)'
+        condition: 'active("iNeed.esp") and not active("iNeed CACO Patch.esp")'
+      - <<: *patch3rdParty
+        subs:
+          - 'iNeed - Dangerous Disease'
+          - '[ Be a Milk Drinker - iNeed CACO-Frostfall Patches ](https://www.nexusmods.com/skyrimspecialedition/mods/15301)'
+        condition: 'active("iNeed - Dangerous Diseases.esp") and not active("CACO - iNeed DD Patch.esp")'
       - <<: *semiCompatible
         subs:
           - 'iNeed - Extended'
@@ -7982,6 +7992,11 @@ plugins:
           - 'Flora Respawn Fix'
           - '[Flora Respawn Fix SE for Beyond Skyrim](https://www.nexusmods.com/skyrimspecialedition/mods/11072/)'
         condition: 'active("FloraRespawnFix.esp") and not active("BSHeartlandFRF.esp")'
+      - <<: *patch3rdParty
+        subs:
+          - 'iNeed'
+          - '[Beyond Skyrim - Bruma - Tweaks Enhancements and Patches SSE](https://www.nexusmods.com/skyrimspecialedition/mods/19374/)'
+        condition: 'active("iNeed.esp") and not active("Bruma - iNeed Patch.esp")'
       - <<: *patch3rdParty
         subs:
           - 'Ordinator - Perks of Skyrim'


### PR DESCRIPTION
Notes: 'iNeed CACO Patch.esp' is different from kryptopyr's script patch. This patch distributes CACO foods into iNeed food categories of light, medium and heavy.