### PR TITLE
Update Skyrim Revamped load order

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7329,6 +7329,9 @@ plugins:
     after:
       - 'LoreWorthyBandits.esp'
       - 'mrbs-uniqueloot-se.esp'
+      - 'WACCF_Armor and Clothing Extension.esp'
+      - 'Weapon AF.esp'
+      - 'Weapons Armor Clothing & Clutter Fixes.esp'
     tag:
       - Delev
       - Invent


### PR DESCRIPTION
WACCF, ACE, WAF should not overwrite the leveled list changes of Skyrim Revamped.