### PR TITLE
Add DynDOLOD.esm to Dynamic LOD group

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1869,6 +1869,7 @@ plugins:
       - 'http://forum.step-project.com/topic/13029-dyndolod-236-skyrim-se-beta-with-dynamic-lod/'
     group: *dynamicLODGroup
   - name: 'DynDOLOD.esm'
+    group: *dynamicLODGroup
     req:
       - name: 'SKSE/Plugins/PapyrusUtil.dll'
         display: '[PapyrusUtil SE](https://www.nexusmods.com/skyrimspecialedition/mods/13048/) or [DynDOLOD .DLL SSE](https://forum.step-project.com/topic/13716-dyndolod-dll/)'


### PR DESCRIPTION
Quote taken from DynDOLOD_Manual_SSE.html

> **Load/Overwrite Orders**
> 
> Generated DynDOLOD.esm and DynDOLOD.esp can be sorted by LOOT or manually. Typically DynDOLOD.esm should be the last ESM (and after the Unofficial Skyrim Special Edition Patch even if it is not a master in DynDOLOD.esm) and DynDOLOD.esp the last ESP for the entire load order.
> 
> The DynDOLOD.esm contains only overwrites/data from other ESM files, including master flagged ESP/ESL. The DynDOLOD.esp overwrites/contains data from the entire load order.
> 
> Note that Skyrim Special Edition may enforce its own plugin load order over the one set by whatever mod manager is used. Check the in-game load order to verify.