### PR TITLE
Add Hybrid Loot and EZs load order

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7061,6 +7061,14 @@ plugins:
   - name: 'EconomyOverhaul CV - (Vokrii|Ordinator) Patch.esp'
     after: [ 'EconomyOverhaul CV - MorrowLootUltimate Patch.esp' ]
 
+  - name: 'Hybrid Loot and EZs.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/26085' ]
+    after:
+      - 'LoreWorthyBandits.esp'
+      - 'WACCF_Armor and Clothing Extension.esp'
+      - 'Weapon AF.esp'
+      - 'Weapons Armor Clothing & Clutter Fixes.esp'
+
   - name: 'Immersive Ingestibles.esp'
     url: [ 'https://bethesda.net/en/mods/skyrim/mod-detail/3587775' ]
     after: [ 'Requiem.esp' ]


### PR DESCRIPTION
WACCF, ACE, WAF, Lore worthy bandits should not overwrite the leveled list changes of Hybrid Loot and EZs.