### PR TITLE
Fix for Trade & Barter Patch Name

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7385,7 +7385,7 @@ plugins:
         subs:
           - 'Keld-Nar'
           - '[Trade and Barter - Patches](https://www.nexusmods.com/skyrimspecialedition/mods/23220/)'
-        condition: 'active("Keld-Nar.esp") and not active("Trade and Barter - Keld-Nar Patch.esp")'
+        condition: 'active("Keld-Nar.esp") and not active("Keld-Nar - Trade and Barter Patch.esp")'
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_TradeBarter_Patch.esp") and (version("LegacyoftheDragonborn.esm", "5.0.24", >=) or (not checksum("LegacyoftheDragonborn.esm", 31563183) and not checksum("LegacyoftheDragonborn.esm", 6736FB94) and not checksum("LegacyoftheDragonborn.esm", CB82480D)))'
       - *requiresMCM

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7385,7 +7385,7 @@ plugins:
         subs:
           - 'Keld-Nar'
           - '[Trade and Barter - Patches](https://www.nexusmods.com/skyrimspecialedition/mods/23220/)'
-        condition: 'active("Keld-Nar.esp") and not active("Keld-Nar - Trade and Barter Patch.esp")'
+        condition: 'active("Keld-Nar.esp") and not active("Trade and Barter - Keld-Nar Patch.esp") and not active("Keld-Nar - Trade and Barter Patch.esp")'
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_TradeBarter_Patch.esp") and (version("LegacyoftheDragonborn.esm", "5.0.24", >=) or (not checksum("LegacyoftheDragonborn.esm", 31563183) and not checksum("LegacyoftheDragonborn.esm", 6736FB94) and not checksum("LegacyoftheDragonborn.esm", CB82480D)))'
       - *requiresMCM


### PR DESCRIPTION
The patch for Trade & Barter and Keld-Nar was named incorrectly.
The mod author appears to have renamed the file after a version change. 
This will match the new name.

