### PR TITLE
Add afters for Misc Dialogue Edits

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7197,6 +7197,17 @@ plugins:
       - crc: 0x75419F86
         util: 'SSEEdit v4.0.2'
 
+  - name: 'Misc Dialogue Edits.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/28904/' ]
+    after:
+      - 'Alternate Start - Live Another Life.esp'
+      - 'Immersive Citizens - AI Overhaul.esp'
+      - 'Relationship Dialogue Overhaul.esp'
+  - name: 'More Dialogue Options.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/28905/' ]
+    after:
+      - 'Misc Dialogue Edits.esp'
+
   - name: 'More idle markers.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/24859/' ]
     dirty:


### PR DESCRIPTION
Needs to sort after:
- Alternate Start.
- Immersive Citizens.
- Relationship Dialogue Overhaul.

Needs to sort before:
- More Dialogue Options.

Source: Modpage compatibility section and tested in xEdit.

[Misc Dialogue Edits](https://www.nexusmods.com/skyrimspecialedition/mods/28904)

https://user-images.githubusercontent.com/1944639/64747117-f3011d00-d505-11e9-9a85-e5bf5e6d82ff.png