### PR TITLE
Sort MCWT Friendly Faralda after More idle markers

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11406,6 +11406,7 @@ plugins:
       - crc: 0x116B6B2F
         util: 'SSEEdit v4.0.2'
   - name: 'MCWT_FriendlyFaralda.esp'
+    after: [ 'More idle markers.esp' ]
     msg:
       - <<: *alreadyInX
         subs: [ 'Improved College Entry - Questline Tweaks' ]


### PR DESCRIPTION
https://www.nexusmods.com/skyrimspecialedition/articles/906

Minor Conflict:
Tavern Idles edits Faralda's package to make her not always be at the foot of the bridge. Recommended to load FF after it to overwrite TI's changes.

https://user-images.githubusercontent.com/1944639/66257679-22691980-e794-11e9-88bd-879d5f1f78cb.png