### PR TITLE
Update CC plugin regex pattern

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -797,7 +797,7 @@ globals:
         text: 'В этой версии LOOT плагины Creation Club обрабатываются хуже. Поэтому их поддержка ограничена до версии LOOT 0.13.1. Рекомендуется обновить как можно скорее.'
       - lang: sv
         text: 'Denna version av LOOT har sämre hantering av Creation Club plugins. Stöd för dessa är därför begränsad i versionen tidigare än LOOT 0.13.1. Du rekommenderas att uppdatera så snart som möjligt.'
-    condition: 'version("LOOT", "0.13.1.0", <) and file("cc[A-Z]{3}FO4[0-9]{3}-[a-zA-Z0-9()]+\.es(l|m)")'
+    condition: 'version("LOOT", "0.13.1.0", <) and file("cc[A-Z]{3}SSE[0-9]{3}.*\.es(l|m)")'
   - type: say
     content:
       - lang: en
@@ -1343,9 +1343,7 @@ plugins:
       - 'Dragonborn.esm'
 
 ###### Creation Club ######
-  - name: 'cc(bgs|eej|twb)sse.*\.esm'
-    group: *ccGroup
-  - name: 'cc(bgs|edh|eej|ffb|fsv|mty|pew|qdr|rms|vsv)sse.*\.esl'
+  - name: 'cc[A-Z]{3}SSE[0-9]{3}.*\.es(l|m)'
     group: *ccGroup
   # Adventurer's Backpack
   - name: 'ccfsvsse001-backpacks.esl'


### PR DESCRIPTION
Updated LOOT inferior handling message condition.
- Replaced _FO4_ with _SSE_.
- Replaced capture group with wildcard to match plugins with an underscore `ccbgssse057-ba_stalhrim.esl`
Replaced CC group assignment regex pattern.