### PR TITLE
Group changes for early loaders

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5740,7 +5740,7 @@ plugins:
 
   - name: 'TerrainLodRedone.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9135/' ]
-    group: *veryEarlyGroup
+    group: *fixesGroup
 
   - name: 'Trees in Cities.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1941/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1659,12 +1659,12 @@ plugins:
       - crc: 0xD0948CCF
         util: 'SSEEdit v4.0.3'
   - name: 'Skyrim Project Optimization - Full Version.esp'
-    group: *veryEarlyGroup
+    group: *fixesGroup
     clean:
       - crc: 0x137A03B3
         util: 'SSEEdit v4.0.3'
   - name: 'Skyrim Project Optimization - No Homes - Full Version.esp'
-    group: *veryEarlyGroup
+    group: *fixesGroup
     clean:
       - crc: 0x81A0DD15
         util: 'SSEEdit v4.0.3'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -993,12 +993,8 @@ groups:
       - *preEarlyGroup
       - *fixesGroup
 
-  - name: &underridesGroup Underrides
-
   - name: default
-    after:
-      - *earlyLoadersGroup
-      - *underridesGroup
+    after: [ *earlyLoadersGroup ]
 
   - name: &floraGroup Flora
     description: 'A group for mods that add, remove or improve grass, plants and Trees.'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11179,7 +11179,7 @@ plugins:
 
   - name: 'Bee Hives.esp'
     url: [ 'https://www.afkmods.com/index.php?/files/file/1891-bee-hives//' ]
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     clean:
       # version: 2.0.3
       - crc: 0x9774E2CE

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8365,7 +8365,7 @@ plugins:
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/159'
       - 'https://bethesda.net/en/mods/skyrim/mod-detail/2954089'
   - name: 'BetterQuestObjectives.esp'
-    group: *underridesGroup
+    group: *earlyLoadersGroup
     after:
       - 'QuestsAreInSkyrim.esp'
       - 'QuestsAreInSkyrimUSSEP.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9395,8 +9395,8 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18177'
         name: 'QUARK - Qwinn''s Ultimate Amulet Restoration Kit'
-
     # Must sort before WACCF Armor and Clothing Extension
+
   - name: 'WACCF_Armor and Clothing Extension.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/19002/' ]
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2751,7 +2751,7 @@ plugins:
 
   - name: 'LSFX-SSE-Audiosettings.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1841/' ]
-    group: *veryEarlyGroup
+    group: *fixesGroup
     clean:
       - crc: 0x8018F548
         util: 'SSEEdit v4.0.3'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5340,7 +5340,7 @@ plugins:
 
   - name: 'Gildergreen Regrown.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/348/' ]
-    group: *underridesGroup
+    group: *earlyLoadersGroup
     clean:
       # version: 2.0.1
       - crc: 0x8627D73D

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5228,7 +5228,7 @@ plugins:
 
   - name: 'Destructible Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/28291/' ]
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     dirty:
       # version: 0.4
       - <<: *quickClean

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -979,11 +979,8 @@ groups:
   - name: &ccGroup Creation Club
     after: [ *dlcGroup ]
 
-  - name: &preVeryEarlyGroup Pre Very Early (Patches/Add-ons)
-    after: [ *ccGroup ]
-
   - name: &veryEarlyGroup Very Early Loaders
-    after: [ *preVeryEarlyGroup ]
+    after: [ *ccGroup ]
 
   - name: &floraGroup Flora
     description: 'A group for mods that add, remove or improve grass, plants and Trees.'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9576,7 +9576,7 @@ plugins:
 
   - name: 'Circlets and Masks with all Robes and Hoods.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/3732/' ]
-    group: *veryEarlyGroup
+    group: *fixesGroup
     tag:
       - Graphics
       - Names

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5381,7 +5381,7 @@ plugins:
 
   - name: 'Immersive Farms.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/19026' ]
-    group: *floraGroup
+    group: *earlyLoadersGroup
     dirty:
       # version: 1.1
       - <<: *quickClean

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1509,7 +1509,7 @@ plugins:
       - 'https://www.afkmods.com/index.php?/files/file/1888-unofficial-skyrim-special-edition-patch/'
       - 'https://bethesda.net/en/mods/skyrim/mod-detail/2947658'
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/266/'
-    group: *veryEarlyGroup
+    group: *fixesGroup
     after:
       - name: 'Lanterns Of Skyrim - All In One - Main.esm'
         condition: 'checksum("Lanterns Of Skyrim - All In One - Main.esm", EB94B5F8)'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1542,7 +1542,7 @@ plugins:
   ### Unofficial Creation Club Updates ###
   - name: 'JRCCPatches.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12951/' ]
-    group: *preVeryEarlyGroup
+    group: *fixesGroup
     inc: [ 'unofficial skyrim creation club content patch.esl' ]
   - name: 'JR(SpellPack|ArcaneArcherPack|Chrysamere|KnightsOfTheNine|DwarvenMudcrab|Zombies|RuinsEdge|Shadowrend|StaffOfSheogorath|StendarrsHammer)(Patch)?\.esp'
     inc: [ 'unofficial skyrim creation club content patch.esl' ]
@@ -1560,11 +1560,11 @@ plugins:
     inc: [ 'Unofficial Arcane Archer Pack Patch.esl' ]
   - name: 'JRSpellPackPatch.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12748/' ]
-    group: *preVeryEarlyGroup
+    group: *fixesGroup
     inc: [ 'Unofficial Arcane Accessories Patch.esl' ]
   - name: 'JRStendarrsHammerPatch.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12750/' ]
-    group: *preVeryEarlyGroup
+    group: *fixesGroup
 
   ### Unofficial Skyrim Creation Club Content Patches ###
   - name: 'Unofficial (Skyrim Creation Club Content|Arcane Accessories|Arcane Archer Pack|Arms of Chaos|Bone Wolf|Chrysamere|Civil War Champions|Daedric Mail Armor|Dawnfang and Duskfang|Dead Man''s Dread|Divine Crusader|Dragonscale Armor|Dwarven Armored Mudcrab|Dwarven Mail Armor|Ebony Plate Armor|Elite Crossbows|Elven Hunter Armor|Expanded Crossbow Pack|Forgotten Seasons|Goblins|Gray Cowl Returns|Hendraheim|Lord''s Mail|Myrwatch|Netch Leather Armors|Nix-Hound|Nordic Jewelry|Pets of Skyrim|Plague of the Dead|Rare Curios|Ruin''s Edge|Saints and Seducers|Saturalia Holiday Pack|Shadowfoot Sanctum|Shadowrend|Skyrim Survival|Spell Knight Armor|Staff of Hasedoki|Staff of Sheogorath|Stalhrim Fur Armor|Steel Soldier Armor|Stendarr''s Hammer|Sunder & Wraithguard|Tundra Homestead|Umbra|Vigil Enforcer Armor Set|Wild Horses) Patch.esl'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1852,6 +1852,7 @@ plugins:
     tag: [ Graphics ]
   - name: 'SMIM-SE-Merged-All.esp'
     after:
+      - 'AK - Placeable Statics SE.esp'
       - 'Blowing in the Wind SSE.esp'
       - 'Destructible Skyrim.esp'
     inc:
@@ -2297,6 +2298,7 @@ plugins:
   - name: 'ELFX - Exteriors.esp'
     group: *earlyLoadersGroup
     after:
+      - 'AK - Placeable Statics SE.esp'
       - 'Blowing in the Wind SSE.esp'
       - 'SMIM-SE-Merged-All.esp'
       - 'Prometheus_No_snow_Under_the_roof.esp'
@@ -5167,7 +5169,9 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5124' ]
   - name: 'Blowing in the Wind SSE.esp'
     group: *earlyLoadersGroup
-    after: [ 'Destructible Skyrim.esp' ]
+    after:
+      - 'AK - Placeable Statics SE.esp'
+      - 'Destructible Skyrim.esp'
     clean:
       # version: 2.04
       - crc: 0x8EF0F5D1
@@ -5230,6 +5234,7 @@ plugins:
   - name: 'Destructible Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/28291/' ]
     group: *earlyLoadersGroup
+    after: [ 'AK - Placeable Statics SE.esp' ]
     dirty:
       # version: 0.4
       - <<: *quickClean
@@ -5582,6 +5587,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/518/' ]
     group: *earlyLoadersGroup
     after:
+      - 'AK - Placeable Statics SE.esp'
       # Group afters to avoid sorting errors.
       - 'Blowing in the Wind SSE.esp'
       - 'SMIM-SE-Merged-All.esp'
@@ -14289,7 +14295,7 @@ plugins:
 
   - name: 'AK - Placeable Statics SE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/342/' ]
-    group: *preVeryEarlyGroup
+    group: *earlyLoadersGroup
 
   - name: 'AlchemistRetreat.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/29358/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -15853,7 +15853,7 @@ plugins:
   - name: 'UnlimitedBookshelves.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2885/' ]
     # Authors instructions: Load directly after Unofficial Skyrim Special Edition Patch.
-    group: *veryEarlyGroup
+    group: *fixesGroup
     msg:
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_UnlimitedBookshelves_Patch.esp") and (version("LegacyoftheDragonborn.esm", "5.0.24", >=) or (not checksum("LegacyoftheDragonborn.esm", 31563183) and not checksum("LegacyoftheDragonborn.esm", 6736FB94) and not checksum("LegacyoftheDragonborn.esm", CB82480D)))'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5720,7 +5720,6 @@ plugins:
 
   - name: 'SmoothShores.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10624/' ]
-    group: *floraGroup
     dirty:
       - <<: *quickClean
         crc: 0x3CC7601F

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2346,7 +2346,7 @@ plugins:
         util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 1
   - name: 'ELFX - Weathers.esp'
-    group: *underridesGroup
+    group: *earlyLoadersGroup
     after: [ 'Audio Overhaul Skyrim.esp' ]
     clean:
       - crc: 0x0F02A920
@@ -2621,7 +2621,7 @@ plugins:
       - C.ImageSpace
       - C.Light
   - name: 'Realistic Lighting Overhaul - Weathers.esp'
-    group: *underridesGroup
+    group: *earlyLoadersGroup
     tag: [ Graphics ]
   - name: 'RLO - Major City Exteriors - No Guard Torches.esp'
     tag: [ Invent ]
@@ -3144,7 +3144,7 @@ plugins:
 
   - name:  'Dolomite Weathers.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/7895/' ]
-    group: *underridesGroup
+    group: *earlyLoadersGroup
     clean:
       - crc: 0x87498763
         util: 'SSEEdit v4.0.3'
@@ -3176,7 +3176,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/12842/'
         name: 'NAT - Natural and Atmospheric Tamriel'
-    group: *underridesGroup
+    group: *earlyLoadersGroup
     after: [ 'Audio Overhaul Skyrim.esp' ]
     inc:
       - 'Aequinoctium.esp'
@@ -3240,7 +3240,7 @@ plugins:
 
   - name: 'Obsidian Weathers.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12125/' ]
-    group: *underridesGroup
+    group: *earlyLoadersGroup
     after:
       - 'Audio Overhaul Skyrim.esp'
       - name: 'TrueStormsSE.esp'
@@ -3364,7 +3364,7 @@ plugins:
 
   - name: 'TrueStormsSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2472/' ]
-    group: *underridesGroup
+    group: *earlyLoadersGroup
     after:
       - 'Audio Overhaul Skyrim.esp'
       - 'ELFX - Weathers.esp'
@@ -3559,7 +3559,7 @@ plugins:
   - name: 'Vivid Weathers(SE| SE -| - ).*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2187/' ]
   - name: 'Vivid WeathersSE.esp'
-    group: *underridesGroup
+    group: *earlyLoadersGroup
     after: [ 'Audio Overhaul Skyrim.esp' ]
     inc:
       - 'Aequinoctium.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5041,7 +5041,7 @@ plugins:
 
   - name: 'Ducks and Swans.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2149/' ]
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     msg:
       - <<: *patch3rdPartyQUASIPC
         subs: [ 'Unofficial Skyrim Special Edition Patch' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4384,7 +4384,6 @@ plugins:
 
   - name: 'Ambriel.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/969/' ]
-    group: *addonsGroup
     dirty:
       # version: AQSE1.06
       - <<: *reqManualFix

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6241,7 +6241,7 @@ plugins:
         util: 'SSEEdit v4.0.3'
   - name: 'URN Extended.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/11750/' ]
-    group: *veryEarlyGroup
+    group: *fixesGroup
     clean:
       - crc: 0xE05F27B6
         util: 'SSEEdit v4.0.3'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5703,7 +5703,7 @@ plugins:
 
   - name: 'SkyrimImprovedPuddles-DG-HF-DB.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1462/' ]
-    group: *veryEarlyGroup
+    group: *fixesGroup
 
   - name: 'SkyrimIsWindy.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5836/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1801,7 +1801,7 @@ plugins:
       - crc: 0x70E9C0E7
         util: 'SSEEdit v4.0.3'
   - name: 'dD - Enhanced Blood Main LITE.esp'
-    group: *veryEarlyGroup
+    group: *fixesGroup
     clean:
       - crc: 0x6CF176EC
         util: 'SSEEdit v4.0.3'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6792,7 +6792,7 @@ plugins:
 
   - name: 'DLCIntegration.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/8032/' ]
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     msg:
       - <<: *patchProvided
         subs: [ 'Beyond Skyrim DLC Integration' ]
@@ -6811,7 +6811,7 @@ plugins:
         util: 'SSEEdit v4.0.2f'
   - name: 'DLCIntegration Beyond Skyrim Compatibility Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/8032/' ]
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     clean:
       # version: 1.1
       - crc: 0x32F4BBE5

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2681,8 +2681,6 @@ plugins:
         crc: 0x1E22FDD6
         util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 37
-  - name: 'Audio Overhaul Skyrim - Legacy of the Dragonborn Patch.esp'
-    group: *underridesGroup
   - name: 'Audio Overhaul Skyrim - Obsidian Weathers Patch.esp'
     after:
       - 'Audio Overhaul Skyrim - True Storms.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6192,7 +6192,7 @@ plugins:
       - crc: 0x9B010343
         util: 'SSEEdit v4.0.3'
   - name: 'thepeopleofskyrim.esp'
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     inc:
       - 'Immersive Patrols II.esp'
       - 'tpos_Cutting_Room_Floorpatch.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5344,7 +5344,7 @@ plugins:
 
   - name: 'Grass Field.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/17909' ]
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
 
   - name: 'HearthfireGrassFix.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/13461/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4918,7 +4918,9 @@ plugins:
 
   - name: 'OBIS SE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/4145' ]
-    after: [ 'DIVERSE SKYRIM.esp' ]
+    after:
+      - 'Cloaks.esp'
+      - 'DIVERSE SKYRIM.esp'
     msg:
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_OBIS_Patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -15610,7 +15610,7 @@ plugins:
 
   - name: 'Shadowmarks.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/353/' ]
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     clean:
       # version: 2.0.1
       - crc: 0x802F5628

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6202,14 +6202,14 @@ plugins:
 
   - name: 'WARZONES - SSE - Civil Unrest.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2360' ]
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     clean:
       # version: 0.94
       - crc: 0xD755C4B7
         util: 'SSEEdit v4.0.3'
   - name: 'WARZONES - SSE - DLC - Assault Attack.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2365/' ]
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     dirty:
       # version: 1.0
       - <<: *quickClean

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1570,7 +1570,7 @@ plugins:
   ### Unofficial Skyrim Creation Club Content Patches ###
   - name: 'Unofficial (Skyrim Creation Club Content|Arcane Accessories|Arcane Archer Pack|Arms of Chaos|Bone Wolf|Chrysamere|Civil War Champions|Daedric Mail Armor|Dawnfang and Duskfang|Dead Man''s Dread|Divine Crusader|Dragonscale Armor|Dwarven Armored Mudcrab|Dwarven Mail Armor|Ebony Plate Armor|Elite Crossbows|Elven Hunter Armor|Expanded Crossbow Pack|Forgotten Seasons|Goblins|Gray Cowl Returns|Hendraheim|Lord''s Mail|Myrwatch|Netch Leather Armors|Nix-Hound|Nordic Jewelry|Pets of Skyrim|Plague of the Dead|Rare Curios|Ruin''s Edge|Saints and Seducers|Saturalia Holiday Pack|Shadowfoot Sanctum|Shadowrend|Skyrim Survival|Spell Knight Armor|Staff of Hasedoki|Staff of Sheogorath|Stalhrim Fur Armor|Steel Soldier Armor|Stendarr''s Hammer|Sunder & Wraithguard|Tundra Homestead|Umbra|Vigil Enforcer Armor Set|Wild Horses) Patch.esl'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18975/' ]
-    group: *underridesGroup
+    group: *fixesGroup
   - name: 'Unofficial Skyrim Creation Club Content Patch.esl'
     tag:
       - Keywords

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -989,20 +989,12 @@ groups:
   - name: &landscapeGroup Landscape
     description: 'A group for plugins that modify landscapes to fix issues and/or improve visuals.'
     after: [ *floraGroup ]
-
-  - name: &preAddonsGroup Pre Add-ons (Patches/Add-ons)
-
-  - name: &addonsGroup Add-ons & Expansions
-    after:
-      - *preAddonsGroup
-      - *veryEarlyGroup
-
   - name: &preFixesGroup Pre Fixes (Patches/Add-ons)
 
   - name: &fixesGroup Fixes & Resources
     after:
       - *preFixesGroup
-      - *addonsGroup
+      - *veryEarlyGroup
 
   - name: &preEarlyGroup Pre Early (Patches/Add-ons)
 
@@ -1018,6 +1010,12 @@ groups:
     after:
       - *earlyLoadersGroup
       - *underridesGroup
+
+
+  - name: &preAddonsGroup Pre Add-ons (Patches/Add-ons)
+
+  - name: &addonsGroup Add-ons & Expansions
+    after: [ *preAddonsGroup ]
 
   - name: &racesGroup Races & Classes
     description: 'A group for modules that modify character Races & Classes.'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4245,7 +4245,7 @@ plugins:
 ###### Character Appearance - Presets ######
   - name: 'AsharaSkyrimCharacterPresetsReplacer.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2406/' ]
-    group: *veryEarlyGroup
+    group: *fixesGroup
     inc:
       - 'Better_Male_Presets.esp'
       - 'Kayla_CharPreset.esp'
@@ -4265,7 +4265,7 @@ plugins:
 
   - name: 'Better_Male_Presets.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2001/' ]
-    group: *veryEarlyGroup
+    group: *fixesGroup
     inc: [ 'AsharaSkyrimCharacterPresetsReplacer.esp' ]
     msg:
       - type: say
@@ -4282,7 +4282,7 @@ plugins:
 
   - name: 'Kayla_CharPreset.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/3851/' ]
-    group: *veryEarlyGroup
+    group: *fixesGroup
     inc:
       - 'AsharaSkyrimCharacterPresetsReplacer.esp'
       - 'Lagertha_CharPreset.esp'
@@ -4303,7 +4303,7 @@ plugins:
 
   - name: 'Lagertha_CharPreset.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2629/' ]
-    group: *veryEarlyGroup
+    group: *fixesGroup
     inc:
       - 'Kayla_CharPreset.esp'
       - 'Lydia Face Preset 64bit.esp'
@@ -4323,7 +4323,7 @@ plugins:
 
   - name: 'Lydia Face Preset 64bit.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1080/' ]
-    group: *veryEarlyGroup
+    group: *fixesGroup
     inc:
       - 'AsharaSkyrimCharacterPresetsReplacer.esp'
       - 'Kayla_CharPreset.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3692,7 +3692,7 @@ plugins:
 
   - name: 'Hair Replacer( Assets)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/7409/' ]
-    group: *veryEarlyGroup
+    group: *fixesGroup
   - name: 'Hair Replacer Assets.esp'
     after: [ 'Hair Replacer.esp' ]
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4359,7 +4359,6 @@ plugins:
     url:
       - 'http://3dnpc.com/2017/11/20/3dnpc-v3-4-for-oldrim-and-sse/'
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/29194/'
-    group: *underridesGroup
     msg:
       - <<: *patch3rdParty_RSCPC
         condition: 'active("RSkyrimChildren.esm") and not active("RSC 3DNPC Patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2445,7 +2445,6 @@ plugins:
 
   - name: 'EmbersHD.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/14368' ]
-    group: *underridesGroup
     after: [ 'CinematicFireFX.esp' ]
     clean:
       - crc: 0x68222B4D

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6410,7 +6410,7 @@ plugins:
 
   - name: 'Mortal Enemies( - No RunWalk Changes| - Rival Remix( - NoRunWalkChanges)?| - 2.0 Test Version)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/4881' ]
-    group: *underridesGroup
+    group: *earlyLoadersGroup
     after: [ 'Immersive Movement.esp' ]
     msg:
       - <<: *useOnlyOneX

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3798,7 +3798,7 @@ plugins:
 
   - name: 'RSkyrimChildren.esm'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2650' ]
-    group: *preVeryEarlyGroup
+    group: *fixesGroup
     msg:
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_RSChildren_Patch.esp") and (version("LegacyoftheDragonborn.esm", "5.0.24", >=) or (not checksum("LegacyoftheDragonborn.esm", 31563183) and not checksum("LegacyoftheDragonborn.esm", 6736FB94) and not checksum("LegacyoftheDragonborn.esm", CB82480D)))'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2463,7 +2463,6 @@ plugins:
 
   - name: 'ImprovedHearthfireLighting.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/721' ]
-    group: *underridesGroup
     clean:
       - crc: 0xA71A75BB
         util: 'SSEEdit v4.0.3'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2915,7 +2915,7 @@ plugins:
 
   - name: 'SoS - The Dungeons.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/8091/' ]
-    group: *underridesGroup
+    group: *earlyLoadersGroup
     after: [ 'LSFX-SSE-Audiosettings.esp' ]
     inc: [ 'SoundsofSkyrimComplete.esp' ]
     tag: [ Sound ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2039,7 +2039,7 @@ plugins:
     url:
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/12604/'
       - 'https://github.com/Odie/skyui-vr/releases/'
-    group: *underridesGroup
+    group: *fixesGroup
     req:
       - *SKSE
       - *SKSE_VR

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1606,7 +1606,7 @@ plugins:
 
   - name: 'FloraRespawnFix.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/13186/' ]
-    group: *floraGroup
+    group: *fixesGroup
     msg:
       - <<: *patch3rdPartyQUASIPC
         subs: [ 'Ars Metallica' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12149,7 +12149,7 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/13552'
         name: 'Expanded Towns and Cities (SSE)'
   - name: 'ETaC - RESOURCES.esm'
-    group: *veryEarlyGroup
+    group: *fixesGroup
     tag: [ Graphics ]
     clean:
       # version: 0.4.4 MCM

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5165,22 +5165,22 @@ plugins:
   - name: 'Blowing in the Wind.*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5124' ]
   - name: 'Blowing in the Wind SSE.esp'
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     after: [ 'Destructible Skyrim.esp' ]
     clean:
       # version: 2.04
       - crc: 0x8EF0F5D1
         util: 'SSEEdit v4.0.0'
   - name: 'Blowing in the Wind - ELFX Exterior patch.esp'
-    group: *preVeryEarlyGroup
+    group: *preEarlyGroup
   - name: 'Blowing in the Wind - ELFX Exteriors Patch SSE.esp'
-    group: *preVeryEarlyGroup
+    group: *preEarlyGroup
   - name: 'Blowing in the Wind - Lanterns of Skyrim Patch SSE.esp'
-    group: *preVeryEarlyGroup
+    group: *preEarlyGroup
   - name: 'Blowing in the Wind - Lanterns of Skyrim SE - MCM versionPatch.esp'
-    group: *preVeryEarlyGroup
+    group: *preEarlyGroup
   - name: 'Blowing in the Wind - SMIM Merged All Patch SSE.esp'
-    group: *preVeryEarlyGroup
+    group: *preEarlyGroup
 
   - name: 'Cathedral Concept - Lightweight Grass Overhaul.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/21954/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10027,7 +10027,7 @@ plugins:
       - crc: 0x0D7685E5
         util: 'SSEEdit v4.0.2f'
   - name: 'Lore Weapon Expansion - (Daedric Crescent|Goldbrand|Relics of the Crusader)\.esp'
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     inc: [ *LotD_v5 ]
   - name: 'Lore Weapon Expansion - Daedric Crescent.esp'
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10769,7 +10769,6 @@ plugins:
         itm: 514
   - name: 'BS_DLC_patch.esp'
     url: [ 'https://bethesda.net/en/mods/skyrim/mod-detail/4044167' ]
-    group: *veryEarlyGroup
     msg:
       - <<: *patch3rdPartyQUASIPC
         subs: [ 'Unofficial Skyrim Special Edition Patch' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5059,7 +5059,7 @@ plugins:
 
   - name: 'Immersive Wenches.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/595/' ]
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     tag: [ C.LockList ]
     msg:
       - <<: *patchProvided

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5020,7 +5020,7 @@ plugins:
 
   - name: '(CollegeStudents|ICNs_ImmersiveCollegeNPCs)\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9252/' ]
-    group: *underridesGroup
+    group: *earlyLoadersGroup
   - name: 'ICNs_ImmersiveCollegeNPCs.esp'
     clean:
       # version: 1.1.1

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1842,12 +1842,12 @@ plugins:
       - C.ImageSpace
 
   - name: 'static mesh improvement mod se.esp'
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
   - name: 'SMIM-SE.*\.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/659/'
         name: 'Static Mesh Improvement Mod SE'
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     tag: [ Graphics ]
   - name: 'SMIM-SE-Merged-All.esp'
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5579,7 +5579,7 @@ plugins:
 
   - name: 'Prometheus_No_snow_Under_the_roof.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/518/' ]
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     after:
       # Group afters to avoid sorting errors.
       - 'Blowing in the Wind SSE.esp'
@@ -5599,7 +5599,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/15064/'
         name: 'No snow under the roof - Bug fixes'
-    group: *preVeryEarlyGroup
+    group: *preEarlyGroup
   - name: 'NSUTR_bugfixes.esp'
     clean:
       # version: 1.4

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -982,13 +982,6 @@ groups:
   - name: &veryEarlyGroup Very Early Loaders
     after: [ *ccGroup ]
 
-  - name: &floraGroup Flora
-    description: 'A group for mods that add, remove or improve grass, plants and Trees.'
-    after: [ *veryEarlyGroup ]
-
-  - name: &landscapeGroup Landscape
-    description: 'A group for plugins that modify landscapes to fix issues and/or improve visuals.'
-    after: [ *floraGroup ]
   - name: &preFixesGroup Pre Fixes (Patches/Add-ons)
 
   - name: &fixesGroup Fixes & Resources
@@ -1011,6 +1004,12 @@ groups:
       - *earlyLoadersGroup
       - *underridesGroup
 
+  - name: &floraGroup Flora
+    description: 'A group for mods that add, remove or improve grass, plants and Trees.'
+
+  - name: &landscapeGroup Landscape
+    description: 'A group for plugins that modify landscapes to fix issues and/or improve visuals.'
+    after: [ *floraGroup ]
 
   - name: &preAddonsGroup Pre Add-ons (Patches/Add-ons)
 
@@ -1019,9 +1018,7 @@ groups:
 
   - name: &racesGroup Races & Classes
     description: 'A group for modules that modify character Races & Classes.'
-    after:
-      - default
-      - *landscapeGroup
+    after: [ default ]
 
   - name: &economyGroup Economy
     description: 'A group for mods that alter the Economy of the game.'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -979,15 +979,12 @@ groups:
   - name: &ccGroup Creation Club
     after: [ *dlcGroup ]
 
-  - name: &veryEarlyGroup Very Early Loaders
-    after: [ *ccGroup ]
-
   - name: &preFixesGroup Pre Fixes (Patches/Add-ons)
 
   - name: &fixesGroup Fixes & Resources
     after:
       - *preFixesGroup
-      - *veryEarlyGroup
+      - *ccGroup
 
   - name: &preEarlyGroup Pre Early (Patches/Add-ons)
 
@@ -997,7 +994,6 @@ groups:
       - *fixesGroup
 
   - name: &underridesGroup Underrides
-    after: [ *veryEarlyGroup ]
 
   - name: default
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2480,7 +2480,7 @@ plugins:
     url:
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/2429'
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/23378'
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     clean:
       - crc: 0xEB94B5F8
         util: 'SSEEdit v4.0.3'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2294,7 +2294,7 @@ plugins:
         util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
   - name: 'ELFX - Exteriors.esp'
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     after:
       - 'Blowing in the Wind SSE.esp'
       - 'SMIM-SE-Merged-All.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12130,7 +12130,7 @@ plugins:
 
   - name: 'Enlightened College of Winterhold.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/8710/' ]
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
 
   - name: 'Enhanced Solitude SSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/27816/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1513,6 +1513,7 @@ plugins:
     after:
       - name: 'Lanterns Of Skyrim - All In One - Main.esm'
         condition: 'checksum("Lanterns Of Skyrim - All In One - Main.esm", EB94B5F8)'
+      - 'Requiem Records Fix.esp'
     msg:
       - <<: *patch3rdParty_KPH_CACO
         condition: 'active("Complete Alchemy & Cooking Overhaul.esp") and not active("CACO_USSEP_Patch.esp") and not active("ccqdrsse001-survivalmode.esl")'
@@ -16114,7 +16115,7 @@ plugins:
       - NPC.Class
       - Text
   - name: 'Requiem Records Fix.esp'
-    group: *preVeryEarlyGroup
+    group: *fixesGroup
   - name: 'Requiem for the Indifferent.esp'
     group: *lateChangesGroup
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12005,7 +12005,7 @@ plugins:
 
   - name: 'CoW Bridge Fix.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/17972/' ]
-    group: *veryEarlyGroup
+    group: *fixesGroup
     inc: [ 'WinterholdBridgeFixed.esp' ]
     dirty:
       # version: 1

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2775,7 +2775,7 @@ plugins:
 
   - name: 'Reverb and Ambiance Overhaul - Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/701/' ]
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     tag: [ Sound ]
     msg:
       - <<: *patchProvided

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2630,7 +2630,7 @@ plugins:
   - name: 'Audio Overhaul Skyrim.*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12466/' ]
   - name: 'Audio Overhaul Skyrim.esp'
-    group: *underridesGroup
+    group: *earlyLoadersGroup
     after:
       - 'LSFX-SSE-Audiosettings.esp'
       - 'Reverb and Ambiance Overhaul - Skyrim.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8886,7 +8886,7 @@ plugins:
 
   - name: 'QuestsAreInSkyrim(USSEP)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18416/' ]
-    group: *underridesGroup
+    group: *earlyLoadersGroup
 
   - name: 'Religion.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/67663/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6367,7 +6367,7 @@ plugins:
 
   - name: 'Immersive Movement.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/15649/' ]
-    group: *underridesGroup
+    group: *earlyLoadersGroup
     msg:
       - <<: *patchIncluded
         subs: [ 'Mortal Enemies' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1588,7 +1588,7 @@ plugins:
 ###### Fixes ######
   - name: 'Butterflies.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/29434/' ]
-    group: *veryEarlyGroup
+    group: *fixesGroup
 
   - name: 'ButterfliesUnchained.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/29538/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11705,7 +11705,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10434/'
         name: 'Carriage Stops of Skyrim'
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
     clean:
       # version: 1.1
       - crc: 0xA15D3872

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11460,7 +11460,7 @@ plugins:
 
   - name: 'Laundry.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2011/' ]
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
 
   - name: 'Left Hand Crossing.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18726/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9772,7 +9772,7 @@ plugins:
 
   - name: 'HFDecorativeDolls.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/493/' ]
-    group: *veryEarlyGroup
+    group: *earlyLoadersGroup
 
   - name: 'Hothtrooper44_Armor(Compilation|_Ecksstra).esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1650,12 +1650,12 @@ plugins:
         name: 'Skyrim Project Optimization SE'
     after: [ 'Unofficial Skyrim Special Edition Patch.esp' ]
   - name: 'Skyrim Project Optimization - Full Version.esm'
-    group: *underridesGroup
+    group: *fixesGroup
     clean:
       - crc: 0x45374C76
         util: 'SSEEdit v4.0.3'
   - name: 'Skyrim Project Optimization - No Homes - Full Version.esm'
-    group: *underridesGroup
+    group: *fixesGroup
     clean:
       - crc: 0xD0948CCF
         util: 'SSEEdit v4.0.3'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2095,7 +2095,6 @@ plugins:
 
   - name: 'Joy of Perspective.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9358' ]
-    group: *underridesGroup
     after:
       - 'Endgame NPC Overhaul.esp'
       - 'UNP Vanilla Outfits.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2276,7 +2276,6 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/2424/'
         name: 'Enhanced Lights and FX'
   - name: 'EnhancedLightsandFX.esp'
-    group: *underridesGroup
     inc:
       - 'RelightingSkyrim_SSE.esp'
       - 'RLO - Interiors.esp'
@@ -2307,37 +2306,30 @@ plugins:
       - crc: 0x9B390393
         util: 'SSEEdit v4.0.3'
   - name: 'ELFX - NoBreezehome.esp'
-    group: *underridesGroup
     clean:
       - crc: 0x16B967BB
         util: 'SSEEdit v4.0.3'
   - name: 'ELFX - NoHjerim.esp'
-    group: *underridesGroup
     clean:
       - crc: 0xEFC3B86E
         util: 'SSEEdit v4.0.3'
   - name: 'ELFX - NoHoneyside.esp'
-    group: *underridesGroup
     clean:
       - crc: 0x636D8DC1
         util: 'SSEEdit v4.0.3'
   - name: 'ELFX - NoProudspireManor.esp'
-    group: *underridesGroup
     clean:
       - crc: 0x378FA7EE
         util: 'SSEEdit v4.0.3'
   - name: 'ELFX - NoSeverinManor.esp'
-    group: *underridesGroup
     clean:
       - crc: 0x328328C8
         util: 'SSEEdit v4.0.3'
   - name: 'ELFX - NoVlindrelHall.esp'
-    group: *underridesGroup
     clean:
       - crc: 0xB88AC75D
         util: 'SSEEdit v4.0.3'
   - name: 'ELFX - NoPlayerHomes.esp'
-    group: *underridesGroup
     inc:
       - 'ELFX - NoBreezehome.esp'
       - 'ELFX - NoHjerim.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2705,7 +2705,6 @@ plugins:
 
   - name: 'DeadlySpellImpacts.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12939/' ]
-    group: *underridesGroup
     after:
       - name: 'Audio Overhaul Skyrim.esp'
         condition: 'file("Qw_DeadlySpellImpacts_AOS Patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6671,7 +6671,6 @@ plugins:
 
   - name: 'iNeed.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/645/' ]
-    group: *underridesGroup
     after: [ 'SkyUI_SE.esp' ]
     msg:
       - <<: *patch3rdParty_KPH_CACO

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6123,7 +6123,6 @@ plugins:
 
   - name: 'TouringCarriages.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/15948/' ]
-    group: *underridesGroup
     after:
       - 'Landscape Fixes For Grass Mods.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9428,11 +9428,21 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18177'
         name: 'QUARK - Qwinn''s Ultimate Amulet Restoration Kit'
-    # Must be in group before WACCF
 
+    # Must sort before WACCF Armor and Clothing Extension
   - name: 'WACCF_Armor and Clothing Extension.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/19002/' ]
     after:
+      - 'AmuletsShowOnEverything.esp'
+      - 'AmuletsShowOnClothes.esp'
+      - 'AmuletsShowOnHeavyArmor.esp'
+      - 'AmuletsShowOnLightArmor.esp'
+      - 'AmuletsShowOnRobes.esp'
+      - 'AmuletsShowOnEverything-JOP.esp'
+      - 'AmuletsShowOnClothes-JOP.esp'
+      - 'AmuletsShowOnHeavyArmor-JOP.esp'
+      - 'AmuletsShowOnLightArmor-JOP.esp'
+      - 'AmuletsShowOnRobes-JOP.esp'
       - 'AnotherSortingMod_2017-SSE.esp'
       - 'WACCF_ASM-2019.esp'
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11321,7 +11321,6 @@ plugins:
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/276/'
       - 'https://www.afkmods.com/index.php?/files/file/978-cutting-room-floor/'
       - 'https://bethesda.net/en/mods/skyrim/mod-detail/2955350'
-    group: *underridesGroup
     after:
       - '3DNPC.esp'
       - 'Audio Overhaul Skyrim.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9932,7 +9932,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/4933'
         name: 'Winter Is Coming SSE - Cloaks'
-    group: *underridesGroup
   - name: '1nivWICCloaks.esp'
     msg:
       - <<: *patch3rdParty_CCSMPC

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10052,7 +10052,6 @@ plugins:
   - name: 'Lore Weapon Expansion( - Daedric Crescent| - Goldbrand| - Relics of the Crusader)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/9660/' ]
   - name: 'Lore Weapon Expansion.esp'
-    group: *underridesGroup
     after:
       - 'Audio Overhaul Skyrim.esp'
       - 'DLCIntegration.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9429,7 +9429,6 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18177'
         name: 'QUARK - Qwinn''s Ultimate Amulet Restoration Kit'
     # Must be in group before WACCF
-    group: *preFixesGroup
 
   - name: 'WACCF_Armor and Clothing Extension.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/19002/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9433,7 +9433,6 @@ plugins:
 
   - name: 'WACCF_Armor and Clothing Extension.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/19002/' ]
-    group: *fixesGroup
     after:
       - 'AnotherSortingMod_2017-SSE.esp'
       - 'WACCF_ASM-2019.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4534,7 +4534,6 @@ plugins:
 
   - name: 'Endgame NPC Overhaul.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/897/' ]
-    group: *underridesGroup
     after:
       - 'AmazingFollowerTweaks.esp'
       - 'UFO - Ultimate Follower Overhaul.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2569,7 +2569,6 @@ plugins:
 
   - name: 'RelightingSkyrim_SSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/8586/' ]
-    group: *underridesGroup
     inc:
       - 'ClimatesOfTamriel-Dungeons-Darker.esp'
       - 'ClimatesOfTamriel-Dungeons-Hardcore.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9599,7 +9599,6 @@ plugins:
 
   - name: 'Cloaks( - Dawnguard| - USSEP Patch)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6369/' ]
-    group: *underridesGroup
   - name: 'Cloaks.esp'
     tag: [ Invent ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2260,7 +2260,6 @@ plugins:
 ###### AudioVisual - Lighting ######
   - name: 'CinematicFireFX.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/16326/' ]
-    group: *underridesGroup
     inc: [ 'NAT.esp' ]
     clean:
       - crc: 0x4CF60EE4

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8762,7 +8762,6 @@ plugins:
 
   - name: 'konahrik_accoutrements.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/22206' ]
-    group: *underridesGroup
     msg:
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_KA_Patch.esp") and (version("LegacyoftheDragonborn.esm", "5.0.24", >=) or (not checksum("LegacyoftheDragonborn.esm", 31563183) and not checksum("LegacyoftheDragonborn.esm", 6736FB94) and not checksum("LegacyoftheDragonborn.esm", CB82480D)))'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -15796,7 +15796,6 @@ plugins:
 
   - name: 'Tel_Nalta.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18680/' ]
-    group: *underridesGroup
     inc:
       - name: 'MoonAndStar_MAS.esp'
         condition: 'active("MoonAndStar_MAS.esp") and not active("MoonAndStar_TelNaltaPatch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9541,7 +9541,6 @@ plugins:
       - 'https://bethesda.net/en/mods/skyrim/mod-detail/3072082'
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10'
         name: 'Another Sorting Mod - Replacer Plugin'
-    group: *underridesGroup
     msg:
       - *alreadyInLotD
       - <<: *patch3rdParty
@@ -9588,7 +9587,6 @@ plugins:
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/902/'
       - 'https://bethesda.net/en/mods/skyrim/mod-detail/3203152'
       - 'https://bethesda.net/en/mods/skyrim/mod-detail/3203032'
-    group: *underridesGroup
     msg: [ *alreadyInLotD ]
     tag: [ Delev ]
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1788,7 +1788,6 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/2357/'
         name: 'Enhanced Blood Textures SE'
   - name: 'dD - Enhanced Blood Main.esp'
-    group: *underridesGroup
     after:
       - 'Audio Overhaul Skyrim.esp'
       - 'Immersive Sounds - Compendium.esp'
@@ -1807,12 +1806,10 @@ plugins:
       - crc: 0x6CF176EC
         util: 'SSEEdit v4.0.3'
   - name: 'dD-Reduced Wound Size.esp'
-    group: *underridesGroup
     clean:
       - crc: 0x35D96F84
         util: 'SSEEdit v4.0.3'
   - name: 'dD-(Larger|Reduced) Splatter Size\.esp'
-    group: *underridesGroup
     msg:
       - <<: *useOnlyOneX
         condition: 'many("dD-(Larger|Reduced) Splatter Size\.esp")'
@@ -1822,7 +1819,6 @@ plugins:
       - 'EBT - skyBirds Patch.esp'
       - 'EBT - skyBirds Patch (mid).esp'
       - 'EBT - skyBirds Patch (short).esp'
-    group: *underridesGroup
     msg:
       - <<: *useOnlyOneX
         condition: 'many("dD-(Medium|Short) Script Range\.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1949,7 +1949,6 @@ plugins:
 ###### AudioVisual - Interface ######
   - name: 'AnotherSortingMod_2017-SSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10/' ]
-    group: *underridesGroup
     after:
       - 'Joy of Perspective.esp'
       - 'Weapons Armor Clothing & Clutter Fixes.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11063,7 +11063,6 @@ plugins:
     url:
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/6180'
       - 'https://bethesda.net/en/mods/skyrim/mod-detail/3327746'
-    group: *underridesGroup
     after:
       - 'Enhanced Landscapes.esp'
       - 'Landscape Fixes For Grass Mods.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7950,7 +7950,6 @@ plugins:
     url:
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/20791'
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/22075'
-    group: *preFixesGroup
     after:
       - 'Ambriel.esp'
       - 'Cutting Room Floor.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10476,7 +10476,6 @@ plugins:
 
   - name: 'UNP Vanilla Outfits.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/11136/' ]
-    group: *underridesGroup
 
   - name: 'Vikings Weaponry - Johnskyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/14409/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2685,7 +2685,6 @@ plugins:
   - name: 'Audio Overhaul Skyrim - RealisticWaterTwo Patch.esp'
     after: [ 'RealisticWaterTwo.esp' ]
   - name: 'Audio Overhaul Skyrim - Immersive Sounds Patch.esp'
-    group: *underridesGroup
     tag: [ Sound ]
     dirty:
       - <<: *quickClean

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7298,6 +7298,8 @@ plugins:
     group: *fixesGroup
     after:
       - 'Audio Overhaul Skyrim.esp'
+      - name: 'Guard Dialogue Overhaul.esp'
+        condition: 'checksum("Guard Dialogue Overhaul.esp", 6ABC1129) or checksum("Guard Dialogue Overhaul.esp", 5CB27D7D)'
       - 'Immersive Sounds - Compendium.esp'
       - 'Undeath.esp'
       - 'UnlimitedBookshelves.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8423,7 +8423,6 @@ plugins:
       - crc: 0x8B33FD2B
         util: 'SSEEdit v4.0.2f'
   - name: 'BetterQuestObjectives-DBForevertoMisc.esp'
-    group: *underridesGroup
     after: [ 'BetterQuestObjectives.esp' ]
     clean:
       # Version: 1.8.3alpha
@@ -8446,7 +8445,6 @@ plugins:
       - crc: 0xAB22406D
         util: 'SSEEdit v4.0.2f'
   - name: 'BetterQuestObjectives - BCS Patch.esp'
-    group: *underridesGroup
     after: [ 'BetterQuestObjectives.esp' ]
     clean:
       # Version: 1.8.3alpha
@@ -8458,7 +8456,6 @@ plugins:
       - crc: 0x3D710D33
         util: 'SSEEdit v4.0.2f'
   - name: 'BetterQuestObjectives-CRFPatch.esp'
-    group: *underridesGroup
     after: [ 'BetterQuestObjectives.esp' ]
     clean:
       # Version: 1.8.3alpha

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10726,7 +10726,6 @@ plugins:
         name: 'Beyond Skyrim - Bruma SE'
   - name: 'BSAssets.esm'
     url: [ 'https://bethesda.net/en/mods/skyrim/mod-detail/4027835' ]
-    group: *underridesGroup
     tag:
       - C.Light
       - C.RecordFlags
@@ -10736,7 +10735,6 @@ plugins:
         util: 'SSEEdit v4.0.2'
   - name: 'BSHeartland.esm'
     url: [ 'https://bethesda.net/en/mods/skyrim/mod-detail/4027831' ]
-    group: *underridesGroup
     msg:
       - <<: *patch3rdParty
         subs:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8793,7 +8793,6 @@ plugins:
 
   - name: 'Missing Apprentices CRF Quest Fix.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6677/' ]
-    group: *underridesGroup
     after:
       - 'BetterQuestObjectives-CRFPatch.esp'
       - 'Book Covers Skyrim.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5478,7 +5478,6 @@ plugins:
       - crc: 0xFF2C28E6
         util: 'SSEEdit v4.0.2'
   - name: 'Landscape Fixes For Grass mods - Cutting Room Floor Locations.esp'
-    group: *underridesGroup
     clean:
       # version: 1.06
       - crc: 0xC5FF509C

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10671,7 +10671,6 @@ plugins:
 
   - name: 'WarmongerArmory_LeveledList.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/4956/' ]
-    group: *underridesGroup
     after:
       - '1nivWICCloaks.esp'
       - '1nivWICCloaksNoGuards.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7293,7 +7293,6 @@ plugins:
   - name: 'Weapons Armor Clothing & Clutter Fixes.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18994/' ]
     inc: [ 'Race Scale Remover.esp' ]
-    group: *fixesGroup
     after:
       - 'Audio Overhaul Skyrim.esp'
       - name: 'Guard Dialogue Overhaul.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2737,7 +2737,6 @@ plugins:
 
   - name: 'Immersive Sounds - Compendium.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/523/' ]
-    group: *underridesGroup
     after:
       - 'Audio Overhaul Skyrim.esp'
       - 'LSFX-SSE-Audiosettings.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10938,7 +10938,6 @@ plugins:
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/4301/'
       - 'https://bethesda.net/en/mods/skyrim/mod-detail/3107024'
   - name: 'MoonAndStar_MAS.esp'
-    group: *underridesGroup
     after:
       - 'AuroraVillage.esp'
       - 'Landscape Fixes For Grass Mods.esp'
@@ -10966,7 +10965,6 @@ plugins:
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
   - name: 'MoonAndStar_ImmersionPatch.esp'
-    group: *underridesGroup
     inc: [ *LotD_v5 ]
     dirty:
       # version: 2.0
@@ -10979,7 +10977,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10751'
         name: 'Moon and Star - WARZONES Assault Attack Compatibility Patch'
-    group: *underridesGroup
 
   - name: 'moonpath.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9793,7 +9793,6 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/3479/'
         name: 'Immersive Armors'
-    group: *underridesGroup
   - name: 'Hothtrooper44_ArmorCompilation.esp'
     after: [ 'Ambriel.esp' ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6694,7 +6694,6 @@ plugins:
         util: 'SSEEdit v4.0.3'
   - name: 'iNeed - Extended.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/645/' ]
-    group: *underridesGroup
     after:
       - 'AnotherSortingMod_2017-SSE.esp'
       - 'Weapons Armor Clothing & Clutter Fixes.esp'


### PR DESCRIPTION
#1040 

- Moved mods from Underrides, Fixes & Resources and Add-ons & Expansions groups to the Default group.
- Moved mods from Very Early Loaders group to Fixes & Resources and Early Loaders groups.
- Removed Underrides and Very Early Loaders groups.