### PR TITLE
Load Skyrim Revamped after Lore Worthy Bandits

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7192,7 +7192,9 @@ plugins:
 
   - name: 'Skyrim Revamped.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/14338/' ]
-    after: [ 'mrbs-uniqueloot-se.esp' ]
+    after:
+      - 'LoreWorthyBandits.esp'
+      - 'mrbs-uniqueloot-se.esp'
     tag:
       - Delev
       - Invent


### PR DESCRIPTION
Skyrim Revamped rebalances loots and it should not be overwritten by Lore Worthy Bandits. It is the same reason as why Lore Worthy Bandits' author recommends Morrowloot to be loaded after his mod.