### PR TITLE
Add Smildon load order

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4407,6 +4407,7 @@ plugins:
       - 'Skyrim Immersive Creatures Special Edition.esp'
       - 'WICO - Immersive People.esp'
       - 'Wildcat - Combat of Skyrim.esp'
+      - 'Smilodon - Combat of Skyrim.esp'
     msg:
       - <<: *patchProvided
         subs: [ 'Skyrim Immersive Creatures' ]
@@ -5621,6 +5622,8 @@ plugins:
       - *includesMBBF
   - name: 'Smilodon - Combat of Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2824/' ]
+    after:
+      - 'UltimateCombat.esp'
     msg:
       - <<: *compatNotes
         subs: [ 'https://www.nexusmods.com/skyrimspecialedition/articles/119' ]
@@ -5654,6 +5657,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1876/' ]
     after:
       - 'Wildcat - Combat of Skyrim.esp'
+      - 'Smilodon - Combat of Skyrim.esp'
     msg:
       - <<: *patch3rdParty
         subs:


### PR DESCRIPTION
- SRCEO's combat style should overwrite Smilodon's to make boss fight work properly.
- Smildon's author recommends Vigor to be loaded after Smilodon.
- Smildon provides more detailed changes of combat style so the author recommends it to be loaded after Ultimate Combat.

Source: https://www.nexusmods.com/skyrimspecialedition/articles/119