### PR TITLE
Update Convenient Carriages patch messages

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11433,6 +11433,15 @@ plugins:
         subs: [ 'City Entrances Overhaul - Markarth' ]
         condition: 'active("Markarth Entrance Overhaul.esp") and not active("CC_CEOMark_Patch.esp")'
       - <<: *patchIncluded
+        subs: [ 'City Entrances Overhaul - Windhelm' ]
+        condition: 'active("WindhelmEntranceOverhaul.esp") and not active("CC_CEOWind_Patch.esp")'
+      - <<: *patchIncluded
+        subs: [ 'Cutting Room Floor' ]
+        condition: 'active("Cutting Room Floor.esp") and not active("Landscape Fixes For Grass Mods.esp") and not active("CC_CRF_Patch.esp")'
+      - <<: *patchIncluded
+        subs: [ 'Cutting Room Floor and Landscape Fixes For Grass Mods' ]
+        condition: 'active("Cutting Room Floor.esp") and active("Landscape Fixes For Grass Mods.esp") and not active("CC_CRF_LFFGM_Patch.esp")'
+      - <<: *patchIncluded
         subs: [ 'Dawnstar' ]
         condition: 'active("Dawnstar.esp") and not active("CC_ArtDws_Patch.esp")'
       - <<: *patchIncluded
@@ -11453,16 +11462,7 @@ plugins:
       - <<: *patchIncluded
         subs: [ 'Storefront' ]
         condition: 'active("Storefront.esp") and not active("CC_ArtStorefront_Patch.esp")'
-      - <<: *patchProvided
-        subs: [ 'City Entrances Overhaul - Windhelm' ]
-        condition: 'active("WindhelmEntranceOverhaul.esp") and not active("CC_CEOWind_Patch.esp")'
-      - <<: *patchProvided
-        subs: [ 'Cutting Room Floor' ]
-        condition: 'active("Cutting Room Floor.esp") and not active("Landscape Fixes For Grass Mods.esp") and not active("CC_CRF_Patch.esp")'
-      - <<: *patchProvided
-        subs: [ 'Cutting Room Floor and Landscape Fixes For Grass Mods' ]
-        condition: 'active("Cutting Room Floor.esp") and active("Landscape Fixes For Grass Mods.esp") and not active("CC_CRF_LFFGM_Patch.esp")'
-      - <<: *patchProvided
+      - <<: *patchIncluded
         subs: [ 'The Great City of Solitude' ]
         condition: 'active("The Great City of Solitude.esp") and not active("CC_TGCS_Patch.esp")'
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11421,9 +11421,6 @@ plugins:
     inc: [ 'CFTO.esp' ]
     msg:
       - <<: *patchIncluded
-        subs: [ 'Ancient Land' ]
-        condition: 'active("AncientLand.esp") and not active("CC_AncLand_Patch.esp")'
-      - <<: *patchIncluded
         subs: [ 'Better Dynamic Snow' ]
         condition: 'active("Better Dynamic Snow.esp") and not active("CC_BDSnow_Patch.esp")'
       - <<: *patchIncluded


### PR DESCRIPTION
1. Remove obsolete Convenient Carriages - Ancient Land patch. The author of the mod removed the patch.
2. Update Convenient Carriages patch messages. Now the patches are included in FOMOD installer.