### PR TITLE
Add SkyVRaan Shimmering VR Waters load order

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3014,6 +3014,12 @@ plugins:
         util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 5
 
+  - name: 'CubemapEnabler.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/30571/' ]
+    group: *lateChangesGroup
+  - name: 'SkyVRaan-WaterGrass.esp'
+    after: [ 'Landscape Fixes For Grass Mods.esp' ]
+
   - name: 'RealisticWaterTwo.*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2182/' ]
   - name: 'RealisticWaterTwo.esp'


### PR DESCRIPTION
According to the author of the mod, cubemap enabler should be at the very end of load order to overwrite water type data. However, it could be before or after DynDOLOD depending on how DynDOLOD.esp was built.

Water grass addon should be loaded after Landscape Fixes for grass mod.