### PR TITLE
Remove unreliable cleaning entries

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1200,9 +1200,6 @@ plugins:
         crc: 0x0593B3FA
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      - crc: 0xCC3A0108
-        util: 'SSEEdit v4.0.2'
   # Alternative Armors - Stalhrim Fur
   - name: 'ccbgssse057-ba_stalhrim.esl'
     dirty:
@@ -1210,9 +1207,6 @@ plugins:
         crc: 0x56233BBB
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      - crc: 0x49ED48F1
-        util: 'SSEEdit v4.0.2'
   # Arcane Accessories
   - name: 'ccbgssse014-spellpack01.esl'
     group: *ccGroup
@@ -1241,9 +1235,6 @@ plugins:
         crc: 0xB359C671
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 9
-    clean:
-      - crc: 0x76637E1D
-        util: 'SSEEdit v4.0.2'
   # Bone Wolf
   - name: 'ccbgssse036-petbwolf.esl'
     group: *ccGroup
@@ -1273,9 +1264,6 @@ plugins:
         crc: 0x46617891
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 6
-    clean:
-      - crc: 0x22651F41
-        util: 'SSEEdit v4.0.2'
   # Dawnfang & Duskfang
   - name: 'ccbgssse013-dawnfang.esl'
     clean:
@@ -1308,9 +1296,6 @@ plugins:
         crc: 0xA7CE6075
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 4
-    clean:
-      - crc: 0x1EE75A07
-        util: 'SSEEdit v4.0.2'
   # Expanded Crossbow Pack
   - name: 'ccffbsse002-crossbowpack.esl'
     clean:
@@ -1325,9 +1310,6 @@ plugins:
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 8
         udr: 1
-    clean:
-      - crc: 0x497905BA
-        util: 'SSEEdit v4.0.2'
   # Lord's Mail
   - name: 'ccbgssse021-lordsmail.esl'
     group: *ccGroup
@@ -1349,9 +1331,6 @@ plugins:
         crc: 0x0B570B3E
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
-    clean:
-      - crc: 0x8EF25773
-        util: 'SSEEdit v4.0.2'
   # Nix-Hound
   - name: 'ccbgssse035-petnhound.esl'
     group: *ccGroup
@@ -1366,9 +1345,6 @@ plugins:
         crc: 0xC2BB3D44
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 8
-    clean:
-      - crc: 0xBD1BCFF5
-        util: 'SSEEdit v4.0.2'
   # Pets of Skyrim
   - name: 'ccvsvsse002-pets.esl'
     group: *ccGroup
@@ -1377,9 +1353,6 @@ plugins:
         crc: 0x286A8B5B
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 8
-    clean:
-      - crc: 0x8EE4DADE
-        util: 'SSEEdit v4.0.2'
   # Plague of the Dead
   - name: 'ccbgssse003-zombies.esl'
     group: *ccGroup
@@ -1391,9 +1364,6 @@ plugins:
         crc: 0x83983FC6
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      - crc: 0x7C65D56F
-        util: 'SSEEdit v4.0.2'
   # Rare Curios
   - name: 'ccbgssse037-curios.esl'
     group: *ccGroup
@@ -1408,9 +1378,6 @@ plugins:
         crc: 0xAFAFB011
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
-    clean:
-      - crc: 0x9CABA454
-        util: 'SSEEdit v4.0.2'
   # Saturalia Holiday Pack
   - name: 'ccvsvsse001-winter.esl'
     group: *ccGroup
@@ -1438,9 +1405,6 @@ plugins:
         crc: 0xE9E660A8
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      - crc: 0xEDB6AFC0
-        util: 'SSEEdit v4.0.2'
   # Spell Knight Armor
   - name: 'ccedhsse002-splkntset.esl'
     group: *ccGroup
@@ -1449,9 +1413,6 @@ plugins:
         crc: 0x021A90CA
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 11
-    clean:
-      - crc: 0x6997290A
-        util: 'SSEEdit v4.0.2'
   # Staff of Hasedoki
   - name: 'ccbgssse045-hasedoki.esl'
     group: *ccGroup
@@ -1460,9 +1421,6 @@ plugins:
         crc: 0x21FAFBB0
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 6
-    clean:
-      - crc: 0x4FA7B836
-        util: 'SSEEdit v4.0.2'
   # Staff of Sheogorath
   - name: 'ccbgssse019-staffofsheogorath.esl'
     group: *ccGroup
@@ -1483,9 +1441,6 @@ plugins:
         crc: 0xE34F307C
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 20
-    clean:
-      - crc: 0x7AA24B95
-        util: 'SSEEdit v4.0.2'
   # Survival Mode
   - name: 'ccqdrsse001-survivalmode.esl'
     group: *ccGroup
@@ -1521,9 +1476,6 @@ plugins:
         crc: 0x611D6AA2
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      - crc: 0x15AFD14B
-        util: 'SSEEdit v4.0.2'
   # Tundra Homestead
   - name: 'cceejsse001-hstead.esm'
     group: *ccGroup
@@ -1534,9 +1486,6 @@ plugins:
         crc: 0xE371B3A9
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      - crc: 0x1D1F9622
-        util: 'SSEEdit v4.0.2'
   # Umbra
   - name: 'ccbgssse016-umbra.esm'
     group: *ccGroup
@@ -1553,9 +1502,6 @@ plugins:
         crc: 0x3433AA80
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 10
-    clean:
-      - crc: 0x316747AB
-        util: 'SSEEdit v4.0.2'
   # Vigil Enforcer Armor Set
   - name: 'ccmtysse002-ve.esl'
     group: *ccGroup
@@ -1564,9 +1510,6 @@ plugins:
         crc: 0x97B385FF
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 11
-    clean:
-      - crc: 0xFD62E00C
-        util: 'SSEEdit v4.0.2'
   # Wild Horses
   - name: 'ccbgssse034-mntuni.esl'
     group: *ccGroup
@@ -1575,9 +1518,6 @@ plugins:
         crc: 0x7CBD33F1
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 26
-    clean:
-      - crc: 0xB7E407EA
-        util: 'SSEEdit v4.0.2'
 
 ###### Unofficial Patches ######
   - name: 'Unofficial Skyrim Special Edition Patch.esp'
@@ -1649,12 +1589,12 @@ plugins:
   - name: 'unofficial skyrim survival patch.es(l|p)'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12655/' ]
     group: *underridesGroup
+    tag:
+      - Graphics
     clean:
       # version: 3.0
       - crc: 0x74DDAE7A
         util: 'SSEEdit v4.0.0'
-    tag:
-      - Graphics
 
 ###### Fixes ######
   - name: 'FloraRespawnFix.esp'
@@ -2167,10 +2107,7 @@ plugins:
         crc: 0x292F204E
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
-    clean:
-      # version: 2.0.2c
-      - crc: 0x7BEE8346
-        util: 'SSEEdit v4.0.0'
+
   - name: 'NQS_NamedQuicksaves.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/16840/' ]
     req:
@@ -2295,10 +2232,6 @@ plugins:
         crc: 0xDD00738B
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
-    clean:
-      # version: 3.06
-      - crc: 0x4F998F53
-        util: 'SSEEdit v4.0.0'
   - name: 'ELFX - Exteriors.esp'
     group: *veryEarlyGroup
     after:
@@ -2360,10 +2293,6 @@ plugins:
         crc: 0x181ECD13
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 1
-    clean:
-      # version: 3.06
-      - crc: 0xB39F6E89
-        util: 'SSEEdit v4.0.0'
   - name: 'ELFX - Weathers.esp'
     group: *underridesGroup
     after:
@@ -2568,10 +2497,7 @@ plugins:
         crc: 0x431CF3C5
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      # version: 1.0.6, after QAC
-      - crc: 0x31A0B062
-        util: 'SSEEdit v4.0.2'
+
   - name: '(Realistic Lighting Overhaul|RLO) -.*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/844/' ]
   - name: 'RLO - Major City Exteriors - No Guard Torches.esp'
@@ -2663,13 +2589,6 @@ plugins:
         crc: 0x747BD772
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 6
-    clean:
-      # version: 3.0.0
-      - crc: 0x96BF25A6
-        util: 'SSEEdit v4.0.0'
-      # version: 3.2.0, after QAC
-      - crc: 0x0CD5C85F
-        util: 'SSEEdit v4.0.2'
   - name: 'Audio Overhaul Skyrim - RealisticWaterTwo Patch.esp'
     after:
       - 'RealisticWaterTwo.esp'
@@ -2683,10 +2602,6 @@ plugins:
         crc: 0x1E22FDD6
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 37
-    clean:
-      # version: 3.0.1
-      - crc: 0xBE0EFA92
-        util: 'SSEEdit v4.0.2'
   - name: 'Audio Overhaul Skyrim - Legacy of the Dragonborn Patch.esp'
     group: *underridesGroup
   - name: 'Audio Overhaul Skyrim - Obsidian Weathers.esp'
@@ -2721,10 +2636,6 @@ plugins:
         crc: 0x4ED7C6DC
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
-    clean:
-      # version: 3.2, after QAC
-      - crc: 0xC26200BF
-        util: 'SSEEdit v4.0.2'
   - name: 'Immersive Music Replacer.esp'
     dirty:
       # version: 3.2
@@ -2732,10 +2643,6 @@ plugins:
         crc: 0x7DC72CE5
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
-    clean:
-      # version: 3.2, after QAC
-      - crc: 0xAFDE8ACA
-        util: 'SSEEdit v4.0.2'
 
   - name: 'Immersive Sounds - Compendium.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/523/' ]
@@ -2815,10 +2722,6 @@ plugins:
         crc: 0xAA85D810
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      # version: 1.5
-      - crc: 0x99C3B788
-        util: 'SSEEdit v4.0.2'
 
   - name: 'Soulmancer Soundtrack - NoVindDun.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/22551/' ]
@@ -2955,10 +2858,7 @@ plugins:
         crc: 0x28EAF3CD
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      # version: 1.6, after QAC
-      - crc: 0x109281F0
-        util: 'SSEEdit v4.0.2'
+
   - name: 'UHDAP -.*\.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18115/'
@@ -3030,10 +2930,7 @@ plugins:
         crc: 0xC16B0C43
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
-    clean:
-      # version: 1.1.1
-      - crc: 0xF809245A
-        util: 'SSEEdit v4.0.2'
+
   - name: 'RealisticWaterTwo - FlowingLakes.esp'
     clean:
       # version: 1.1.1
@@ -3131,10 +3028,7 @@ plugins:
         crc: 0x8377D03C
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 19
-    clean:
-      # version: 0.4.2c
-      - crc: 0xEAA28ADD
-        util: 'SSEEdit v4.0.0'
+
   - name: 'Obsidian Weathers.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12125/' ]
     group: *underridesGroup
@@ -3268,9 +3162,7 @@ plugins:
       # version: 1.01
       - crc: 0x49921FB9
         util: 'SSEEdit v4.0.0'
-      # version: 1.01 - No Fog
-      - crc: 0x9318EEA3
-        util: 'SSEEdit v4.0.0'
+
   - name: 'Vivid Weathers(SE| SE -| - ).*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2187/' ]
   - name: 'Vivid WeathersSE.esp'
@@ -3338,10 +3230,6 @@ plugins:
         crc: 0xF1A0B710
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 18
-    clean:
-      # version: 2.30
-      - crc: 0xF7A0E586
-        util: 'SSEEdit v4.0.0'
   - name: 'Vivid Weathers SE - Summer Season.esp'
     inc:
       - 'Vivid Weathers SE - Winter.esp'
@@ -4000,10 +3888,6 @@ plugins:
         crc: 0x56EBF1FC
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 328
-    clean:
-      # version: 3.42
-      - crc: 0xE40C3938
-        util: 'SSEEdit v4.0.0'
 
   - name: 'BenDoonSSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/274/' ]
@@ -4046,10 +3930,7 @@ plugins:
         crc: 0x9CCE987C
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 34
-    clean:
-      # version: 2.4C
-      - crc: 0x938CF2CD
-        util: 'SSEEdit v4.0.0'
+
   - name: 'Janessa Half Argonian Companion.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/24096']
     msg:
@@ -4062,13 +3943,6 @@ plugins:
         crc: 0x39D3BC6F
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
-    clean:
-      # version: 1.0
-      - crc: 0xBC38732F
-        util: 'SSEEdit v4.0.2'
-      # version: 1.0, wild edits cleaned.
-      - crc: 0x1A3E4FE1
-        util: 'SSEEdit v4.0.2'
 
   - name: '0Kaidan.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12496/' ]
@@ -4107,10 +3981,7 @@ plugins:
         crc: 0xACAFA4C7
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 13
-    clean:
-      # version: 1.3.0
-      - crc: 0xF205ED42
-        util: 'SSEEdit v4.0.2'
+
   - name: 'MrissiTailOfTroubles.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9666/' ]
     dirty:
@@ -4119,10 +3990,7 @@ plugins:
         crc: 0x8897007A
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 34
-    clean:
-      # version: 1.6
-      - crc: 0x1713C743
-        util: 'SSEEdit v4.0.0'
+
   - name: 'Endgame NPC Overhaul.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/897/' ]
     group: *underridesGroup
@@ -4141,10 +4009,7 @@ plugins:
         crc: 0x251F8670
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 31
-    clean:
-      # version: 2.1, after QAC
-      - crc: 0xA997AF81
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Rigmor.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5271/' ]
     inc:
@@ -4172,16 +4037,6 @@ plugins:
         crc: 0xFB1916CD
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 413
-    clean:
-      # version: 1.0 Full
-      - crc: 0x2654E7F5
-        util: 'SSEEdit v4.0.2'
-      # version: 1.0 Just Rigmor
-      - crc: 0xC8D60470
-        util: 'SSEEdit v4.0.2'
-      # version: 1.0 BS Bruma
-      - crc: 0x107B68FF
-        util: 'SSEEdit v4.0.2'
 
   - name: 'SofiaFollower.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2180/' ]
@@ -4351,10 +4206,6 @@ plugins:
         crc: 0x2AA82040
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 4
-    clean:
-      # version: 3.0, after QAC
-      - crc: 0x4BE6CA87
-        util: 'SSEEdit v4.0.2'
 
   - name: 'High Level Enemies( - Dawnguard| - Dragonborn)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/3231/' ]
@@ -4604,10 +4455,6 @@ plugins:
         crc: 0x924AD45B
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      # version: 2.5
-      - crc: 0xA981A2DA
-        util: 'SSEEdit v4.0.0'
 
   - name: 'skyBirds_SSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2315/' ]
@@ -4827,10 +4674,7 @@ plugins:
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 130
         udr: 218
-    clean:
-      # version: 1.1
-      - crc: 0x2EEBF517
-        util: 'SSEEdit v4.0.1'
+
   - name: 'Landscape( Fixes)? For Grass Mods.*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9005/' ]
   - name: 'Landscape Fixes For Grass Mods.esp'
@@ -4995,10 +4839,6 @@ plugins:
         crc: 0xE4021E8A
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
-    clean:
-      # version: 2.3, after QAC
-      - crc: 0xE70AB25C
-        util: 'SSEEdit v4.0.2'
   - name: 'SunDaytime(South|North_MM_default)\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/11052/' ]
     msg:
@@ -5042,10 +4882,6 @@ plugins:
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 59
         udr: 5
-    clean:
-      # version: 3.2
-      - crc: 0xC22A5329
-        util: 'SSEEdit v4.0.0'
   - name: 'NSUTR_bugfixes.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/15064/'
@@ -5066,10 +4902,6 @@ plugins:
         crc: 0x2EE577A0
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 33
-    clean:
-      # version: 1.4
-      - crc: 0x6A1DF988
-        util: 'SSEEdit v4.0.0'
   - name: 'NSUTR_improvements.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/15064/'
@@ -5081,10 +4913,6 @@ plugins:
         crc: 0xBE9E7F5F
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
-    clean:
-      # version: 1.4
-      - crc: 0x8E47790E
-        util: 'SSEEdit v4.0.0'
   - name: 'NSUTR_Static_fix.esp'
     group: *preVeryEarlyGroup
     clean:
@@ -5106,10 +4934,6 @@ plugins:
         crc: 0xE7403486
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      # version: 1.0
-      - crc: 0xA208B2B1
-        util: 'SSEEdit v4.0.0'
 
   - name: 'S3DTrees NextGenerationForests.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12371/' ]
@@ -5189,10 +5013,7 @@ plugins:
         crc: 0x8A99CCE9
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 15
-    clean:
-      # version: 0.7
-      - crc: 0xE7F146C7
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Tamriel Reloaded HD SE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6372/' ]
     group: *floraGroup
@@ -5203,10 +5024,7 @@ plugins:
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 12
         udr: 5
-    clean:
-      # version: 1.01, after QAC
-      - crc: 0x42CB6BBA
-        util: 'SSEEdit v4.0.2'
+
   - name: 'TerrainLodRedone.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9135/' ]
     group: *veryEarlyGroup
@@ -5221,10 +5039,6 @@ plugins:
         crc: 0x91BADF25
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 38
-    clean:
-      # version: 1.3.3
-      - crc: 0x28B9ECB9
-        util: 'SSEEdit v4.0.0'
   # Unique Locations Riverwood - Alt Start Patch
   - name: 'ULALPatch.esp'
     dirty:
@@ -5234,10 +5048,6 @@ plugins:
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 4
         udr: 1
-    clean:
-      # version: 1.0
-      - crc: 0x0B808080
-        util: 'SSEEdit v4.0.0'
   # Unique Locations Riverwood - JK's Skyrim Patch
   - name: 'Riverwood Forest - JK''s Skyrim Patch.esp'
     clean:
@@ -5253,10 +5063,6 @@ plugins:
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 10
         udr: 48
-    clean:
-      # version: 1.1
-      - crc: 0xCDD1AA52
-        util: 'SSEEdit v4.0.0'
   # Unique Locations Riverwood - Snapneck Shack Patch
   - name: 'ELSnapneckShackPatch.esp'
     clean:
@@ -5336,10 +5142,7 @@ plugins:
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 22
         udr: 9
-    clean:
-      # version: 1.0
-      - crc: 0x99D025AD
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Whiterun Forest Borealis.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/11343/' ]
     group: *floraGroup
@@ -5364,10 +5167,6 @@ plugins:
         crc: 0x68A235DA
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 6
-    clean:
-      # version: 2.0
-      - crc: 0xB74D4E23
-        util: 'SSEEdit v4.0.2'
 
 ###### Gameplay ######
   - name: 'Improved Traps.esp'
@@ -5508,10 +5307,6 @@ plugins:
         crc: 0x32D1318D
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 773
-    clean:
-      # version: 1.0
-      - crc: 0x17DF49FE
-        util: 'SSEEdit v4.0.1'
 
 ###### Gameplay - Character Classes & Races ######
   - name: 'Character Creation Overhaul.esp'
@@ -5538,10 +5333,6 @@ plugins:
         crc: 0xF4EC1F03
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 24
-    clean:
-      # version: 1.3.3, after QAC
-      - crc: 0x9740479E
-        util: 'SSEEdit v4.0.2'
 
   - name: 'Imperious - Races of Skyrim.esp'
     url:
@@ -6305,22 +6096,6 @@ plugins:
         crc: 0xAB5FD735
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 271
-    clean:
-      # version: Original 1.2
-      - crc: 0x69197AB9
-        util: 'SSEEdit v4.0.2'
-      # version: Simplified Full 2.20
-      - crc: 0x36E134D7
-        util: 'SSEEdit v4.0.2'
-      # version: Simplified No Artifacts 2.20
-      - crc: 0x1997BC94
-        util: 'SSEEdit v4.0.2'
-      # version: Another Sorting Mod Replacer 1.2.26
-      - crc: 0xC74AE50C
-        util: 'SSEEdit v4.0.2'
-      # version: Omega Replacer 1.99.9
-      - crc: 0xB15D945C
-        util: 'SSEEdit v4.0.2'
   - name: 'MLU - AAE Ultimate Edition.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/3058/' ]
     after:
@@ -6622,10 +6397,6 @@ plugins:
         crc: 0xAF52C3D7
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      # version: 1.07SSE
-      - crc: 0x2B3FF1BA
-        util: 'SSEEdit v4.0.0'
 
   - name: 'Apocalypse - Magic of Skyrim.esp'
     url:
@@ -6749,10 +6520,6 @@ plugins:
         crc: 0xC238C832
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 4226
-    clean:
-      # version: 1.5.5.1, after QAC
-      - crc: 0xAD2B40A5
-        util: 'SSEEdit v4.0.2'
 
   - name: 'PatronGodsOfSkyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/155/' ]
@@ -6771,10 +6538,6 @@ plugins:
         crc: 0x647371BC
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 23
-    clean:
-      # version: 1.0.5
-      - crc: 0x472DDCD1
-        util: 'SSEEdit v4.0.2'
 
   - name: 'Predator Vision.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2777/' ]
@@ -6796,10 +6559,6 @@ plugins:
         crc: 0x48A567EA
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 42
-    clean:
-      # version: 1.0
-      - crc: 0x6202C837
-        util: 'SSEEdit v4.0.2'
 
   - name: 'Tainted_Blood.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9312/' ]
@@ -6851,10 +6610,6 @@ plugins:
         crc: 0xF3A47A99
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 23
-    clean:
-      # version: 1.3.0
-      - crc: 0x8468D97D
-        util: 'SSEEdit v4.0.1'
 
 ###### Gameplay - Mount & Follower Managers ######
   - name: 'AmazingFollowerTweaks.esp'
@@ -6883,16 +6638,6 @@ plugins:
         crc: 0x3899F517
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      # version: AFT 1.66sse
-      - crc: 0xF43B6124
-        util: 'SSEEdit v4.0.0'
-      # version: iAFT 3.09SE
-      - crc: 0xCB85EFD2
-        util: 'SSEEdit v4.0.0'
-      # version: iAFT 3.09SE DLC & USSEP Patch
-      - crc: 0x2CE005AD
-        util: 'SSEEdit v4.0.0'
 
   - name: 'Convenient Horses.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9519/' ]
@@ -7169,10 +6914,6 @@ plugins:
         crc: 0xA61F66AD
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      # version: 0.4
-      - crc: 0x539DB18D
-        util: 'SSEEdit v4.0.2'
   - name: 'Immersive Citizens - ELE patch.esp'
     clean:
       # version: 0.4
@@ -7195,10 +6936,6 @@ plugins:
         crc: 0x6227D18D
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 17
-    clean:
-      # version: 0.4
-      - crc: 0x3ED97678
-        util: 'SSEEdit v4.0.2'
   - name: 'Immersive Citizens - TC patch.esp'
     clean:
       # version: 0.4
@@ -7466,13 +7203,6 @@ plugins:
         crc: 0x91F8E094
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 31
-    clean:
-      # version: 1.6 Immersive Edition, after QAC
-      - crc: 0xBC83ECFA
-        util: 'SSEEdit v4.0.2'
-      # version: 7.4.1, after QAC
-      - crc: 0xF94EEA3A
-        util: 'SSEEdit v4.0.2'
 
   - name: 'BetterQuestObjectives.*\.esp'
     url:
@@ -7656,10 +7386,6 @@ plugins:
         crc: 0x14593BAE
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 17
-    clean:
-      # version: 0.1
-      - crc: 0x3C052452
-        util: 'SSEEdit v4.0.2'
 
   - name: 'Finding_VelehkSain(_MAQF)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/19815/' ]
@@ -7686,10 +7412,6 @@ plugins:
         crc: 0xE6DC78C3
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 7
-    clean:
-      # version: 1.8
-      - crc: 0x8F81344C
-        util: 'SSEEdit v4.0.0'
 
   - name: 'Immersive Encounters.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18330/' ]
@@ -7715,10 +7437,6 @@ plugins:
         crc: 0x93449BB7
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 47
-    clean:
-      # version: 5.5.3
-      - crc: 0x603FE7C9
-        util: 'SSEEdit v4.0.1'
 
   - name: 'Missing Apprentices CRF Quest Fix.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6677/' ]
@@ -7757,10 +7475,6 @@ plugins:
         crc: 0x9985DFF3
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      # version: 1.0
-      - crc: 0x505FDAEA
-        util: 'SSEEdit v4.0.0'
 
   - name: 'NotSoFast-MageGuild.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5686/' ]
@@ -7795,10 +7509,6 @@ plugins:
         crc: 0xE1DCDD42
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 32
-    clean:
-      # version: 1.0, after QAC
-      - crc: 0xC8B74D51
-        util: 'SSEEdit v4.0.2'
   - name: 'quest_pitfighter_dlc01.esp'
     dirty:
       # version: 1.0
@@ -7806,10 +7516,6 @@ plugins:
         crc: 0xE4C4B73B
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 6
-    clean:
-      # version: 1.0, after QAC
-      - crc: 0xCD63ACCB
-        util: 'SSEEdit v4.0.2'
 
   - name: 'Religion.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/67663/' ]
@@ -8118,10 +7824,7 @@ plugins:
         crc: 0xBEA0B2DA
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
-    clean:
-      # version: 2.1
-      - crc: 0xA5438653
-        util: 'SSEEdit v4.0.0'
+
   - name: 'AmuletsShowOn(Clothes|Everything|HeavyArmor|LightArmor|Robes)?(-JOP)?.*\.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18177'
@@ -8427,10 +8130,6 @@ plugins:
         crc: 0x8491D752
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 5
-    clean:
-      # version: 1.58
-      - crc: 0xD7423A4E
-        util: 'SSEEdit v4.0.0'
   - name: 'imp_helm_(Immersive_Armors|IDPM|USSEP)\.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/12405/'
@@ -8567,10 +8266,6 @@ plugins:
         crc: 0x7663A7AE
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 15
-    clean:
-      # version: 1.01, after QAC
-      - crc: 0xE96A8206
-        util: 'SSEEdit v4.0.2'
   - name: 'OvensAndChurnsPlayerHouses.esp'
     dirty:
       # version: 1.01
@@ -8578,10 +8273,6 @@ plugins:
         crc: 0x37E22F6C
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 11
-    clean:
-      # version: 1.01, after QAC
-      - crc: 0x09852124
-        util: 'SSEEdit v4.0.2'
   - name: 'OvensAndChurnsMinorInns.esp'
     dirty:
       # version: 1.01
@@ -8589,10 +8280,6 @@ plugins:
         crc: 0x97224F16
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 26
-    clean:
-      # version: 1.01, after QAC
-      - crc: 0xBB1402D2
-        util: 'SSEEdit v4.0.2'
 
   - name: 'PrvtI_HeavyArmory.esp'
     url:
@@ -8622,10 +8309,6 @@ plugins:
         crc: 0xA202F2E4
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 42
-    clean:
-      # version: 4.8.0, after QAC
-      - crc: 0x2459BBF4
-        util: 'SSEEdit v4.0.2'
 
   - name: 'RUSTIC SOULGEMS - (Sorted|Unsorted)( - ESL)?( - GIST)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5785' ]
@@ -8656,13 +8339,7 @@ plugins:
         crc: 0xE54891DA
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
-    clean:
-      # version: 1.0
-      - crc: 0x89792621
-        util: 'SSEEdit v4.0.0'
-      # version: 1.0 - ESL flagged
-      - crc: 0x72B14661
-        util: 'SSEEdit v4.0.0'
+
   - name: 'ScopedBows.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/912/' ]
     tag:
@@ -8748,10 +8425,6 @@ plugins:
         crc: 0xEC89CAD3
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 19
-    clean:
-      # version: 1.01 Fully cleaned
-      - crc: 0xBB98A580
-        util: 'SSEEdit v4.0.0'
   - name: 'TheWulfPanda - City Teleport Spells Less Magicka Increase Cast Time.esp'
     dirty:
       # version: 1.01
@@ -8759,10 +8432,6 @@ plugins:
         crc: 0x5AE957AB
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 19
-    clean:
-      # version: 1.01 Fully cleaned
-      - crc: 0x75837344
-        util: 'SSEEdit v4.0.0'
   - name: 'TheWulfPanda - Faction Teleport Spells( Less Magicka Increased Cast Time)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6991/' ]
     msg:
@@ -8779,10 +8448,6 @@ plugins:
         crc: 0x6DA7BCF5
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 30
-    clean:
-      # version: 1.01 Fully cleaned
-      - crc: 0xBDB41425
-        util: 'SSEEdit v4.0.0'
   - name: 'TheWulfPanda - Faction Teleport Spells Less Magicka Increased Cast Time.esp'
     dirty:
       # version: 1.03
@@ -8790,10 +8455,6 @@ plugins:
         crc: 0x3BEDC8A5
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 30
-    clean:
-      # version: 1.03 Fully cleaned
-      - crc: 0xE637DE54
-        util: 'SSEEdit v4.0.0'
   - name: 'TheWulfPanda - Teleport Spells Towns and Villages( Less Magicka Increase Cast Time)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/7267/' ]
     msg:
@@ -8810,10 +8471,6 @@ plugins:
         crc: 0xE614F5D7
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 17
-    clean:
-      # version: 1.03 Fully cleaned
-      - crc: 0x2E1C6AA4
-        util: 'SSEEdit v4.0.0'
   - name: 'TheWulfPanda - Teleport Spells Towns and Villages Less Magicka Increase Cast Time.esp'
     dirty:
       # version: 1.00
@@ -8821,10 +8478,6 @@ plugins:
         crc: 0x2393970C
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 17
-    clean:
-      # version: 1.00 Fully cleaned
-      - crc: 0x6A6995CB
-        util: 'SSEEdit v4.0.0'
 
   - name: 'UNP Vanilla Outfits.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/11136/' ]
@@ -8854,10 +8507,6 @@ plugins:
         crc: 0x24B9E639
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
-    clean:
-      # version: 4.06SE
-      - crc: 0x2D31CE29
-        util: 'SSEEdit v4.0.0'
   - name: 'Wintermyst - Increased Damage.esp'
     clean:
       # version: 4.06SE
@@ -9043,13 +8692,7 @@ plugins:
         crc: 0x0B12B4E7
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 514
-    clean:
-      # version: 1.3.3, after cleaning
-      - crc: 0x2F3CF5FA
-        util: 'SSEEdit v4.0.2'
-      # version: 1.3.3, after cleaning & correcting the (unused) circular leveled list
-      - crc: 0x2BD82405
-        util: 'SSEEdit v4.0.2'
+
   - name: 'BS_DLC_patch.esp'
     url: [ 'https://bethesda.net/en/mods/skyrim/mod-detail/4044167' ]
     group: *veryEarlyGroup
@@ -9084,13 +8727,7 @@ plugins:
         crc: 0x787070C1
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 24
-    clean:
-      # version: 1.5
-      - crc: 0x86745B7A
-        util: 'SSEEdit v4.0.2'
-      # version: 1.5 - ESL flagged
-      - crc: 0xA4762EF8
-        util: 'SSEEdit v4.0.2'
+
   - name: 'BS_Campfire.esp'
     tag:
       - Names
@@ -9112,10 +8749,7 @@ plugins:
         crc: 0x7E36F0E5
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 122
-    clean:
-      # version: 1.0
-      - crc: 0xC4E7CC46
-        util: 'SSEEdit v4.0.1'
+
   - name: 'Darkend.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10423' ]
     dirty:
@@ -9124,10 +8758,7 @@ plugins:
         crc: 0x616730B8
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 26
-    clean:
-      # version: 1.4
-      - crc: 0x4E9A526A
-        util: 'SSEEdit v4.0.0'
+
   - name: 'Falskaar.esm'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2057/' ]
     msg:
@@ -9155,9 +8786,7 @@ plugins:
         crc: 0x353FFB77
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 19
-    clean:
-      - crc: 0x2A55AB15
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Gray Fox Cowl.esm'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/4509/'
@@ -9193,10 +8822,7 @@ plugins:
         crc: 0x2D753507
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      # version: 2.0
-      - crc: 0xD14F7D61
-        util: 'SSEEdit v4.0.0'
+
   - name: 'MoonAndStar_MAS.esp'
     group: *underridesGroup
     after:
@@ -9224,10 +8850,7 @@ plugins:
         crc: 0xEB5AEFAF
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
-    clean:
-      # version: 3.2, after automatic & manual cleaning
-      - crc: 0xAF91987E
-        util: 'SSEEdit v4.0.0'
+
   - name: 'JRWZMASPatch.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10751'
@@ -9352,13 +8975,7 @@ plugins:
         crc: 0x2E278EC6
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 52
-    clean:
-      # version: 1.3.0, English Machine
-      - crc: 0x4ADF03DE
-        util: 'SSEEdit v4.0.2'
-      # version: 2.1, replacer from Vigilant Voiced
-      - crc: 0x129711EF
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Vigilant.esm'
     dirty:
       # version: 1.3.0 beta
@@ -9371,13 +8988,7 @@ plugins:
         crc: 0x82B79B7B
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 52
-    clean:
-      # version: 1.3.0 beta, after QAC
-      - crc: 0xFECB8731
-        util: 'SSEEdit v4.0.2'
-      # version: 2.1,  after QAC - replacer from Vigilant Voiced
-      - crc: 0xC430827C
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Wyrmstooth.esp'
     url: [ 'https://archive.org/details/Wyrmstooth1.17BSSE' ]
     msg:
@@ -9409,10 +9020,7 @@ plugins:
         crc: 0xFC45B26D
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 9
-    clean:
-      # version: 1.0.3, After QAC.
-      - crc: 0x4D6BFB00
-        util: 'SSEEdit v4.0.2'
+
   - name: 'AHZBetterDGEntranceSE - BSHeartland Patch.esp'
     req:
       - 'AHZBetterDGEntranceSE.esp'
@@ -9432,10 +9040,7 @@ plugins:
         crc: 0x4696B973
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 210
-    clean:
-      # version: 4.6, after QAC
-      - crc: 0x8E64A573
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Aurora(Village| - Moon and Star Patch).esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/17647' ]
   - name: 'AuroraVillage.esp'
@@ -9447,10 +9052,7 @@ plugins:
         crc: 0x9F71C5AA
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 12
-    clean:
-      # version: 1.1
-      - crc: 0x77DFD69B
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Aurora - Moon and Star Patch.esp'
     dirty:
       # version: 1.0
@@ -9458,10 +9060,7 @@ plugins:
         crc: 0x3931F00E
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      # version: 1.0
-      - crc: 0xF208EFB1
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Badersee.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/16419' ]
     dirty:
@@ -9502,13 +9101,7 @@ plugins:
         crc: 0x7E530609
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 17
-    clean:
-      # version: 1.1
-      - crc: 0xF0F0D623
-        util: 'SSEEdit v4.0.1'
-      # version: 1.1, sorted masters
-      - crc: 0xF471822F
-        util: 'SSEEdit v4.0.1'
+
   - name: 'Bring Out Your Dead.esp'
     url:
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/323/'
@@ -9576,10 +9169,6 @@ plugins:
         crc: 0x62C75F1D
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 34
-    clean:
-      # version: 3.5, after QAC
-      - crc: 0x7CC11F7A
-        util: 'SSEEdit v4.0.2'
 
   - name: 'Convenient Bridges.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2715/' ]
@@ -9589,10 +9178,7 @@ plugins:
         crc: 0x231346AC
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 99
-    clean:
-      # version: 1.1
-      - crc: 0xA0C59971
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Cutting Room Floor.esp'
     url:
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/276/'
@@ -9686,10 +9272,7 @@ plugins:
         crc: 0x462DE2B9
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 24
-    clean:
-      # version: 1.4, after QAC
-      - crc: 0xD3729171
-        util: 'SSEEdit v4.0.2'
+
   - name: 'frozenintime.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12625/' ]
     dirty:
@@ -9703,13 +9286,7 @@ plugins:
         crc: 0x264F55D5
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 4
-    clean:
-      # version: 1.1, regular
-      - crc: 0x4525D16E
-        util: 'SSEEdit v4.0.0'
-      # version: 1.1, reduced loot
-      - crc: 0x5CCCE61F
-        util: 'SSEEdit v4.0.0'
+
   - name: 'HammetDungeons.es(m|p)'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12186/' ]
   - name: 'HammetDungeons.esp'
@@ -9731,10 +9308,7 @@ plugins:
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 22
         udr: 66
-    clean:
-      # version: 1.0, after QAC
-      - crc: 0x31116464
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Incaendo_IsengravBarrow.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/17263/' ]
     dirty:
@@ -9743,10 +9317,7 @@ plugins:
         crc: 0x7EE2A03E
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 147
-    clean:
-      # version: 1.1, after QAC
-      - crc: 0xE6031531
-        util: 'SSEEdit v4.0.2'
+
   - name: 'JokerineArgonianSettlement.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/17263/' ]
     dirty:
@@ -9755,10 +9326,7 @@ plugins:
         crc: 0x76A74A54
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 13
-    clean:
-      # version: 1.1
-      - crc: 0xB8F103DE
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Laundry.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2011/' ]
     group: *veryEarlyGroup
@@ -9770,10 +9338,7 @@ plugins:
         crc: 0xBF023846
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 7
-    clean:
-      # version: 1.0
-      - crc: 0xB53ED106
-        util: 'SSEEdit v4.0.2'
+
   - name: 'LoreiusSettlement.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/17249' ]
     clean:
@@ -9788,10 +9353,7 @@ plugins:
         crc: 0x22D00784
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 66
-    clean:
-      # version: 1.6
-      - crc: 0xED8C7F77
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Oblivion Gates in Cities.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/388/' ]
     inc:
@@ -9835,10 +9397,7 @@ plugins:
         crc: 0x6C90193C
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 37
-    clean:
-      # version: 3.08
-      - crc: 0x61CEBF5A
-        util: 'SSEEdit v4.0.2'
+
   - name: 'simpleCarriageExpansion.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10434/'
@@ -9878,10 +9437,6 @@ plugins:
         crc: 0xDF79FA9B
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 10
-    clean:
-      # version: 1.4
-      - crc: 0x59CCC471
-        util: 'SSEEdit v4.0.2'
   - name: 'Stonecrest - Verdant, Patch.esp'
     dirty:
       # version: 1.4
@@ -9889,10 +9444,6 @@ plugins:
         crc: 0x02A47EF7
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
-    clean:
-      # version: 1.4
-      - crc: 0xAA63C572
-        util: 'SSEEdit v4.0.2'
 
   - name: 'Storefront.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/364/' ]
@@ -9916,10 +9467,6 @@ plugins:
         crc: 0x701ADC3A
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 120
-    clean:
-      # version: 5.01
-      - crc: 0x6684B2FF
-        util: 'SSEEdit v4.0.1'
   - name: 'TES Arena Amol.esp'
     dirty:
       # version: 5.01
@@ -9927,10 +9474,6 @@ plugins:
         crc: 0x28F9DAFA
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 13
-    clean:
-      # version: 5.01
-      - crc: 0x36947B49
-        util: 'SSEEdit v4.0.1'
   - name: 'Tes Arena Nimalten.esp'
     dirty:
       # version: 5.01
@@ -9938,10 +9481,6 @@ plugins:
         crc: 0xB34448CC
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 26
-    clean:
-      # version: 5.01
-      - crc: 0x9365E227
-        util: 'SSEEdit v4.0.1'
   - name: 'Tes Arena NorthKeep.esp'
     dirty:
       # version: 5.01
@@ -9949,10 +9488,6 @@ plugins:
         crc: 0x0EEE0E4B
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 15
-    clean:
-      # version: 5.01
-      - crc: 0x9C623E34
-        util: 'SSEEdit v4.0.1'
   - name: 'TES (DunstadGrove|Granite Hall|Pagran Village|Vernim Wood).esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/318' ]
   - name: 'TES DunstadGrove.esp'
@@ -9962,10 +9497,6 @@ plugins:
         crc: 0x72FE5CB8
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 14
-    clean:
-      # version: 5.01
-      - crc: 0x01D35219
-        util: 'SSEEdit v4.0.1'
   - name: 'Tes Granite Hall.esp'
     dirty:
       # version: 5.01
@@ -9973,10 +9504,6 @@ plugins:
         crc: 0x69AAC6DC
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 14
-    clean:
-      # version: 5.01
-      - crc: 0x8B59AB56
-        util: 'SSEEdit v4.0.1'
   - name: 'Tes Pagran Village.esp'
     dirty:
       # version: 5.01
@@ -9984,10 +9511,6 @@ plugins:
         crc: 0xF4AB0C61
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 19
-    clean:
-      # version: 5.01
-      - crc: 0x428913E5
-        util: 'SSEEdit v4.0.1'
   - name: 'Tes Vernim Wood.esp'
     dirty:
       # version: 5.01
@@ -9995,10 +9518,7 @@ plugins:
         crc: 0x5F6B48AE
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 19
-    clean:
-      # version: 5.01
-      - crc: 0xB5E436EC
-        util: 'SSEEdit v4.0.1'
+
   - name: 'vikingmeadhall.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/17132/' ]
     dirty:
@@ -10007,10 +9527,7 @@ plugins:
         crc: 0x10B36003
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 6
-    clean:
-      # version: 1.1
-      - crc: 0xFA3E20B8
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Watchtowers of Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/19230' ]
     dirty:
@@ -10020,10 +9537,7 @@ plugins:
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 16
         udr: 18
-    clean:
-      # version: 1.0
-      - crc: 0xBF51ABC2
-        util: 'SSEEdit v4.0.2'
+
   - name: 'WhiteLighthouseSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/21955' ]
     dirty:
@@ -10032,10 +9546,7 @@ plugins:
         crc: 0x3D32FCC3
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
-    clean:
-      # version: 2.0
-      - crc: 0x5DC395B3
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Windhelm Docks Pathways SE( - Better Docks AIO Patch| - Open Cities Skyrim Patch)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/8697' ]
   - name: 'Windhelm Docks Pathways SE.esp'
@@ -10061,10 +9572,6 @@ plugins:
         crc: 0x19F035CF
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 6
-    clean:
-      # version: 1.4
-      - crc: 0x8A99A059
-        util: 'SSEEdit v4.0.2'
 
 ###### Location - Overhauls ######
   - name: 'CollegeOfWinterholdImmersive.esp'
@@ -10091,10 +9598,6 @@ plugins:
         crc: 0xA935628A
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 4
-    clean:
-      # version: 5.3
-      - crc: 0x8AEC2250
-        util: 'SSEEdit v4.0.2'
 
   - name: 'CoW Bridge Fix.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/17972/' ]
@@ -10107,10 +9610,6 @@ plugins:
         crc: 0x72FFC50B
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 23
-    clean:
-      # version: 1, after QAC
-      - crc: 0x81A62029
-        util: 'SSEEdit v4.0.2'
 
   - name: 'Darkwater Crossing.esp'
     url:
@@ -10510,10 +10009,7 @@ plugins:
         crc: 0x78362B89
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 20
-    clean:
-      # version: 106
-      - crc: 0x3D6A5454
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Holds.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10609/' ]
     dirty:
@@ -10522,10 +10018,6 @@ plugins:
         crc: 0xCECBF47C
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 170
-    clean:
-      # version: 0.0.8, after QAC
-      - crc: 0xF0E82EA0
-        util: 'SSEEdit v4.0.2'
 
   - name: 'InnCredible.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/790/' ]
@@ -10551,10 +10043,6 @@ plugins:
         crc: 0xC354E06E
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 91
-    clean:
-      # version: 1.2
-      - crc: 0x78A014E6
-        util: 'SSEEdit v4.0.1'
   - name: 'Inns and Taverns - Heartwood Inn.esp'
     inc:
       - 'Inns and Taverns.esp'
@@ -10564,10 +10052,6 @@ plugins:
         crc: 0x358FD05D
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 11
-    clean:
-      # version: 1.2
-      - crc: 0xC59F7380
-        util: 'SSEEdit v4.0.1'
   - name: 'Inns and Taverns - The Ghostly View.esp'
     inc:
       - 'Inns and Taverns.esp'
@@ -10577,10 +10061,7 @@ plugins:
         crc: 0x1EB28610
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 13
-    clean:
-      # version: 1.2
-      - crc: 0xA309051E
-        util: 'SSEEdit v4.0.1'
+
   - name: 'Ivarstead.esp'
     url:
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/349'
@@ -10903,10 +10384,6 @@ plugins:
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 167
         udr: 72
-    clean:
-      # version: 1.0, after QAC
-      - crc: 0xE6346F4D
-        util: 'SSEEdit v4.0.2'
   - name: 'Kato''s Cities Trees.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9200' ]
     dirty:
@@ -10915,10 +10392,6 @@ plugins:
         crc: 0xDEF4D752
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
-    clean:
-      # version: 1.0, after QAC
-      - crc: 0xBA26D75E
-        util: 'SSEEdit v4.0.2'
 
   - name: 'Keld-Nar.esp'
     url:
@@ -11380,9 +10853,6 @@ plugins:
       # version: 1.0 Regular
       - crc: 0xDB7238E5
         util: 'SSEEdit v4.0.2'
-      # version: 2.0 Enhanced, after QAC
-      - crc: 0xB9E8C050
-        util: 'SSEEdit v4.0.2'
 
   - name: '(Palaces Castles Enhanced|PCE - ).*\.esp'
     url:
@@ -11473,10 +10943,6 @@ plugins:
         crc: 0x7260B6A1
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 12
-    clean:
-      # version: 2.2, after QAC
-      - crc: 0x08C6D0E7
-        util: 'SSEEdit v4.0.2'
   - name: 'PCE - RLO Patch.esp'
     after:
       - 'PCE - Skyrim Sewers Patch.esp'
@@ -11495,10 +10961,6 @@ plugins:
         crc: 0x7F257FE6
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 15
-    clean:
-      # version: 1.02
-      - crc: 0xA271F411
-        util: 'SSEEdit v4.0.1'
   - name: 'Raven Rock - Clockwork Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/640' ]
     dirty:
@@ -11507,10 +10969,6 @@ plugins:
         crc: 0x42CE0509
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
-    clean:
-      # version: 1.00
-      - crc: 0x25A0C1EA
-        util: 'SSEEdit v4.0.1'
 
   - name: 'RavenRockReborn.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/24867' ]
@@ -11552,10 +11010,7 @@ plugins:
         crc: 0xBD63547F
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 19
-    clean:
-      # version: 1.1, After QAC
-      - crc: 0xEBD6BF3D
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Rorikstead.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/16881/' ]
     after:
@@ -11602,10 +11057,7 @@ plugins:
         crc: 0x9E66B431
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 6
-    clean:
-      # version: 2.2, after cleaning & master sort
-      - crc: 0x06E66E36
-        util: 'SSEEdit v4.0.0'
+
   - name: 'Shor''s Stone.esp'
     url:
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/354/'
@@ -11665,13 +11117,6 @@ plugins:
         crc: 0x9022BD8E
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 10
-    clean:
-      # version: 1.4
-      - crc: 0x52D33A33
-        util: 'SSEEdit v4.0.2'
-      # version: 1.4 Open Cities
-      - crc: 0xFA4A0A6A
-        util: 'SSEEdit v4.0.2'
   - name: 'SkyR - Riverwood Interiors.esp'
     clean:
       # version: 1.4
@@ -11765,13 +11210,6 @@ plugins:
         crc: 0xDC243E1D
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 4
-    clean:
-      # version: 1.4
-      - crc: 0x4FD1702D
-        util: 'SSEEdit v4.0.2'
-      # version: 1.4 Open Cities
-      - crc: 0xDB302CF5
-        util: 'SSEEdit v4.0.2'
   - name: 'SkyR - Windhelm Interiors USP patch.esp'
     clean:
       # version: 1.4
@@ -11838,10 +11276,7 @@ plugins:
         crc: 0x0D4D03BC
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 48
-    clean:
-      # version: 1, after QAC
-      - crc: 0x9BE14491
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Undriel_QuaintRavenRock.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/11307/' ]
     inc:
@@ -11862,10 +11297,6 @@ plugins:
         crc: 0xD0F9D3BA
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 16
-    clean:
-      # version: 1.5
-      - crc: 0x70CB4A4C
-        util: 'SSEEdit v4.0.1'
 
   - name: 'Vaults of Skyrim (1.0 NEXUS|Palaces Patch)\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10386/' ]
@@ -11881,10 +11312,6 @@ plugins:
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 20
         udr: 24
-    clean:
-      # version: 1.0, after QAC
-      - crc: 0x8DB3D128
-        util: 'SSEEdit v4.0.2'
   - name: 'Vaults of Skyrim Palaces Patch.esp'
     req:
       - 'Palaces Castles Enhanced.esp'
@@ -11895,10 +11322,6 @@ plugins:
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 26
         udr: 17
-    clean:
-      # version: 1.1, after QAC
-      - crc: 0x0B9E120E
-        util: 'SSEEdit v4.0.2'
 
   - name: 'VikingShipPlayerHome.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/13526/' ]
@@ -11911,10 +11334,7 @@ plugins:
         crc: 0x158C80FB
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
-    clean:
-      # version: 1.5
-      - crc: 0x15E93749
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Whistling Mine.esp'
     url:
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/367/'
@@ -12020,10 +11440,6 @@ plugins:
         crc: 0xA91FF679
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 13
-    clean:
-      # version: 1.3
-      - crc: 0x35BA34A7
-        util: 'SSEEdit v4.0.2'
   - name: 'CEOWindhelm - .*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/19400' ]
   - name: 'CEOWindhelm - Windhelm Exterior Altered Patch.esp'
@@ -12033,10 +11449,6 @@ plugins:
         crc: 0xD55110D5
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      # version: 1.3
-      - crc: 0xC45F84BF
-        util: 'SSEEdit v4.0.2'
   - name: 'CEOWindhelm - JUSTICE Patch.esp'
     clean:
       # version: 1.3
@@ -12077,10 +11489,6 @@ plugins:
         crc: 0xE3CC668A
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      # version: 1.3
-      - crc: 0xCA8D30FB
-        util: 'SSEEdit v4.0.2'
   - name: 'CEOWindhelm - Trees in Cities Patch.esp'
     clean:
       # version: 1.3
@@ -12093,10 +11501,6 @@ plugins:
         crc: 0x1044CACF
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 26
-    clean:
-      # version: 1.3
-      - crc: 0xC02D9F89
-        util: 'SSEEdit v4.0.2'
   - name: 'CEOWindhelm - Lanterns of Skyrim Patch.esp'
     clean:
       # version: 1.3
@@ -12217,10 +11621,6 @@ plugins:
         crc: 0x68DB9EF6
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 14
-    clean:
-      # version: 1.2
-      - crc: 0xEF776FE0
-        util: 'SSEEdit v4.0.2'
 
   - name: 'CaranthirTowerReborn.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/4269/' ]
@@ -12309,10 +11709,6 @@ plugins:
       - <<: *quickClean
         crc: 0xA312951A
         itm: 9
-    clean:
-      # version: 2.3
-      - crc: 0xE744B19A
-        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
   - name: 'Eli_RiverwoodShack.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6238/' ]
     msg:
@@ -12323,10 +11719,6 @@ plugins:
       - <<: *quickClean
         crc: 0xF8FD2B2D
         itm: 9
-    clean:
-      # version: 1.2
-      - crc: 0xA84FD4FB
-        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
   - name: 'Eli_Routa.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1193/' ]
     msg:
@@ -12341,13 +11733,6 @@ plugins:
       - <<: *quickClean
         crc: 0x89C6605C
         itm: 10
-    clean:
-      # version: 1.0
-      - crc: 0xB194F162
-        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
-      # version: 1.0 non stormcloak
-      - crc: 0x642A0C3C
-        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
   - name: 'Eli_Ruska.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/16177/' ]
     dirty:
@@ -12355,10 +11740,7 @@ plugins:
         crc: 0xD1CC4A86
         util: 'SSEEdit v3.2.84 EXPERIMENTAL'
         itm: 7
-    clean:
-      # version: 1.0
-      - crc: 0x8D0B7D5F
-        util: 'SSEEdit v3.2.84 EXPERIMENTAL'
+
   - name: 'ElysiumEstate-HF(NoKids)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/4119/' ]
     msg:
@@ -12513,10 +11895,6 @@ plugins:
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 14
         udr: 8
-    clean:
-      # version: 3.1
-      - crc: 0x17FA99E1
-        util: 'SSEEdit v4.0.2'
   - name: 'Hidden Homes- Falkreath.esp'
     dirty:
       # version: 3.1
@@ -12524,10 +11902,6 @@ plugins:
         crc: 0xF2AAE996
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
-    clean:
-      # version: 3.1
-      - crc: 0x9AF6C7BF
-        util: 'SSEEdit v4.0.2'
   - name: 'Hidden Homes- Haafingar.esp'
     dirty:
       # version: 3.1
@@ -12536,10 +11910,6 @@ plugins:
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 6
         udr: 1
-    clean:
-      # version: 3.1
-      - crc: 0x7F4C4B37
-        util: 'SSEEdit v4.0.2'
   - name: 'Hidden Homes- Hjaalmarch.esp'
     dirty:
       # version: 3.1
@@ -12547,10 +11917,6 @@ plugins:
         crc: 0xF06F06D4
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 7
-    clean:
-      # version: 3.1
-      - crc: 0x978F8DFD
-        util: 'SSEEdit v4.0.2'
   - name: 'Hidden Homes- The Pale.esp'
     dirty:
       # version: 3.1
@@ -12571,10 +11937,6 @@ plugins:
         crc: 0x2490FF1B
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
-    clean:
-      # version: 3.1
-      - crc: 0x802B0D4D
-        util: 'SSEEdit v4.0.2'
   - name: 'Hidden Homes- The Rift.esp'
     dirty:
       # version: 3.1
@@ -12582,10 +11944,6 @@ plugins:
         crc: 0xCA506944
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 124
-    clean:
-      # version: 3.1
-      - crc: 0x4D21E0D1
-        util: 'SSEEdit v4.0.2'
   - name: 'Hidden Homes- Whiterun.esp'
     dirty:
       # version: 3.1
@@ -12594,10 +11952,6 @@ plugins:
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
         udr: 3
-    clean:
-      # version: 3.1
-      - crc: 0x493B8883
-        util: 'SSEEdit v4.0.2'
   - name: 'Hidden Homes- Winterhold.esp'
     dirty:
       # version: 3.1
@@ -12621,10 +11975,6 @@ plugins:
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 102
         udr: 5
-    clean:
-      # version: 1.0
-      - crc: 0xEAE959E5
-        util: 'SSEEdit v4.0.2'
 
   - name: 'LC_BuildYourNobleHouse.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18308' ]
@@ -12724,10 +12074,7 @@ plugins:
         crc: 0x57B248AB
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      # version: 1.0
-      - crc: 0xECB898FE
-        util: 'SSEEdit v4.0.2'
+
   - name: 'ProudspiremanorTNFBP.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5276/' ]
     dirty:
@@ -12736,10 +12083,7 @@ plugins:
         crc: 0x2AE17DBF
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
-    clean:
-      # version: 1.0
-      - crc: 0x3FADCCE0
-        util: 'SSEEdit v4.0.0'
+
   - name: 'ProudspireSmithingRoom.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6012/' ]
     dirty:
@@ -12763,10 +12107,7 @@ plugins:
         crc: 0x79F28EB3
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 63
-    clean:
-      # version: 1.0
-      - crc: 0xA2C2A003
-        util: 'SSEEdit v4.0.0'
+
   - name: 'proudspirebasementcrypt.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12158/' ]
     dirty:
@@ -12791,10 +12132,7 @@ plugins:
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 21
         udr: 18
-    clean:
-      # version: 1.0
-      - crc: 0xC7F23915
-        util: 'SSEEdit v4.0.0'
+
   - name: 'Riftrun_HF_v_2_0.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/757/' ]
     after:
@@ -12855,10 +12193,6 @@ plugins:
         crc: 0xDB9E70DA
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 6
-    clean:
-      # version: 1.0
-      - crc: 0x67A6845B
-        util: 'SSEEdit v4.0.0'
 
   - name: 'The Crossroads Cellar.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9367' ]
@@ -12884,10 +12218,7 @@ plugins:
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 209
         udr: 23
-    clean:
-      # version: 1.8, after QAC
-      - crc: 0xEE1E8389
-        util: 'SSEEdit v4.0.2'
+
   - name: 'Undriel_Ebongrove.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/17396/' ]
     dirty:
@@ -12896,10 +12227,7 @@ plugins:
         crc: 0xF14C7BA7
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 38
-    clean:
-      # version: 1.1.1
-      - crc: 0x40D0E678
-        util: 'SSEEdit v4.0.2'
+
   - name: 'UnlimitedBookshelves.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2885/' ]
     # Authors instructions: Load directly after Unofficial Skyrim Special Edition Patch.
@@ -12931,9 +12259,6 @@ plugins:
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 9
         udr: 4
-    clean:
-      - crc: 0xFDB326CD
-        util: 'SSEEdit v4.0.2'
 
 ###### Legacy of the Dragonborn ######
   - name: 'LegacyoftheDragonborn.esm'
@@ -13536,13 +12861,6 @@ plugins:
         crc: 0xFA9ADDF9
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      # version: 1.1.0
-      - crc: 0x5C12FE22
-        util: 'SSEEdit v4.0.0'
-      # version: 1.1.0, esp - ESL flagged
-      - crc: 0x57124060
-        util: 'SSEEdit v4.0.0'
 
 ###### Settlements Expanded SE ######
   - name: 'Settlements Expanded SE.*\.esp'
@@ -13683,10 +13001,6 @@ plugins:
         crc: 0xF43B0AB6
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1394
-    clean:
-      # version: 8.1.8
-      - crc: 0x5BBC6D85
-        util: 'SSEEdit v4.0.1'
 
   - name: '(tpos_complete02_RTCWG|thepeopleofskyrim)\.esp'
     url:


### PR DESCRIPTION
The crc will not match future versions of xEdit due to mark modified.
This only affects clean entries for dirty plugins.