### PR TITLE
Add Survival Mode patches for some popular mods

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1536,6 +1536,36 @@ plugins:
           - 'Weapons Armor Clothing and Clutter Fixes'
           - '[ kryptopyr''s Patch Hub ](https://www.nexusmods.com/skyrimspecialedition/mods/19518)'
         condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp") and not active("WACCF_Survival Mode_Patch.esp") and not active("Complete Alchemy & Cooking Overhaul.esp")'
+      - <<: *patch3rdParty
+        subs:
+          - 'Cloaks of Skyrim'
+          - '[ Conner''s Survival Mode patches ](https://www.nexusmods.com/skyrimspecialedition/mods/19154)'
+        condition: 'active("Cloaks.esp") and not active("Survival Mode Patches - Cloaks Of Skyrim.esp")'
+      - <<: *patch3rdParty
+        subs:
+          - 'Winter Is Coming'
+          - '[ Conner''s Survival Mode patches ](https://www.nexusmods.com/skyrimspecialedition/mods/19154)'
+        condition: 'active("1nivWICCloaks.esp") and not active("Survival Mode Patches - Winter Is Coming.esp")'
+      - <<: *patch3rdParty
+        subs:
+          - 'Campfire'
+          - '[ Conner''s Survival Mode patches ](https://www.nexusmods.com/skyrimspecialedition/mods/19154)'
+        condition: 'active("Campfire.esm") and not active("Survival Mode Patches - Campfire.esp")'
+      - <<: *patch3rdParty
+        subs:
+          - 'Beasts of Tamriel'
+          - '[ Conner''s Survival Mode patches ](https://www.nexusmods.com/skyrimspecialedition/mods/19154)'
+        condition: 'active("Beasts of Tamriel.esp") and not active("Survival Mode Patches - Beasts Of Tamriel.esp")'
+      - <<: *patch3rdParty
+        subs:
+          - 'Be a Milk Drinker'
+          - '[ Conner''s Survival Mode patches ](https://www.nexusmods.com/skyrimspecialedition/mods/19154)'
+        condition: 'active("MilkSSE.esp.esp") and not active("Survival Mode Patches - Be A Milk Drinker.esp")'
+      - <<: *patch3rdParty
+        subs:
+          - 'Google''s ESO Provisioning'
+          - '[ Conner''s Survival Mode patches ](https://www.nexusmods.com/skyrimspecialedition/mods/19154)'
+        condition: 'active("GPProvisioning.esp") and not active("Survival Mode Patches - Google''s ESO Provisioning.esp")'
       - <<: *semiCompatible
         subs:
           - '[Unlimited Bookshelves](https://www.nexusmods.com/skyrimspecialedition/mods/2885/)'


### PR DESCRIPTION
Nexus user Conner has made [some patches for popular mods](https://www.nexusmods.com/skyrimspecialedition/mods/19154) to get them to work nicely with Survival Mode, but LOOT doesn't know about these patches to recommend them.

I think I did this right - I'm not unfamiliar with YAML, but I'm far from an expert. I didn't do all the patches, because I looked at the file listing for Zim's Immersive Artifacts and laziness descended on me like a storm cloud. Sorry.