### PR TITLE
Adding CBBE-WACCF patch dependency msg

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16699,3 +16699,14 @@ plugins:
       - <<: *patchProvided
         subs: [ 'Skyrim SE - Project Optimization - ESM VERSION' ]
         condition: 'active("Skyrim Project Optimization - Full Version.esm") and not active("JK''s The Bannered Mare SPO Patch.esp")'
+
+  ### Caliente's Beautiful Bodies Enhancer -CBBE- ###
+  - name: 'CBBE.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/198' ]
+    msg:
+      - type: say
+        content:
+          - lang: en
+            text: 'You seem to be using Weapons Armor Clothing and Clutter Fixes. A compatibility patch is available here %1%.'
+        subs: [ '[Weapons Armor Clothing and Clutter Fixes - CBBE Patch](https://www.nexusmods.com/skyrimspecialedition/mods/19176)' ]
+        condition: 'active("CBBE.esp")  and active("Weapons Armor Clothing & Clutter Fixes.esp")'


### PR DESCRIPTION
Can't detect if the patch is installed or not since it doesn't have an es(l|m|p) so just using a generic msg to notify users of the patch's existence