### PR TITLE
Sort Armor Rating Redux after Smilodon

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7102,6 +7102,7 @@ plugins:
     after:
       - 'Combat Evolved.esp'
       - 'Wildcat - Combat of Skyrim.esp'
+      - 'Smilodon - Combat of Skyrim.esp'
     clean:
       - crc: 0x473DB27A
         util: 'SSEEdit v4.0.3'


### PR DESCRIPTION
Armor rating data from Armor Rating Redux should not be overwritten by Smilodon.