### PR TITLE
Majestic Mountains - Beyond Skyrim landscape conflicts fix

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10901,7 +10901,6 @@ plugins:
         name: 'Beyond Skyrim - Bruma SE'
   - name: 'BSAssets.esm'
     url: [ 'https://bethesda.net/en/mods/skyrim/mod-detail/4027835' ]
-    after: [ 'MajesticMountains_Landscape.esm' ]
     tag:
       - C.Light
       - C.RecordFlags

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5654,7 +5654,6 @@ plugins:
       - crc: 0x2E75A18D
         util: 'SSEEdit v4.0.3'
   - name: 'MajesticMountains_Landscape.esm'
-    after: [ 'BSHeartland.esm' ]
     clean:
       - crc: 0xF9583331
         util: 'SSEEdit v4.0.3'
@@ -10902,6 +10901,7 @@ plugins:
         name: 'Beyond Skyrim - Bruma SE'
   - name: 'BSAssets.esm'
     url: [ 'https://bethesda.net/en/mods/skyrim/mod-detail/4027835' ]
+    after: [ 'MajesticMountains_Landscape.esm' ]
     tag:
       - C.Light
       - C.RecordFlags


### PR DESCRIPTION
Changed load order for MajesticMountains_Landscape.esm to load before the Beyond Skyrim Bruma masters to resolve landscape conflicts.