### PR TITLE
Lore Worthy Bandits load order

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6197,6 +6197,7 @@ plugins:
         name: '(SJG) OMEGA - The Modular Gameplay Overhaul'
     group: *economyGroup
     after:
+      - 'LoreWorthyBandits.esp'
       - 'Weapon AF.esp'
       - 'WACCF_Armor and Clothing Extension.esp'
       - 'Weapons Armor Clothing & Clutter Fixes.esp'


### PR DESCRIPTION
Lore Worthy Bandits' author recommends the mod to be loaded before MLU to get varied bandits with different gears in line with MLU.