### PR TITLE
Add ENB Light.esp

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2576,6 +2576,13 @@ plugins:
       - name: 'RLO - Interiors.esp'
         condition: 'not file("Realistic Lighting Overhaul - Major City Interiors.esp")'
 
+  - name: 'ENB Light.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/22574' ]
+    after:
+      - 'ELE_SSE.esp'
+    req:
+      - 'Particle Patch for ENB SSE.esp'
+
   - name: 'ImprovedHearthfireLighting.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/721' ]
     group: *underridesGroup


### PR DESCRIPTION
Add dependencies for ENB Light. Possibly needs bash tags, also has a UPF patcher, which might require a message.