### PR TITLE
Add VR perk extender requirement for Economy Overhaul complete version

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6862,6 +6862,10 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9542/' ]
     after: [ 'You Hunger.esp' ]
   - name: 'EconomyOverhaulandSpeechcraftImprovements.esp'
+    req:
+      - name: 'SKSE/Plugins/VRPerkExtender.dll'
+        display: '[VR Perk Extender](https://www.nexusmods.com/skyrimspecialedition/mods/16330/)'
+        condition: 'file("SkyrimVR.esm")'
     msg:
       - <<: *patchIncluded
         subs: [ 'Complete Alchemy & Cooking Overhaul' ]


### PR DESCRIPTION
Skyrim VR CTD'd when it ran Economy Overhaul Complete version without VR perk extender because the complete version added many perks to speech tree.