### PR TITLE
Load iNeed after SkyUI

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6512,6 +6512,8 @@ plugins:
   - name: 'iNeed.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/645/' ]
     group: *underridesGroup
+    after:
+      - 'SkyUI_SE.esp'
     msg:
       - <<: *patch3rdParty
         type: warn


### PR DESCRIPTION
If SkyUI isn't loaded before iNeed, heavy\light armor pieces are shown in inventory as "heavy\light food"