### PR TITLE
Add Containers and Leveled Lists Fixes load order

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6910,6 +6910,20 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18571/' ]
     after: [ 'Requiem.esp' ]
 
+  - name: 'Containers and Leveled Lists Fixes.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/26575/' ]
+    group: *economyGroup
+    after:
+      - 'LoreWorthyBandits.esp'
+      - 'MLU.esp'
+      - 'Weapon AF.esp'
+      - 'WACCF_Armor and Clothing Extension.esp'
+      - 'Weapons Armor Clothing & Clutter Fixes.esp'
+    msg:
+      - <<: *patchProvided
+        subs: [ 'Cutting Room Floor' ]
+        condition: 'active("Cutting Room Floor.esp") and not active("CLLF - Cutting Room Floor Patch.esp")'
+
   - name: 'DLCIntegration.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/8032/' ]
     group: *earlyLoadersGroup
@@ -7349,6 +7363,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/23081/' ]
     group: *economyGroup
     after:
+      - 'Containers and Leveled Lists Fixes.esp'
       - 'EconomyOverhaulandSpeechcraftImprovements.esp'
       - 'MLU.esp'
     msg:
@@ -10780,14 +10795,6 @@ plugins:
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_ZimsThaneWeapons_Patch.esp") and (version("LegacyoftheDragonborn.esm", "5.0.24", >=) or (not checksum("LegacyoftheDragonborn.esm", 31563183) and not checksum("LegacyoftheDragonborn.esm", 6736FB94) and not checksum("LegacyoftheDragonborn.esm", CB82480D)))'
 
 ###### Leveled List Modifiers ######
-  - name: 'Containers and Leveled Lists Fixes.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/26575/' ]
-    after: [ 'Weapons Armor Clothing & Clutter Fixes.esp' ]
-    msg:
-      - <<: *patchProvided
-        subs: [ 'Cutting Room Floor' ]
-        condition: 'active("Cutting Room Floor.esp") and not active("CLLF - Cutting Room Floor Patch.esp")'
-
   - name: 'Rebalanced Leveled Lists( - Lite)?\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/26/' ]
     msg:


### PR DESCRIPTION
WACCF, ACE, WAF, Lore worthy bandits should not overwrite leveled list changes of CLLF. It is the same rule as MLU load order.