### PR TITLE
Remove USSEP dependency on RSkyrimChildren.esm

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1533,7 +1533,6 @@ plugins:
     after:
       - name: 'Lanterns Of Skyrim - All In One - Main.esm'
         condition: 'checksum("Lanterns Of Skyrim - All In One - Main.esm", EB94B5F8)'
-      - 'RSkyrimChildren.esm'
     msg:
       - <<: *versionXIncY
         subs:


### PR DESCRIPTION
If RSkyrimChildren.esm is loaded before USSEP, SSE will spin on the load screen forever.

Got this tip from https://www.reddit.com/r/skyrimmods/comments/c3l4qx/stuck_on_main_screen_with_the_spinning_loading/ and found the fix to work for me.