### PR TITLE
Add Mysticism CRF patch message and load order

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7694,11 +7694,20 @@ plugins:
 
   - name: 'MysticismMagic.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/27839' ]
+    msg:
+      - <<: *patch3rdParty
+        subs:
+          - 'Cutting Room Floor'
+          - '[ Mysticism - Cutting Room Floor Patch ](https://www.nexusmods.com/skyrimspecialedition/mods/34010)'
+        condition: 'active("Cutting Room Floor.esp")  and not active("MM - CRF + USSEP.esp")'
     dirty:
       - <<: *quickClean
         crc: 0x617C8095
         util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
+  - name: 'MM - CRF + USSEP.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/34010' ]
+    after: [ 'FleshFX.esp' ]
 
   - name: 'PathOfTheAntiMage.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/19668' ]


### PR DESCRIPTION
1. Add [Mysticism CRF patch](https://www.nexusmods.com/skyrimspecialedition/mods/34010) message
2. Load order: Mysticism CRF patch should be loaded after [Flesh FX](https://www.nexusmods.com/skyrimspecialedition/mods/27456) since Mysticism CRF patch already has the same shader record changes and its magic effect changes shouldn't be overwritten by vanilla values in Flesh FX.