### PR TITLE
Load Diverse Skyrim after Kireina to avoid black face problem

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5172,6 +5172,9 @@ plugins:
 
   - name: 'DIVERSE SKYRIM.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/7707/' ]
+    after:
+      - 'Kireina SSE.esl'
+      - 'Kireina SSE.esp'
     tag:
       - Delev
       - Relev


### PR DESCRIPTION
Diverse Skyrim needs to be loaded after Kireina that changes the default facegen of NPCs in order to fix black face problem.