### PR TITLE
Allow RS Children ESM to be sorted after USSEP

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1508,7 +1508,6 @@ plugins:
     after:
       - name: 'Lanterns Of Skyrim - All In One - Main.esm'
         condition: 'checksum("Lanterns Of Skyrim - All In One - Main.esm", EB94B5F8)'
-      - 'RSkyrimChildren.esm'
     msg:
       - <<: *versionXIncY
         subs:
@@ -3341,7 +3340,7 @@ plugins:
 
   - name: 'RSkyrimChildren.esm'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2650' ]
-    group: *veryEarlyGroup
+    group: *preVeryEarlyGroup
     msg:
       - <<: *patchIncluded
         subs: [ 'Beyond Skyrim - Bruma' ]


### PR DESCRIPTION
I've tested this order and have no issue with getting to the main menu.

`RSkyrimChildren.esm`
`Unofficial Skyrim Special Edition Patch.esp`
`RSChildren.esp`
`RSC_USSEP_AventusFix.esp`

As long as the unresolved reference is fixed.
By using the RSC_USSEP_AventusFix.esp or by removing the
unresolved package from RSChildren.esp.

If you still have the unresolved reference.
This load order will get to the main menu.

`Unofficial Skyrim Special Edition Patch.esp`
`RSkyrimChildren.esm`
`RSChildren.esp`

If I had to guess as to why users are still having issues, there must 
still be something else in their load order that is referencing that
deleted package.

`RSkyrimChildren.esm`
`Unofficial Skyrim Special Edition Patch.esp`
`RSChildren.esp`
`RSC_USSEP_AventusFix.esp`
`modX.esp`

And changing the order is getting them to the main menu.
While not fixing the actual issue.

`Unofficial Skyrim Special Edition Patch.esp`
`RSkyrimChildren.esm`
`RSChildren.esp`
`RSC_USSEP_AventusFix.esp`
`modX.esp`