### PR TITLE
Sort RDO after Alternate Start

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8170,6 +8170,7 @@ plugins:
       - '018Auri.esp'
       - 'FCO - Follower Commentary Overhaul.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
+      - 'alternate start - live another life.esp'
     msg:
       - <<: *patchProvided
         subs: [ 'Amazing Follower Tweaks' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8168,9 +8168,9 @@ plugins:
     after:
       - 'AmazingFollowerTweaks.esp'
       - '018Auri.esp'
+      - 'Alternate Start - Live Another Life.esp'
       - 'FCO - Follower Commentary Overhaul.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
-      - 'alternate start - live another life.esp'
     msg:
       - <<: *patchProvided
         subs: [ 'Amazing Follower Tweaks' ]
@@ -16478,4 +16478,3 @@ plugins:
       - <<: *alreadyInX
         subs: [ 'CCOR_Vokrii.esp']
         condition: 'active("CCOR_Vokrii.esp") and active("Vokrii - WACCF Patch.esp")'
-


### PR DESCRIPTION
Added this per the instructions located on: https://www.nexusmods.com/skyrimspecialedition/mods/1187?tab=description

> - Alternate Start - Live Another Life (LAL)
> 
> A handful of records conflict between RDO and LAL. RDO includes the changes made to these conflicting records by LAL, and therefore should be loaded after LAL so that changes from both mods are applied.