### PR TITLE
Load Realistic Room Rental after Economy Overhaul

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11128,6 +11128,9 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/24859/'
         name: 'Perseids Inns and Taverns - Realistic Room Rental Enhanced'
+    after:
+      - 'EconomyOverhaulandSpeechcraftImprovements.esp'
+      - 'EconomyOverhaulandSpeechcraftImprovementsLite.esp'
   - name: 'RealisticRoomRental.esp'
     dirty:
       # version: 1.8.9.001


### PR DESCRIPTION
If [Realistic Room Rental](https://www.nexusmods.com/skyrimspecialedition/mods/24859) does not load after [Economy Overhaul](https://www.nexusmods.com/skyrimspecialedition/mods/9542), its scripts cannot use varied inn costs in the MCM settings for each inn. It will instead use Economy Overhaul's fixed 25 septims for every inn.