### PR TITLE
Sort landscape group before dynamic patches.

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1049,7 +1049,9 @@ groups:
     after: [ *lateLoadersGroup ]
 
   - name: &dynamicPatchGroup Dynamic Patches
-    after: [ *lvlListsGroup ]
+    after:
+      - *lvlListsGroup
+      - *landscapeGroup
 
   - name: &mapGroup Maps
     description: 'A group for Map & Map Marker plugins that need to be loaded late to preserve worldspace changes.'


### PR DESCRIPTION
To prevent flora mods sorting after bashed patch.
Reported on discord by @Zanderat.

![screenshot of Discord message](https://user-images.githubusercontent.com/1944639/80921034-8a540280-8d6b-11ea-92e3-bede541270cc.png)
