### PR TITLE
Add CLLF load order and patch message

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10780,6 +10780,14 @@ plugins:
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_ZimsThaneWeapons_Patch.esp") and (version("LegacyoftheDragonborn.esm", "5.0.24", >=) or (not checksum("LegacyoftheDragonborn.esm", 31563183) and not checksum("LegacyoftheDragonborn.esm", 6736FB94) and not checksum("LegacyoftheDragonborn.esm", CB82480D)))'
 
 ###### Leveled List Modifiers ######
+  - name: 'Containers and Leveled Lists Fixes.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/26575/' ]
+    after: [ 'Weapons Armor Clothing & Clutter Fixes.esp' ]
+    msg:
+      - <<: *patchProvided
+        subs: [ 'Cutting Room Floor' ]
+        condition: 'active("Cutting Room Floor.esp") and not active("CLLF - Cutting Room Floor Patch.esp")'
+
   - name: 'Rebalanced Leveled Lists( - Lite)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/26/' ]
     msg:


### PR DESCRIPTION
Although the author of CLLF claims that the mod is fully compatible with WACCF, it actually is not. To avoid some part of CLLF's leveled lists being overwritten by WACCF, it has to be loaded after WACCF. It is the same reason why MLU has to be loaded after WACCF.