### PR TITLE
Sort Better Quest Objectives after Quests are in Skyrim

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8075,6 +8075,9 @@ plugins:
       - 'https://bethesda.net/en/mods/skyrim/mod-detail/2954089'
   - name: 'BetterQuestObjectives.esp'
     group: *underridesGroup
+    after:
+      - 'QuestsAreInSkyrim.esp'
+      - 'QuestsAreInSkyrimUSSEP.esp'
     msg:
       - <<: *patchIncluded
         subs: [ 'Alternate Start' ]
@@ -8489,6 +8492,10 @@ plugins:
         crc: 0xE4C4B73B
         util: '[SSEEdit v4.0.2](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 6
+
+  - name: 'QuestsAreInSkyrim(USSEP)?\.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18416/' ]
+    group: *underridesGroup
 
   - name: 'Religion.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/67663/' ]


### PR DESCRIPTION
#885
+ Moved Quests are in Skyrim to underrides group to avoid sorting errors.