### PR TITLE
Reorder translated messages

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -25,45 +25,45 @@ common:
     content:
       - lang: en
         text: 'Delete. Already included in %1%.'
-      - lang: ru
-        text: 'Удалите. Уже включено в %1%.'
-      - lang: es
-        text: 'Borrar. Esta incluido en %1%.'
-      - lang: ko
-        text: '삭제하십시오. 이미 %1%에 포함되어 있습니다.'
-      - lang: zh_CN
-        text: '删除。已包含在%1%中。'
       - lang: da
         text: 'Slet. Allerede inkluderet i %1%.'
-      - lang: ja
-        text: '削除してください。既に%1%に含まれています。'
       - lang: de
         text: 'Löschen. Bereits in %1% enthalten.'
+      - lang: es
+        text: 'Borrar. Esta incluido en %1%.'
+      - lang: ja
+        text: '削除してください。既に%1%に含まれています。'
+      - lang: ko
+        text: '삭제하십시오. 이미 %1%에 포함되어 있습니다.'
+      - lang: pl
+        text: 'Usuń. Już zawarte w %1%'
       - lang: pt
         text: 'Apagar. Já incluído em %1%.'
       - lang: pt_BR
         text: 'Delete. Já icluído em %1%'
-      - lang: pl
-        text: 'Usuń. Już zawarte w %1%'
+      - lang: ru
+        text: 'Удалите. Уже включено в %1%.'
+      - lang: zh_CN
+        text: '删除。已包含在%1%中。'
   - &includesX
     type: say
     content:
       - lang: en
         text: '%1% is included with this mod.'
-      - lang: ru
-        text: '%1% уже включен в этот мод.'
       - lang: de
         text: '%1% ist in dieser Mod enthalten.'
-      - lang: ko
-        text: '%1% 모드가 포함되어 있습니다.'
       - lang: ja
         text: '%1%はこのmodに含まれています。'
+      - lang: ko
+        text: '%1% 모드가 포함되어 있습니다.'
+      - lang: pl
+        text: '%1% jest już zawarte z tym modem.'
       - lang: pt
         text: '%1% vem incluído com este mod.'
       - lang: pt_BR
         text: '%1% está incluído neste mod.'
-      - lang: pl
-        text: '%1% jest już zawarte z tym modem.'
+      - lang: ru
+        text: '%1% уже включен в этот мод.'
   - &includesMBBF
     <<: *includesX
     subs: [ '[ Modern Brawl Bug Fix ](https://www.nexusmods.com/skyrimspecialedition/mods/1473/)' ]
@@ -72,142 +72,142 @@ common:
     content:
       - lang: en
         text: 'Use only one %1%.'
-      - lang: ru
-        text: 'Используйте только один %1%.'
-      - lang: es
-        text: 'Utilizar solo un %1%.'
-      - lang: ko
-        text: '%1%을 한 개만 사용하십시오.'
-      - lang: zh_CN
-        text: '只使用一个%1%。'
-      - lang: ja
-        text: '%1%は一つだけ使用してください。'
       - lang: de
         text: 'Nutzen Sie nur einen %1%.'
+      - lang: es
+        text: 'Utilizar solo un %1%.'
+      - lang: ja
+        text: '%1%は一つだけ使用してください。'
+      - lang: ko
+        text: '%1%을 한 개만 사용하십시오.'
+      - lang: pl
+        text: 'Używa tylko jednego %1%'
       - lang: pt
         text: 'Utilizar apenas um %1%.'
       - lang: pt_BR
         text: 'Utilize apenas um %1%'
-      - lang: pl
-        text: 'Używa tylko jednego %1%'
+      - lang: ru
+        text: 'Используйте только один %1%.'
+      - lang: zh_CN
+        text: '只使用一个%1%。'
 
   - &compatNotes
     type: say
     content:
       - lang: en
         text: 'It is recommended that you read this mod''s [Compatibility Notes](%1%).'
-      - lang: ru
-        text: 'Рекомендуется прочесть [заметки о совместимости](%1%) мода.'
       - lang: de
         text: 'Es wird empfohlen, dass Sie die [Kompatibilitäts-Notizen](%1%) dieses Mods lesen.'
-      - lang: ko
-        text: '이 모드의 [호환성 정보](%1%)를 읽어 보는 걸 권장합니다.'
       - lang: ja
         text: '[互換性に関する注意事項](%1%)を読みましょう。'
+      - lang: ko
+        text: '이 모드의 [호환성 정보](%1%)를 읽어 보는 걸 권장합니다.'
+      - lang: pl
+        text: 'Jest rekomendowane abyś przeczytał [Notki Kompatybilności](%1%) tego moda.'
       - lang: pt
         text: 'É recomendada leitura das [Notas de Compatibilidade](%1%) deste mod.'
       - lang: pt_BR
         text: 'É recomendada a leitura das [Notas de Compatibilidade](%1%) deste mod.'
-      - lang: pl
-        text: 'Jest rekomendowane abyś przeczytał [Notki Kompatybilności](%1%) tego moda.'
+      - lang: ru
+        text: 'Рекомендуется прочесть [заметки о совместимости](%1%) мода.'
   - &semiCompatible
     type: say
     content:
       - lang: en
         text: '%1% is not fully compatible with this mod. %2%'
-      - lang: ru
-        text: '%1% не полностью совместим с этим модом. %2%'
       - lang: de
         text: '%1% ist nicht voll kompatibel mit dieser Mod. %2%'
-      - lang: ko
-        text: '%1% 모드는 이 모드와 완벽히 호환되지 않습니다. %2%'
       - lang: ja
         text: '%1%は%2%と完全な互換性がありません。'
+      - lang: ko
+        text: '%1% 모드는 이 모드와 완벽히 호환되지 않습니다. %2%'
       - lang: pt
         text: '%1% não é totalmente compatível com este mod. %2%'
       - lang: pt_BR
         text: '%1% não é completamente compatível com este mod. %2%'
+      - lang: ru
+        text: '%1% не полностью совместим с этим модом. %2%'
 
   - &corrupt
     type: warn
     content:
       - lang: en
         text: 'This file is corrupt and should not be used.'
-      - lang: ru
-        text: 'Файл испорчен и не должен использоваться.'
       - lang: de
         text: 'Diese Datei ist korrupt und sollte nicht benutzt werden.'
       - lang: es
         text: 'Este archivo puede corromper tu juego y no debería ser utilizado.'
       - lang: ja
         text: 'このファイルは壊れています。使用しないでください。'
+      - lang: pl
+        text: 'Ten plik jest zepsuty i nie powinien być używany.'
       - lang: pt_BR
         text: 'Este arquivo está corrompido e não deveria ser utilizado.'
-      - lang: pt_BR
-        text: 'Ten plik jest zepsuty i nie powinien być używany.'
+      - lang: ru
+        text: 'Файл испорчен и не должен использоваться.'
   - &doNotClean
     type: say
     content:
       - lang: en
         text: 'Do not clean ITM records, they are intentional and required for the mod to function. It is safe to undelete records, but do not do anything other than that.'
-      - lang: ru
-        text: 'Не очищать ITM-записи. "Грязные" правки оставлены специально и требуются для функционирования мода. Восстановить удаленные записи (UDR) можно безопасно, но идентичные мастерфайлу лучше оставить.'
-      - lang: es
-        text: 'No limpiar las referencias ITM (iguales al master), ya que son intencionales y necesarias para que el Mod funcione. Sí es seguro restaurar las UDR (referencias borradas), pero no haga más que eso.'
-      - lang: zh_CN
-        text: '不干净。"脏"数据是故意的，这是mod需要的功能。'
       - lang: da
         text: 'Rengør ikke ITM-poster: de er forsætlige og krævede for at mod’en fungerer. Det er sikkert at gendanne poster, men gør ikke andet end dét.'
-      - lang: ja
-        text: 'IMTレコードはクリーンしないでください。これらは意図的に残されたデータであり、Modを機能させるために必要です。削除の取り消しは安全に行えますが、それ以外のことは行わないでください。'
       - lang: de
         text: 'ITM-Einträge in diesem Plugin sollten nicht gesäubert werden, sie sind absichtlich enthalten und werden benötigt, damit die Mod richtig funktioniert. Gelöschte Einträge wiederherzustellen ist in Ordnung, alles andere aber nicht.'
+      - lang: es
+        text: 'No limpiar las referencias ITM (iguales al master), ya que son intencionales y necesarias para que el Mod funcione. Sí es seguro restaurar las UDR (referencias borradas), pero no haga más que eso.'
+      - lang: ja
+        text: 'IMTレコードはクリーンしないでください。これらは意図的に残されたデータであり、Modを機能させるために必要です。削除の取り消しは安全に行えますが、それ以外のことは行わないでください。'
       - lang: ko
         text: 'ITM 자료를 삭제하지 마십시오. 모드가 정상 작동하기 위해 의도적으로 남겨진 자료입니다. 삭제를 취소하는 것 이외에는 안전하지 않습니다.'
+      - lang: pl
+        text: 'Nie czyść rekordów ITM, są one zamierzone i potrzebne do działania tego moda. Jest bezpieczne aby cofnąć usunięcie rekordów (UDR), ale nie rób nic innego ponad to. '
       - lang: pt
         text: 'Não apagar os registos ITM. São intencionais e necessárias para o funcionamento do mod. É seguro restaurar os registos, mas não faça nada mais que isso.'
       - lang: pt_BR
         text: 'Não apague os registros ITM. Eles são intencionais e necessários para que o mod funcione. É seguro restaurar os registros, mas nada mais além disso.'
-      - lang: pl
-        text: 'Nie czyść rekordów ITM, są one zamierzone i potrzebne do działania tego moda. Jest bezpieczne aby cofnąć usunięcie rekordów (UDR), ale nie rób nic innego ponad to. '
+      - lang: ru
+        text: 'Не очищать ITM-записи. "Грязные" правки оставлены специально и требуются для функционирования мода. Восстановить удаленные записи (UDR) можно безопасно, но идентичные мастерфайлу лучше оставить.'
+      - lang: zh_CN
+        text: '不干净。"脏"数据是故意的，这是mod需要的功能。'
   - &reqMasterSort
     type: say
     content:
       - lang: en
         text: 'Plugin''s Masters require sorting.'
-      - lang: ru
-        text: 'Мастерфайлы плагина требуют сортировки.'
       - lang: de
         text: 'Die Plugin Master müssen sortiert werden.'
-      - lang: ko
-        text: '플러그인 마스터의 정렬이 필요합니다.'
       - lang: ja
         text: 'このプラグインのマスターはソートが必要です。'
+      - lang: ko
+        text: '플러그인 마스터의 정렬이 필요합니다.'
+      - lang: pl
+        text: 'Wtyczki Główne tej wtyczki wymagają sortowania.'
       - lang: pt
         text: 'A Master deste Plugin necessita ordenação.'
       - lang: pt_BR
         text: 'Os Masters desse plugin necessitam de ordenação.'
-      - lang: pl
-        text: 'Wtyczki Główne tej wtyczki wymagają sortowania.'
+      - lang: ru
+        text: 'Мастерфайлы плагина требуют сортировки.'
   - &wildEdits
     type: say
     content:
       - lang: en
         text: 'This plugin contains wild edits beyond ITM and UDR records and deleted navmeshes and may require additional manual cleaning to not interfere with other mods. %1%'
-      - lang: ru
-        text: 'Плагин содержит дикие правки, кроме ITM, UDR записей и удаленных навмешей и может потребовать дополнительной ручной чистки, чтобы не пересекаться с другими модами. %1%'
       - lang: da
         text: 'Dette plugin indeholder ukontrollerede redigeringer udover ITM- og UDR-poster og slettede navmesher og kan behøve yderligere manuel oprydning for ikke at forstyrre andre mods. %1%'
       - lang: de
         text: 'Dieses Plugin enthält wilde Modifikationen weit über ITM-, und UDR Einträge und entfernte Navmeshes hinaus und benötigt vermutlich mehr manuelle Säuberung um andere Mods nicht zu beeinträchtigen. %1%'
       - lang: ja
         text: 'このプラグインにはITMおよびUDRレコード以外の誤った編集(Wild Edit)が含まれており、navmeshが削除されています。他のmodと干渉しないように、追加の手動クリーニングが必要になる場合があります。%1%'
+      - lang: pl
+        text: 'Ta wtyczka zawiera dzikie edycje (Wild Edit) poza rekordami ITM i UDR oraz usunięte siatki nawigacyjne i może wymagać dodatkowego ręcznego czyszczenia aby nie kolidować z innymi modami. %1%'
       - lang: pt
         text: 'Este plugin contém edições selvagens (Wild Edits) para além dos registros ITM e UDR, e Navmeshes apagadas. Pode requerer limpeza manual adicional de forma a não interferir com outros mods. %1%'
       - lang: pt_BR
         text: 'Este plugin contém edições não-intencionais (Wild Edits) além dos registros ITM e UDR e Navmeshes deletadas e pode requerer limpeza manual adicional de forma que não interfira com outros mods. %1%'
-      - lang: pl
-        text: 'Ta wtyczka zawiera dzikie edycje (Wild Edit) poza rekordami ITM i UDR oraz usunięte siatki nawigacyjne i może wymagać dodatkowego ręcznego czyszczenia aby nie kolidować z innymi modami. %1%'
+      - lang: ru
+        text: 'Плагин содержит дикие правки, кроме ITM, UDR записей и удаленных навмешей и может потребовать дополнительной ручной чистки, чтобы не пересекаться с другими модами. %1%'
     subs: [ '' ]
 
   - &patchUpdateAvailable
@@ -215,96 +215,96 @@ common:
     content:
       - lang: en
         text: 'Update Patch available: %1%'
-      - lang: ru
-        text: 'Доступно обновление патча: %1%'
       - lang: de
         text: 'Update Patch verfügbar: %1%'
-      - lang: ko
-        text: '패치 업데이트 가능: %1%'
       - lang: ja
         text: 'パッチの更新ができます: %1%'
+      - lang: ko
+        text: '패치 업데이트 가능: %1%'
+      - lang: pl
+        text: 'Dostępna Łatka Aktualizująca: %1%'
       - lang: pt
         text: 'Patch de atualização disponível: %1%'
       - lang: pt_BR
         text: 'Patch de Atualização disponível: %1%'
-      - lang: pl
-        text: 'Dostępna Łatka Aktualizująca: %1%'
+      - lang: ru
+        text: 'Доступно обновление патча: %1%'
   - &patchProvided
     type: say
     content:
       - lang: en
         text: 'You seem to be using **%1%**, but you have not enabled a compatibility patch for this mod. A compatibility patch is provided on this plugin''s mod page.'
-      - lang: ru
-        text: 'Похоже, что используется **%1%**, но патч совместимости для него не был подключен. Патч совместимости можно найти на странице плагина.'
       - lang: de
         text: 'Sie scheinen **%1%** zu nutzen, aber Sie haben keinen Kompatibilitätspatch für diese Mod aktiviert. Ein Kompatibilitätspatch wird auf dieser Plugins Mod-Seite zur Verfügung gestellt.'
-      - lang: ko
-        text: '**%1%** 모드와 사용하기 위한 호환성 패치가 작동 중이지 않습니다. 호환성 패치는 이 플러그인의 모드 페이지에서 제공 중입니다.'
       - lang: ja
         text: '**%1%**を使用しているようですが、このmodの互換性パッチが有効になっていません。互換性パッチは、このプラグインのmodページにあります。.'
+      - lang: ko
+        text: '**%1%** 모드와 사용하기 위한 호환성 패치가 작동 중이지 않습니다. 호환성 패치는 이 플러그인의 모드 페이지에서 제공 중입니다.'
+      - lang: pl
+        text: 'Wygląda na to że używasz **%1%**, ale nie masz aktywnej łatki zgodności dla tego moda. Łatka zgodności jest dostarczona na stronie internetowej tej wtyczki.'
       - lang: pt
         text: 'Você aparenta estar a utilizar **%1%**, mas não ativou o patch de compatibilidade para este mod. Um patch de compatibilidade está disponível na página mod deste plugin.'
       - lang: pt_BR
         text: 'Você aparenta estar usando **%1%**, mas não habilitou o patch de compatibilidade para este mod. Um patch de compatibilidade é provido na página desse plugin.'
-      - lang: pl
-        text: 'Wygląda na to że używasz **%1%**, ale nie masz aktywnej łatki zgodności dla tego moda. Łatka zgodności jest dostarczona na stronie internetowej tej wtyczki.'
+      - lang: ru
+        text: 'Похоже, что используется **%1%**, но патч совместимости для него не был подключен. Патч совместимости можно найти на странице плагина.'
   - &patchIncluded
     type: say
     content:
       - lang: en
         text: 'You seem to be using **%1%**, but you have not enabled a compatibility patch for this mod. A compatibility patch is included with this plugin''s installer.'
-      - lang: ru
-        text: 'Похоже, что используется **%1%**, но патч совместимости для него не был подключен. Патч совместимости можно найти в установщике плагина.'
       - lang: de
         text: 'Sie scheinen **%1%** zu nutzen, aber Sie haben keinen Kompatibilitätspatch für diese Mod aktiviert. Ein Kompatibilitätspatch ist enthalten mit dem Installer dieses Plugins.'
-      - lang: ko
-        text: '**%1%** 모드와 사용하기 위한 호환성 패치가 작동 중이지 않습니다. 호환성 패치는 이 플러그인의 인스톨러에 포함되어 있습니다.'
       - lang: ja
         text: '**%1%**を使用しているようですが、このmodの互換性パッチが有効になっていません。互換性パッチは、このプラグインのインストーラーに含まれています。'
+      - lang: ko
+        text: '**%1%** 모드와 사용하기 위한 호환성 패치가 작동 중이지 않습니다. 호환성 패치는 이 플러그인의 인스톨러에 포함되어 있습니다.'
+      - lang: pl
+        text: 'Wygląda na to że używasz **%1%**, ale nie masz aktywnej łatki zgodności dla tego moda. Łatka zgodności jest dostarczona wraz z instalatorem tej wtyczki.'
       - lang: pt
         text: 'Você aparenta estar a utilizar **%1%**, mas não ativou o patch de compatibilidade para este mod. Um patch de compatibilidade está incluído com o instalador do plugin'
       - lang: pt_BR
         text: 'Você aparenta estar usando **%1%**, mas não habilitou o patch de compatibilidade para este mod. Um patch de compatibilidade está incluso com o instalador desse plugin.'
-      - lang: pl
-        text: 'Wygląda na to że używasz **%1%**, ale nie masz aktywnej łatki zgodności dla tego moda. Łatka zgodności jest dostarczona wraz z instalatorem tej wtyczki.'
+      - lang: ru
+        text: 'Похоже, что используется **%1%**, но патч совместимости для него не был подключен. Патч совместимости можно найти в установщике плагина.'
   - &patch3rdParty
     type: say
     content:
       - lang: en
         text: 'You seem to be using **%1%**, but you have not enabled a compatibility patch for this mod. A third party patch is available here: %2%'
-      - lang: ru
-        text: 'Похоже, что используется **%1%**, но патч совместимости для него не был подключен. Патч совместимости можно найти здесь: %2%'
       - lang: de
         text: 'Sie scheinen **%1%** zu nutzen, aber Sie haben keinen Kompatibilitätspatch für diesen Mod aktiviert. Ein Patch von Dritten ist hier verfügbar: %2%'
-      - lang: ko
-        text: '**%1%** 모드와 사용하기 위한 호환성 패치가 작동 중이지 않습니다. 제3자 제공 호환성 패치는 여기에서 다운로드 가능합니다: %2%'
       - lang: ja
         text: '**%1%**を使用しているようですが、このmodの互換性パッチが有効になっていません。サードパーティのパッチはここで入手できます:%2%'
+      - lang: ko
+        text: '**%1%** 모드와 사용하기 위한 호환성 패치가 작동 중이지 않습니다. 제3자 제공 호환성 패치는 여기에서 다운로드 가능합니다: %2%'
+      - lang: pl
+        text: 'Wygląda na to że używasz **%1%**, ale nie masz aktywnej łatki zgodności dla tego moda. Łatka trzeciej strony jest dostępna tutaj: %2%'
       - lang: pt
         text: 'Você aparenta estar a utilizar **%1%**, mas não ativou o patch de compatibilidade para este mod. Um patch feito por terceiros está disponível aqui: %2%'
       - lang: pt_BR
         text: 'Você aparenta estar usando **%1%**, mas não habilitou o patch de compatibilidade para este mod. Um patch feito por terceiros está disponível aqui: %2%'
-      - lang: pl
-        text: 'Wygląda na to że używasz **%1%**, ale nie masz aktywnej łatki zgodności dla tego moda. Łatka trzeciej strony jest dostępna tutaj: %2%'
+      - lang: ru
+        text: 'Похоже, что используется **%1%**, но патч совместимости для него не был подключен. Патч совместимости можно найти здесь: %2%'
   - &patch3rdPartyQUASIPC
     type: say
     content:
       - lang: en
         text: 'You seem to be using **%1%**, but you have not enabled a compatibility patch for this mod. A third party patch is available here: [ Qwinn''s Unified Automated Self Installing Patch Compendium ](https://www.nexusmods.com/skyrimspecialedition/mods/18369)'
-      - lang: ru
-        text: 'Похоже, что используется **%1%**, но патч совместимости для него не был подключен. Патч доступен здесь: [ Qwinn''s Unified Automated Self Installing Patch Compendium ](https://www.nexusmods.com/skyrimspecialedition/mods/18369)'
       - lang: de
         text: 'Sie scheinen **%1%** zu nutzen, aber Sie haben keinen Kompatibilitätspatch für diese Mod aktiviert. Ein Patch von Dritten ist hier verfügbar: [ Qwinn''s Unified Automated Self Installing Patch Compendium ](https://www.nexusmods.com/skyrimspecialedition/mods/18369)'
-      - lang: ko
-        text: '**%1%** 모드와 사용하기 위한 호환성 패치가 작동 중이지 않습니다. 제3자 제공 호환성 패치는 여기에서 다운로드 가능합니다: [ Qwinn''s Unified Automated Self Installing Patch Compendium ](https://www.nexusmods.com/skyrimspecialedition/mods/18369)'
       - lang: ja
         text: '**%1%**を使用しているようですが、このmodの互換性パッチが有効になっていません。サードパーティのパッチはこちらから入手できます:[Qwinn''s Unified Automated Self Installing Patch Compendium] (https://www.nexusmods.com/skyrimspecialedition/mods/18369)'
+      - lang: ko
+        text: '**%1%** 모드와 사용하기 위한 호환성 패치가 작동 중이지 않습니다. 제3자 제공 호환성 패치는 여기에서 다운로드 가능합니다: [ Qwinn''s Unified Automated Self Installing Patch Compendium ](https://www.nexusmods.com/skyrimspecialedition/mods/18369)'
+      - lang: pl
+        text: 'Wygląda na to że używasz **%1%**, ale nie masz aktywnej łatki zgodności dla tego moda. Łatka trzeciej strony jest dostępna tutaj: [ Qwins''s Unified Automated Self Installing Patch Compandium ](https://www.nexusmods.com/skyrimspecialedition/mods/18369)'
       - lang: pt
         text: 'Você aparenta estar a utilizar **%1%**, mas não ativou o patch de compatibilidade para este mod.  Um patch feito por terceiros está disponível aqui: [ Qwinn''s Unified Automated Self Installing Patch Compendium ](https://www.nexusmods.com/skyrimspecialedition/mods/18369)'
       - lang: pt_BR
         text: 'Você aparenta estar usando **%1%**, mas não habilitou um patch de compatibilidade para este mod. Um patch feito por terceiros está disponível aqui: [ Qwins''s Unified Automated Self Installing Patch Compandium ](https://www.nexusmods.com/skyrimspecialedition/mods/18369)'
-      - lang: pl
-        text: 'Wygląda na to że używasz **%1%**, ale nie masz aktywnej łatki zgodności dla tego moda. Łatka trzeciej strony jest dostępna tutaj: [ Qwins''s Unified Automated Self Installing Patch Compandium ](https://www.nexusmods.com/skyrimspecialedition/mods/18369)'
+      - lang: ru
+        text: 'Похоже, что используется **%1%**, но патч совместимости для него не был подключен. Патч доступен здесь: [ Qwinn''s Unified Automated Self Installing Patch Compendium ](https://www.nexusmods.com/skyrimspecialedition/mods/18369)'
   - &patch3rdPartySBCK
     <<: *patch3rdParty
     subs:
@@ -316,79 +316,79 @@ common:
     content:
       - lang: en
         text: 'It appears you have installed **%2%**, but some of its requirements seem to be missing. Please ensure you have correctly installed **%1%**.'
-      - lang: ru
-        text: 'Похоже у вас установлен **%2%**, но некоторые его требования отсутствуют. Убедитесь, что правильно установили **%1%**.'
       - lang: de
         text: 'Es erscheint so als hätten Sie **%2%** installiert, aber einige der Voraussetzungen scheinen zu fehlen. Bitte stellen Sie sicher, dass Sie **%1%** korrekt installiert haben.'
-      - lang: ko
-        text: '**%2%** 모드를 실행하기 위한 필요 모드가 빠져 있습니다. **%1%** 모드를 제대로 설치하십시오.'
       - lang: ja
         text: '**%2%**がインストールされましたが、必要なものの一部が不足しているようです。**%1%**が正しくインストールされていることを確認してください。'
-      - lang: pt_BR
-        text: 'Aparentemente você tem instalado **%2%**, mas alguns de seus requerimentos estão faltando. Por favor tenha certeza de que você instalou **%1%** corretamente.'
+      - lang: ko
+        text: '**%2%** 모드를 실행하기 위한 필요 모드가 빠져 있습니다. **%1%** 모드를 제대로 설치하십시오.'
       - lang: pl
         text: 'Wygląda na to że zainstalowałeś **%2%**, ale wydaje się, że brakuje niektórych z jego wymagań. Upewnij się że poprawnie zainstalowałeś **%1%**.'
+      - lang: pt_BR
+        text: 'Aparentemente você tem instalado **%2%**, mas alguns de seus requerimentos estão faltando. Por favor tenha certeza de que você instalou **%1%** corretamente.'
+      - lang: ru
+        text: 'Похоже у вас установлен **%2%**, но некоторые его требования отсутствуют. Убедитесь, что правильно установили **%1%**.'
   - &missingRequirementXforPlugin
     type: warn
     content:
       - lang: en
         text: 'Some of this plugins requirements seem to be missing. Please ensure you have correctly installed **%1%**.'
-      - lang: ru
-        text: 'Некоторые его требования отсутствуют. Убедитесь, что правильно установили **%1%**.'
       - lang: de
         text: 'Einige der Voraussetzungen dieses Plugins scheinen zu fehlen. Bitte stellen Sie sicher, dass Sie **%1%** korrekt installiert haben.'
       - lang: ja
         text: 'このプラグインに必要なものの一部が不足しているようです。**%1%**が正しくインストールされていることを確認してください。'
-      - lang: pt_BR
-        text: 'Alguns dos requerimentos deste plugin estão faltando. Por favor tenha certeza de que você instalou **%1%** corretamente.'
       - lang: pl
         text: 'Część wymagań dla tej wtyczki wydaje się być brakująca. Upewnij się że poprawnie zainstalowałeś **%1%**.'
+      - lang: pt_BR
+        text: 'Alguns dos requerimentos deste plugin estão faltando. Por favor tenha certeza de que você instalou **%1%** corretamente.'
+      - lang: ru
+        text: 'Некоторые его требования отсутствуют. Убедитесь, что правильно установили **%1%**.'
 
   - &reqSKSE
     type: error
     content:
       - lang: en
         text: 'You have installed %1% but SKSE was not found! See SKSE download page: [SKSE](http://skse.silverlock.org).'
-      - lang: ru
-        text: 'У вас установлен %1%, но SKSE не найден! Смотрите страницу загрузки [SKSE](http://skse.silverlock.org).'
-      - lang: es
-        text: 'Tienes %1% instalado pero SKSE no se pudo encontrar! Por favor descarga SKSE: [SKSE](http://skse.silverlock.org).'
-      - lang: ko
-        text: '%1%가 설치되었지만 SKSE를 찾을 수 없습니다! SKSE 다운로드 페이지를 참조하십시오: [SKSE](http://skse.silverlock.org).'
-      - lang: zh_CN
-        text: '你已经安装了%1%，但是未发现SKSE！请查看SKSE的下载页面：[SKSE](http://skse.silverlock.org)。'
       - lang: da
         text: 'Du har installeret %1% men SKSE blev ikke fundet! Se SKSE-downloadsiden: [SKSE](http://skse.silverlock.org).'
-      - lang: ja
-        text: '%1%はインストールされていますが、SKSEが見つかりません！SKSEのダウンロードページを確認してください。[SKSE](http://skse.silverlock.org)'
       - lang: de
         text: 'Sie haben %1% installiert, aber SKSE wurde nicht gefunden! SKSE kann hier heruntergeladen werden: [SKSE](http://skse.silverlock.org).'
+      - lang: es
+        text: 'Tienes %1% instalado pero SKSE no se pudo encontrar! Por favor descarga SKSE: [SKSE](http://skse.silverlock.org).'
+      - lang: ja
+        text: '%1%はインストールされていますが、SKSEが見つかりません！SKSEのダウンロードページを確認してください。[SKSE](http://skse.silverlock.org)'
+      - lang: ko
+        text: '%1%가 설치되었지만 SKSE를 찾을 수 없습니다! SKSE 다운로드 페이지를 참조하십시오: [SKSE](http://skse.silverlock.org).'
+      - lang: pl
+        text: 'Zainstalowałeś %1% ale nie odnaleziono SKSE! Odwiedź stronę pobierania SKSE: [SKSE](https://skse.silverlock.org).'
       - lang: pt
         text: 'Você instalou %1% mas o SKSE não foi encontrado! Veja a página de download do SKSE: [SKSE](http://skse.silverlock.org).'
       - lang: pt_BR
         text: 'Você tem %1% instalado mas o SKSE não foi encontrado! Veja a página de download do SKSE: [SKSE](https://skse.silverlock.org).'
-      - lang: pl
-        text: 'Zainstalowałeś %1% ale nie odnaleziono SKSE! Odwiedź stronę pobierania SKSE: [SKSE](https://skse.silverlock.org).'
+      - lang: ru
+        text: 'У вас установлен %1%, но SKSE не найден! Смотрите страницу загрузки [SKSE](http://skse.silverlock.org).'
+      - lang: zh_CN
+        text: '你已经安装了%1%，但是未发现SKSE！请查看SKSE的下载页面：[SKSE](http://skse.silverlock.org)。'
   # Useful for when a plugin needs SkyUI, but shouldn't load after it (eg. when it's a master plugin).
   - &requiresMCM
     type: warn
     content:
       - lang: en
         text: 'A **Mod Configuration Menu** is required for this mod to be fully functional. An **MCM** can be added by installing [SkyUI SE](https://www.nexusmods.com/skyrimspecialedition/mods/12604).'
-      - lang: ru
-        text: '**Mod Configuration Menu** требуется для полного функционирования мода. **MCM** может быть добавлен вместе с [SkyUI SE](https://www.nexusmods.com/skyrimspecialedition/mods/12604).'
       - lang: de
         text: 'Ein **Mod-Konfigurationsmenü** ist vorausgesetzt, damit diese Mod voll funktionstüchtig ist. Ein **MCM** kann hinzugefügt werden, indem man [SkyUI SE](https://www.nexusmods.com/skyrimspecialedition/mods/12604) installiert.'
-      - lang: ko
-        text: '모드가 정상 작동하기 위해서는 **모드 설정 메뉴**가필요합니다. [SkyUI SE](https://www.nexusmods.com/skyrimspecialedition/mods/12604)를 설치하면 **MCM** 메뉴를 추가할 수 있습니다.'
       - lang: ja
         text: 'このmodを完全に機能させるには、**Mod Configuration Menu**が必要です。**MCM**を追加するには[SkyUI SE](https://www.nexusmods.com/skyrimspecialedition/mods/12604)を導入してください。'
+      - lang: ko
+        text: '모드가 정상 작동하기 위해서는 **모드 설정 메뉴**가필요합니다. [SkyUI SE](https://www.nexusmods.com/skyrimspecialedition/mods/12604)를 설치하면 **MCM** 메뉴를 추가할 수 있습니다.'
+      - lang: pl
+        text: '**Menu Konfiguracji Modów** jest wymagane aby ten mod funkcjonował w pełni poprawnie. **MCM** może zostać dodane poprzez instalację [SkyUI SE](https://www.nexusmods.com/skyrimspecialedition/mods/12604).'
       - lang: pt
         text: 'Um **Menu de Configuração de Mod** (Mod Configuration Menu) é necessário para este mod funcionar na totalidade. Um **MCM** pode ser adicionado ao instalar [SkyUI SE](https://www.nexusmods.com/skyrimspecialedition/mods/12604).'
       - lang: pt_BR
         text: 'Um **Menu de Configuração de Mod** (Mod Configuration Menu) é necessário para que este mod funcione totalmente. Um **MCM** pode ser adicionado ao instalar [SkyUI SE](https://www.nexusmods.com/skyrimspecialedition/mods/12604).'
-      - lang: pl
-        text: '**Menu Konfiguracji Modów** jest wymagane aby ten mod funkcjonował w pełni poprawnie. **MCM** może zostać dodane poprzez instalację [SkyUI SE](https://www.nexusmods.com/skyrimspecialedition/mods/12604).'
+      - lang: ru
+        text: '**Mod Configuration Menu** требуется для полного функционирования мода. **MCM** может быть добавлен вместе с [SkyUI SE](https://www.nexusmods.com/skyrimspecialedition/mods/12604).'
     condition: 'not active("SkyUI_SE.esp")'
 
   - &deletePlugin
@@ -396,111 +396,111 @@ common:
     content:
       - lang: en
         text: 'When using **%1%**. It''s recommended that you deactivate or delete this ESP file, but keep the resources (e.g. meshes, textures) installed with this mod. As they''re still required by **%1%**.'
-      - lang: ru
-        text: 'Пока используется **%1%**, рекомендуется отключить или удалить esp этого мода, но оставить установленные ресурсы (meshes, textures). Т.к. они все еще требуются для **%1%**.'
       - lang: de
         text: 'Beim Nutzen von **%1%** ist es empfohlen, dass Sie die ESP-Datei deaktivieren oder löschen, aber die mitgelieferten Mittel (z.B Meshes, Texturen) beibehalten die mit dieser Mod mitinstalliert wurden. Diese werden immer noch von **%1%** vorausgesetzt.'
-      - lang: ko
-        text: '**%1%** 모드를 사용중일 떈, 이 ESP 파일을 삭제하고 함께 설치된 리소스(예: 메쉬, 텍스쳐)만 남겨두는 걸 권장합니다. 리소스는 **%1%** 모드에서 필요로 합니다.'
       - lang: ja
         text: '**%1%**を使用中の場合。このespファイルは無効化あるいは削除するのはおすすめしますが、このmodによってインストールされたリソース(メッシュ、テクスチャなど)はそのままにしておいてください。これらは**%1%**によって引き続き必要とされてます。'
+      - lang: ko
+        text: '**%1%** 모드를 사용중일 떈, 이 ESP 파일을 삭제하고 함께 설치된 리소스(예: 메쉬, 텍스쳐)만 남겨두는 걸 권장합니다. 리소스는 **%1%** 모드에서 필요로 합니다.'
+      - lang: pl
+        text: 'Używając **%1%**, jest rekomendowane abyś dezaktywował lub usunął ten plik ESP, ale pozostawił zasoby (siatki, tekstury) zainstalowane z tym modem. Ponieważ są wciąż wymagane przez **%1%**.'
       - lang: pt
         text: 'Ao utilizar **%1%**, é recomendado que você desative ou apage este ficheiro ESP, mas mantenha os recursos (ex. meshes, texturas) instalados por este mod. Sendo que os mesmos ainda são necessitados por **%1%**. '
       - lang: pt_BR
         text: 'Quando se usa **%1%**, é recomendado que você desative ou delete este arquivo ESP, mas que mantenha os recursos (ex. meshes, texturas) que vieram com esse mod.'
-      - lang: pl
-        text: 'Używając **%1%**, jest rekomendowane abyś dezaktywował lub usunął ten plik ESP, ale pozostawił zasoby (siatki, tekstury) zainstalowane z tym modem. Ponieważ są wciąż wymagane przez **%1%**.'
+      - lang: ru
+        text: 'Пока используется **%1%**, рекомендуется отключить или удалить esp этого мода, но оставить установленные ресурсы (meshes, textures). Т.к. они все еще требуются для **%1%**.'
 
   - &versionOldX
     type: say
     content:
       - lang: en
         text: 'It appears you do not have the latest version of %1%. Some mods may require functionality added in the latest version of %1% to work.'
-      - lang: ru
-        text: 'Возможно у вас не установлена новейшая версия %1%. Для работы некоторых модов может требоваться функционал, добавленный в последней версии %1%'
-      - lang: es
-        text: 'Parece que no tienes la última versión de %1%. Algunos mods pueden requerir funcionalidad añadida en la última versión de %1% para funcionar.'
-      - lang: ko
-        text: '%1%의 최신 버전이 없는 것 같습니다. 일부 모드는 %1%의 최신 버전에 추가된 기능을 필요로 할 수 있습니다.'
-      - lang: zh_CN
-        text: '你的%1%似乎不是最新的。有些插件可能需要最新的%1%才能工作。'
-      - lang: ja
-        text: '%1%が最新版ではないようです。一部のModを動作させるには最新版の%1%で追加された機能が必要となる場合があります。'
       - lang: de
         text: 'Sie haben anscheinend nicht die aktuellste Version von %1% installiert. Einige Mods könnten Funktionalitäten benötigen, die nur in der aktuellsten Version von %1% enthalten sind, um zu funktionieren.'
+      - lang: es
+        text: 'Parece que no tienes la última versión de %1%. Algunos mods pueden requerir funcionalidad añadida en la última versión de %1% para funcionar.'
+      - lang: ja
+        text: '%1%が最新版ではないようです。一部のModを動作させるには最新版の%1%で追加された機能が必要となる場合があります。'
+      - lang: ko
+        text: '%1%의 최신 버전이 없는 것 같습니다. 일부 모드는 %1%의 최신 버전에 추가된 기능을 필요로 할 수 있습니다.'
+      - lang: pl
+        text: 'Wygląda na to że nie masz ostatniej aktualnej wersji %1%. Część modów może wymagać funkcjonalności dodanej w ostatniej wersji %1% aby działać poprawnie.'
       - lang: pt
         text: 'Aparenta que você não tem a versão mais recente de %1%. Alguns mods podem requerir funcinalidades adicionadas na última versão de %1% para funcionar.'
       - lang: pt_BR
         text: 'Você aparenta não ter a versão mais recente de %1%. Alguns mods podem requerer funcionalidade que foi adicionada na versão mais recente de %1%.'
-      - lang: pl
-        text: 'Wygląda na to że nie masz ostatniej aktualnej wersji %1%. Część modów może wymagać funkcjonalności dodanej w ostatniej wersji %1% aby działać poprawnie.'
+      - lang: ru
+        text: 'Возможно у вас не установлена новейшая версия %1%. Для работы некоторых модов может требоваться функционал, добавленный в последней версии %1%'
+      - lang: zh_CN
+        text: '你的%1%似乎不是最新的。有些插件可能需要最新的%1%才能工作。'
   - &versionUpToDateX
     type: say
     content:
       - lang: en
         text: 'Your %1% is up-to-date.'
-      - lang: ru
-        text: 'Ваш %1% обновлен.'
-      - lang: es
-        text: 'Tienes la última versión de %1%'
-      - lang: ko
-        text: '%1%가 최신 버전입니다.'
-      - lang: zh_CN
-        text: '你的%1%是最新的。'
       - lang: da
         text: 'Din %1% er opdateret.'
-      - lang: ja
-        text: '%1%は最新版です。'
       - lang: de
         text: 'Ihr %1% ist aktuell.'
+      - lang: es
+        text: 'Tienes la última versión de %1%'
+      - lang: ja
+        text: '%1%は最新版です。'
+      - lang: ko
+        text: '%1%가 최신 버전입니다.'
+      - lang: pl
+        text: 'Twój %1% jest aktualny.'
       - lang: pt
         text: 'O seu %1% está atualizado.'
       - lang: pt_BR
         text: 'Seu %1% está atualizado.'
-      - lang: pl
-        text: 'Twój %1% jest aktualny.'
+      - lang: ru
+        text: 'Ваш %1% обновлен.'
+      - lang: zh_CN
+        text: '你的%1%是最新的。'
   - &versionSksePluginIncSSE
     type: error
     content:
       - lang: en
         text: 'Your installed version of **SKSE Plugin (%1%)** is not compatible with your version of Skyrim SE.'
-      - lang: ru
-        text: 'Установленная у вас версия плагина **SKSE (%1%)** несовместима с вашей версией Skyrim SE.'
       - lang: da
         text: 'Din installerede version af **SKSE Plugin (%1%)** er ikke kompatibel med din version af Skyrim SE.'
-      - lang: ja
-        text: 'インストールされている**SKSE Plugin (%1%)**は使用中のバージョンのSkyrim SEとの互換性がありません。'
       - lang: de
         text: 'Ihre installierte Version von **SKSE Plugin (%1%)** ist nicht kompatibel mit Ihrer Version von Skyrim SE.'
+      - lang: ja
+        text: 'インストールされている**SKSE Plugin (%1%)**は使用中のバージョンのSkyrim SEとの互換性がありません。'
       - lang: ko
         text: '현재 설치된 **SKSE 플러그인 (%1%)** 은 사용 중인 Skyrim SE 버전과 호환되지 않습니다.'
+      - lang: pl
+        text: 'Twoja zainstalowana wersja **Wtyczki SKSE (%1%)** nie jest kompatybilna z wersją twojego Skyrim SE.'
       - lang: pt
         text: 'A sua versão instalada de **SKSE Plugin (%1%)** não é compatível com a sua versão de Skyrim SE.'
       - lang: pt_BR
         text: 'Sua versão instalada do **Plugin do SKSE (%1%)** não é compatível com a sua versão do Skyrim SE.'
-      - lang: pl
-        text: 'Twoja zainstalowana wersja **Wtyczki SKSE (%1%)** nie jest kompatybilna z wersją twojego Skyrim SE.'
+      - lang: ru
+        text: 'Установленная у вас версия плагина **SKSE (%1%)** несовместима с вашей версией Skyrim SE.'
   - &versionXIncY
     type: error
     content:
       - lang: en
         text: 'Your installed version of %1% is not compatible with your version of %2%.'
-      - lang: ru
-        text: 'Установленная у вас версия %1% несовместима с версией %2%.'
       - lang: da
         text: 'Din installerede version af %1% er ikke kompatibel med din version af %2%.'
-      - lang: ja
-        text: 'インストールされている%1%は使用中のバージョンの%2%との互換性がありません。'
       - lang: de
         text: 'Ihre installierte Version von %1% ist nicht kompatibel mit Ihrer Version von %2%.'
+      - lang: ja
+        text: 'インストールされている%1%は使用中のバージョンの%2%との互換性がありません。'
       - lang: ko
         text: '현재 설치된 %1%의 버전은 %2%의 버전과 호환되지 않습니다.'
+      - lang: pl
+        text: 'Twoja zainstalowana wersja %1% nie jest kompatybilna z twoją wersją %2%.'
       - lang: pt
         text: 'A sua versão instalada de %1% não é compatível com a sua versão de %2%.'
       - lang: pt_BR
         text: 'A sua versão instalada de %1% não é compatível com a sua versão de %2%.'
-      - lang: pl
-        text: 'Twoja zainstalowana wersja %1% nie jest kompatybilna z twoją wersją %2%.'
+      - lang: ru
+        text: 'Установленная у вас версия %1% несовместима с версией %2%.'
   - &versionSkseIncSSE
     <<: *versionXIncY
     subs:
@@ -518,54 +518,54 @@ common:
     info:
       - lang: en
         text: 'An explanation of Dirty Edits is available [here](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#Apendix-A).'
-      - lang: ru
-        text: 'Объяснение по грязным правкам доступно [здесь](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#Apendix-A).'
       - lang: de
         text: 'Eine englische Säuberungsanleitung ist [hier](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#s_5-3) verfügbar.'
       - lang: ja
         text: 'Dirty Editsについては[ここ](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#Apendix-A)を参照してください。'
+      - lang: pl
+        text: 'Wytłumaczenie o brudnych wtyczkach (Dirty Edits) jest dostępne [tutaj](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#Apendix-A).'
       - lang: pt
         text: 'Uma explição em inglês de Edição Suja (Dirty Edits) está disponível [aqui](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#Apendix-A).'
       - lang: pt_BR
         text: 'Uma explicação de Edições Sujas (Dirty Edits) está disponível [aqui](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#Apendix-A).'
-      - lang: pl
-        text: 'Wytłumaczenie o brudnych wtyczkach (Dirty Edits) jest dostępne [tutaj](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#Apendix-A).'
+      - lang: ru
+        text: 'Объяснение по грязным правкам доступно [здесь](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#Apendix-A).'
   - &quickClean
     util: '[SSEEdit](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
     info:
       - lang: en
         text: 'Due to Improvements made to the cleaning process with the official release of xEdit 4.0.x+, any mods which were verified as clean with older versions of xEdit may now require additional cleaning. A guide for running xEdit 4.0.x+ in **Quick Auto Clean** mode can be found [here](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#s_5-3-4).'
-      - lang: ru
-        text: 'Из-за изменений в способе очистки в версии xEdit 4.0.x+, моды, что были проверены как чистые с предыдущими версиями xEdit могут вновь потребовать очистки. Руководство по запуску xEdit 4.0.x+ в режиме **Быстрой очистки** может быть найдено [здесь](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#s_5-3-4).'
       - lang: de
         text: 'Wegen Verbesserungen die dem Säuberungsprozess mit der offiziellen Veröffentlichung von xEdit 4.0.x+ zugute gekommen sind, müssen eventuell sämtliche Mods die mithilfe älterer Versionen von xEdit als sauber verifiziert wurden, erneut gesäubert werden. Eine englische Anleitung zum Ausführen von xEdit 4.0.x+ im **Schnell-Automatisch-Säubern** Modus kann [hier](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#s_5-3-4) aufgefunden werden.'
-      - lang: ko
-        text: 'xEdit 4.0.x+ 공식 출시와 함께 소개된 향상된 청소 기능으로 인해, 구 버전의 xEdit로 검증되었던 모드는 추가적인 청소가 필요할 수 있습니다. xEdit 4.0.x+ **Quick Auto Clean** 모드 실행 설명서는 [여기](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#s_5-3-4)에서 찾을 수 있습니다. '
       - lang: ja
         text: 'xEdit 4.0.x+の公式リリースでクリーニングプロセスが改善されたため、以前のバージョンのxEditでクリーニングした場合は、追加のクリーニングが必要になることがあります。xEdit 4.0.x+を**Quick Auto Clean**モードで実行するためのガイドがあります[ここ] (https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#s_5-3-4)。'
+      - lang: ko
+        text: 'xEdit 4.0.x+ 공식 출시와 함께 소개된 향상된 청소 기능으로 인해, 구 버전의 xEdit로 검증되었던 모드는 추가적인 청소가 필요할 수 있습니다. xEdit 4.0.x+ **Quick Auto Clean** 모드 실행 설명서는 [여기](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#s_5-3-4)에서 찾을 수 있습니다. '
+      - lang: pl
+        text: 'W związku z ulepszeniami w procesie czyszczenia z oficjalnym wydaniem xEdit 4.0.x+, każdy mod zweryfikowany jako czysty w starszej wersji xEdit może wymagać dodatkowego czyszczenia. Poradnik jak używać xEdit 4.0.x+ w trybie **Szybkie Auto Czyszczenie** można znaleźć [tutaj](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#s_5-3-4).'
       - lang: pt
         text: 'Devido a melhorias feitas ao processo de limpeza com o lançamento oficial de xEdit 4.0.x+, qualquer mod que seja verificado como limpo por versões anteriores de xEdit podem agora necessitar de limpeza adicional. Um guia em inglês para utilizar xEdit 4.0.x+ no modo **Limpeza Automática Rápida** pode ser encontrado [aqui](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#s_5-3-4).'
       - lang: pt_BR
         text: 'Devido a melhorias feitas ao processo de limpeza com o lançamento oficial do xEdit 4.0.x+, quaisquer mods que foram verificados como limpos com versões antigas do xEdit podem agora necessitar de limpeza adicional. Uma guia para utilizar o xEdit 4.0.x+ no modo **Limpeza Automática Rápida** (Quick Auto Clean) pode ser encontrado [aqui](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#s_5-3-4).'
-      - lang: pl
-        text: 'W związku z ulepszeniami w procesie czyszczenia z oficjalnym wydaniem xEdit 4.0.x+, każdy mod zweryfikowany jako czysty w starszej wersji xEdit może wymagać dodatkowego czyszczenia. Poradnik jak używać xEdit 4.0.x+ w trybie **Szybkie Auto Czyszczenie** można znaleźć [tutaj](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#s_5-3-4).'
+      - lang: ru
+        text: 'Из-за изменений в способе очистки в версии xEdit 4.0.x+, моды, что были проверены как чистые с предыдущими версиями xEdit могут вновь потребовать очистки. Руководство по запуску xEdit 4.0.x+ в режиме **Быстрой очистки** может быть найдено [здесь](https://tes5edit.github.io/docs/5-mod-cleaning-and-error-checking.html#s_5-3-4).'
   - &reqManualFix
     util: '[SSEEdit](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
     info:
       - lang: en
         text: 'It is strongly recommended not to use mods that contain **Deleted navmeshes** as they''re known to cause crashes. **Deleted navmeshes** must be corrected manually(A complex process that should be done by the mod author). More information on **Deleted navmeshes** is provided [here](https://www.creationkit.com/index.php?title=Fixing_Navmesh_Deletion_Tutorial).'
-      - lang: ru
-        text: 'Настоятельно не рекомендуется использовать моды с **удаленными навмешами** т.к. известно, что они вызывают вылеты. **удаленные навмеши** должны быть исправлены вручную(Комплексный процесс, который должен быть выполнен автором мода). Больше информации о **удаленных навмешах** можно найти [здесь](https://www.creationkit.com/index.php?title=Fixing_Navmesh_Deletion_Tutorial).'
       - lang: de
         text: 'Es wird streng empfohlen, keine Mods zu verwenden die **Gelöschte Navmeshes** beinhalten, da diese dafür bekannt sind Abstürze auszulösen. **Gelöschte Navmeshes** müssen manuell korrigiert werden (ein komplexer Prozess der vom Mod-Autor erledigt werden sollte). Mehr Informationen über **Gelöschte Navmeshes** werden [hier](https://www.creationkit.com/index.php?title=Fixing_Navmesh_Deletion_Tutorial) geboten.'
       - lang: ja
         text: '**navmeshの削除**を含むmodは使用しないことを強く推奨します。クラッシュの原因になります。**navmeshの削除**は手動で修正する必要があります(mod作成者が行う必要がある複雑なプロセスです)。**navmeshの削除**の詳細については[ここ](https://www.creationkit.com/index.php?title=Fixing_Navmesh_Deletion_Tutorial)を参照してください。'
+      - lang: pl
+        text: 'Jest silnie zalecane aby nie używać modów zawierających **Usunięte navmeshe** jako że są znane jako powód awarii. **Usunięte navmeshe** muszą zostać poprawione ręcznie(skomplikowany proces który powinien być wykonany przez autora modu). Więcej informacji o **Usuniętych navmeshach** można znaleźć [tutaj](https://www.creationkit.com/index.php?title=Fixing_Navmesh_Deletion_Tutorial).'
       - lang: pt
         text: 'É fortemente recomandado não utilizar mods que contenham **Navmeshes apagados** sendo que são conhecidos por causar falhas. **Navmeshes apagados** devem ser corrigidos manualmente(Um processo complexo que deve ser feito pelo autor do mod). Mais informação sobre **Navmeshes apagados** está disponível em inglês [aqui] (https://www.creationkit.com/index.php?title=Fixing_Navmesh_Deletion_Tutorial).'
       - lang: pt_BR
         text: 'É fortemente recomendade que você não utilize mods que contenham **Navmeshes deletados** pois eles são conhecidos por causar crashes. **Navmeshes deletados devem ser corrigos manualmente (Um processo complexo que deve ser feito pelo autor do mod). Mais informações em **Navmeshes deletadas** está disponível [aqui](https://www.creationkit.com/index.php?title=Fixing_Navmesh_Deletion_Tutorial).'
-      - lang: pl
-        text: 'Jest silnie zalecane aby nie używać modów zawierających **Usunięte navmeshe** jako że są znane jako powód awarii. **Usunięte navmeshe** muszą zostać poprawione ręcznie(skomplikowany proces który powinien być wykonany przez autora modu). Więcej informacji o **Usuniętych navmeshach** można znaleźć [tutaj](https://www.creationkit.com/index.php?title=Fixing_Navmesh_Deletion_Tutorial).'
+      - lang: ru
+        text: 'Настоятельно не рекомендуется использовать моды с **удаленными навмешами** т.к. известно, что они вызывают вылеты. **удаленные навмеши** должны быть исправлены вручную(Комплексный процесс, который должен быть выполнен автором мода). Больше информации о **удаленных навмешах** можно найти [здесь](https://www.creationkit.com/index.php?title=Fixing_Navmesh_Deletion_Tutorial).'
 
 bash_tags:
   - 'Actors.ACBS'
@@ -647,41 +647,42 @@ globals:
     content:
       - lang: en
         text: 'This version of LOOT has inferior handling of Creation Club plugins. Support for these are therefore limited in versions prior to LOOT 0.13.1. It is recommended to update as soon as possible.'
-      - lang: ru
-        text: 'В этой версии LOOT плагины Creation Club обрабатываются хуже. Поэтому их поддержка ограничена до версии LOOT 0.13.1. Рекомендуется обновить как можно скорее.'
       - lang: da
         text: 'Denne version af LOOT har begrænset understøttelse af Creation Club-plugins. Det er derfor anbefalet at opdatere til LOOT 0.13.1 eller senere hurtigst muligt.'
       - lang: de
         text: 'Diese Version von LOOT kann nicht richtig mit Creation Club-Plugins umgehen. Unterstützung für diese ist daher limitiert in Versionen älter als LOOT 0.13.1. Ein Update ist stark empfohlen.'
       - lang: ja
         text: 'このバージョンのLOOTではCreation Clubプラグインをうまく扱えません。そのため、LOOT 0.13.1より前のバージョンではサポートが制限されます。できるだけ早くアップデートすることをおすすめします。'
-      - lang: pt
-        text: 'Esta versão do LOOT contém uma manipulação inferior de plugins do Creation Club. Suporte a estes é então limitado nas versões posteriors a LOOT 0.13.1. É recomendado realizar uma atualização assim que possível.'
       - lang: pl
         text: 'Ta wersja LOOT ma gorszą obsługę wtyczek Creation Club. Wsparcie dla nich będzie limitowane w wersjach LOOT niższych niż 0.13.1. Aktualizacja jest rekomendowana jak najszybciej.'
+      - lang: pt
+        text: 'Esta versão do LOOT contém uma manipulação inferior de plugins do Creation Club. Suporte a estes é então limitado nas versões posteriors a LOOT 0.13.1. É recomendado realizar uma atualização assim que possível.'
+      - lang: ru
+        text: 'В этой версии LOOT плагины Creation Club обрабатываются хуже. Поэтому их поддержка ограничена до версии LOOT 0.13.1. Рекомендуется обновить как можно скорее.'
     condition: 'version("LOOT", "0.13.1.0", <) and file("cc[A-Z]{3}FO4[0-9]{3}-[a-zA-Z0-9()]+\.es(l|m)")'
   - type: say
     content:
       - lang: en
         text: '[Latest LOOT thread](%1%).'
-      - lang: ru
-        text: '[Обсуждение LOOT "(Eng)"](%1%).'
-      - lang: es
-        text: '[Forum de LOOT](%1%).'
-      - lang: ko
-        text: '[최신 LOOT 스레드](%1%).'
-      - lang: zh_CN
-        text: '[最新的LOOT版本](%1%)。'
       - lang: da
         text: '[Seneste LOOT-tråd](%1%).'
-      - lang: ja
-        text: '[LOOTの最新スレッドを開く](%1%)（英語）'
       - lang: de
         text: '[Aktueller LOOT-Thread](%1%).'
-      - lang: pt
-        text: '[Postagem mais recente do LOOT](%1%).'
+      - lang: es
+        text: '[Forum de LOOT](%1%).'
+      - lang: ja
+        text: '[LOOTの最新スレッドを開く](%1%)（英語）'
+      - lang: ko
+        text: '[최신 LOOT 스레드](%1%).'
       - lang: pl
         text: '[Ostatni wątek LOOT](%1%).'
+      - lang: pt
+        text: '[Postagem mais recente do LOOT](%1%).'
+      - lang: ru
+        text: '[Обсуждение LOOT "(Eng)"](%1%).'
+
+      - lang: zh_CN
+        text: '[最新的LOOT版本](%1%)。'
     subs: [ 'https://loot.github.io/latest-thread/' ]
 # Fores New Idles
   - type: say
@@ -689,38 +690,38 @@ globals:
     content:
       - lang: en
         text: 'It appears you have [Fores New Idles in Skyrim SE](https://www.nexusmods.com/skyrimspecialedition/mods/3038) installed. Remember to run GenerateFNISforUsers.exe every time you have installed or un-installed FNIS, or a FNIS based mod.'
-      - lang: ru
-        text: 'У вас установлен [Fores New Idles in Skyrim SE](https://www.nexusmods.com/skyrimspecialedition/mods/3038). Не забудьте запускать GenerateFNISforUsers.exe каждый раз, когда вы установите или удалите FNIS, или любой мод, основанный на FNIS.'
-      - lang: es
-        text: 'Parece que [Fores New Idles in Skyrim SE](https://www.nexusmods.com/skyrimspecialedition/mods/3038) está instalado. Recuerda correr GenerateFNISforUsers.exe cada vez que instales o desinstales FNIS o un mod basado en FNIS.'
-      - lang: ko
-        text: '[Fores New Idles in Skyrim SE](https://www.nexusmods.com/skyrimspecialedition/mods/3038)가 설치되어 있습니다. FNIS 또는 FNIS 기반 모드를 설치하거나 제거할 때마다 GenerateFNISforUsers.exe를 실행하는 것을 잊지 마십시오.'
-      - lang: zh_CN
-        text: '你安装了[FNIS SE](https://www.nexusmods.com/skyrim/mods/11811)。每次安装或卸载基于FNIS的mod时记得运行GenerateFNISforUsers.exe。'
-      - lang: ja
-        text: '[Fores New Idles in Skyrim SE](https://www.nexusmods.com/skyrimspecialedition/mods/3038)がインストールされているようです。FNIS本体、またFNISに準拠するModをインストール/アンインストールする際は、必ずGenerateFNISforUsers.exeを実行し直すようにしてください。'
       - lang: de
         text: 'Sie haben anscheinend [Fores New Idles in Skyrim SE](https://www.nexusmods.com/skyrimspecialedition/mods/3038) installiert. Vergessen Sie nicht, jedes mal GenerateFNISforUsers.exe zu starten, wenn Sie FNIS oder einen auf FNIS basierende Mod installiert oder deinstalliert haben.'
-      - lang: pt
-        text: 'Você aparenta ter [Fores New Idles in Skyrim SE](https://www.nexusmods.com/skyrimspecialedition/mods/3038) instalado. Lembre-se de correr GenerateFNISforUsers.exe cada vez que instale ou desinstale FNIS, ou um mod baseado em FNIS.'
+      - lang: es
+        text: 'Parece que [Fores New Idles in Skyrim SE](https://www.nexusmods.com/skyrimspecialedition/mods/3038) está instalado. Recuerda correr GenerateFNISforUsers.exe cada vez que instales o desinstales FNIS o un mod basado en FNIS.'
+      - lang: ja
+        text: '[Fores New Idles in Skyrim SE](https://www.nexusmods.com/skyrimspecialedition/mods/3038)がインストールされているようです。FNIS本体、またFNISに準拠するModをインストール/アンインストールする際は、必ずGenerateFNISforUsers.exeを実行し直すようにしてください。'
+      - lang: ko
+        text: '[Fores New Idles in Skyrim SE](https://www.nexusmods.com/skyrimspecialedition/mods/3038)가 설치되어 있습니다. FNIS 또는 FNIS 기반 모드를 설치하거나 제거할 때마다 GenerateFNISforUsers.exe를 실행하는 것을 잊지 마십시오.'
       - lang: pl
         text: 'Wygląda na to że masz zainstalowany [Fores New Idles in Skyrim SE](https://www.nexusmods.com/skyrimspecialedition/mods/3038). Pamiętaj aby uruchomić GenerateFNISforUsers.exe za każdym razem kiedy zainstalowałeś lub odinstalowałeś FNIS, lub mod bazujący na FNIS.'
+      - lang: pt
+        text: 'Você aparenta ter [Fores New Idles in Skyrim SE](https://www.nexusmods.com/skyrimspecialedition/mods/3038) instalado. Lembre-se de correr GenerateFNISforUsers.exe cada vez que instale ou desinstale FNIS, ou um mod baseado em FNIS.'
+      - lang: ru
+        text: 'У вас установлен [Fores New Idles in Skyrim SE](https://www.nexusmods.com/skyrimspecialedition/mods/3038). Не забудьте запускать GenerateFNISforUsers.exe каждый раз, когда вы установите или удалите FNIS, или любой мод, основанный на FNIS.'
+      - lang: zh_CN
+        text: '你安装了[FNIS SE](https://www.nexusmods.com/skyrim/mods/11811)。每次安装或卸载基于FNIS的mod时记得运行GenerateFNISforUsers.exe。'
 # Skyrim Script Extender - Required Scripts
   - type: warn
     condition: 'not file("scripts/skse.pex") and ((file("../SkyrimSE.exe") and file("../skse64_loader.exe")) or (file("../SkyrimVR.exe") and file("../sksevr_loader.exe")))'
     content:
       - lang: en
         text: 'It appears you have installed **Skyrim Script Extender**, but its required scripts seem to be missing. Please ensure you have correctly installed the scripts bundled with the **[SKSE](http://skse.silverlock.org)** installation archive.'
-      - lang: ru
-        text: 'Похоже, у вас установлен **Skyrim Script Extender**, но требуемые скрипты отсутствуют. Убедитесь, что правильно установили скрипты из архива **[SKSE](http://skse.silverlock.org)**.'
       - lang: de
         text: 'Es erscheint als hätten Sie **Skyrim Script Extender** installiert, aber die vorausgesetzten Skripte scheinen zu fehlen. Bitte stellen Sie sicher, dass Sie die Skripte korrekt mit installiert haben, die mit dem **[SKSE](http://skse.silverlock.org)** Installationsarchiv enthalten sind.'
       - lang: ja
         text: 'Skyrim Script Extenderをインストールしてあるようですが、必要なスクリプトが見つかりません。**[SKSE] (http://skse.silverlock.org)**に付属するスクリプトが正しくインストールされているかを確認してください。'
-      - lang: pt
-        text: 'Você aparenta ter instalado **Skyrim Script Extender**, mas os seus scripts necessário estão em falta. Por favor, garanta que tem os devidamente instalados os scripts the acompanham o arquivo de instalação do **[SKSE](http://skse.silverlock.org)**'
       - lang: pl
         text: 'Wygląda na to że zainstalowałeś **Skyrim Script Extender**, ale jego wymagane skrypty są brakujące. Upewnij się że poprawnie zainstalowałeś skrypty w pakiecie z archiwum instalacyjnym **[SKSE](http://skse.silverlock.org)**'
+      - lang: pt
+        text: 'Você aparenta ter instalado **Skyrim Script Extender**, mas os seus scripts necessário estão em falta. Por favor, garanta que tem os devidamente instalados os scripts the acompanham o arquivo de instalação do **[SKSE](http://skse.silverlock.org)**'
+      - lang: ru
+        text: 'Похоже, у вас установлен **Skyrim Script Extender**, но требуемые скрипты отсутствуют. Убедитесь, что правильно установили скрипты из архива **[SKSE](http://skse.silverlock.org)**.'
 
 # Skyrim SE - Latest Version
   - <<: *versionOldX

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -680,7 +680,6 @@ globals:
         text: '[Postagem mais recente do LOOT](%1%).'
       - lang: ru
         text: '[Обсуждение LOOT "(Eng)"](%1%).'
-
       - lang: zh_CN
         text: '[最新的LOOT版本](%1%)。'
     subs: [ 'https://loot.github.io/latest-thread/' ]


### PR DESCRIPTION
Use this order for translations:
`en cs da de es fi fr ja ko pl pt pt_BR ru sv zh_CN`

Also fixes the falsely labeled Polish translation `Ten plik jest zepsuty i nie powinien być używany.` from `pt_BR` to `pl` (`pt_BR` was twice listed under `&corrupt`).