### PR TITLE
Updates for Lighting Enhancers

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2408,7 +2408,7 @@ plugins:
       - crc: 0x0F02A920
         util: 'SSEEdit v4.0.3'
   - name: 'ELFXEnhancer.esp'
-    group: *highPriorityGroup
+    group: *lightingEnhancerGroup
     inc:
       - 'ELE_SSE.esp'
       - 'ELFX - Hardcore.esp'
@@ -2424,7 +2424,7 @@ plugins:
       - crc: 0x06339952
         util: 'SSEEdit v4.0.3'
   - name: 'ELFX - Hardcore.esp'
-    group: *highPriorityGroup
+    group: *lightingEnhancerGroup
     after:
       - 'Alternate Start - Live Another Life.esp'
       - 'Immersive Citizens - OCS patch.esp'
@@ -2454,7 +2454,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/1377/'
         name: 'Enhanced Lighting for ENB'
-    group: *highPriorityGroup
+    group: *lightingEnhancerGroup
     after:
       - 'Alternate Start - Live Another Life.esp'
       - 'Ars Metallica.esp'
@@ -2504,8 +2504,13 @@ plugins:
 
   - name: 'ENB Light.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/22574' ]
-    group: *lateLoadersGroup
-    after: [ 'ELE_SSE.esp' ]
+    group: *lightingEnhancerGroup
+    after:
+      - 'ELE_SSE.esp'
+      - 'ELFXEnhancer.esp'
+      - 'ELFX - Hardcore.esp'
+      - 'Luminosity - Lightweight Lighting.esp'
+      - 'Luminosity Lighting Overhaul.esp'
     req:
       - name: '../d3d11.dll'
         display: '[ENBSeries](http://enbdev.com/download_mod_tesskyrimse.html)'
@@ -2588,7 +2593,7 @@ plugins:
         itm: 2
   - name: 'Luminosity - Lightweight Lighting.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/16830' ]
-    group: *highPriorityGroup
+    group: *lightingEnhancerGroup
     after:
       - 'Alternate Start - Live Another Life.esp'
       - 'Immersive Citizens - OCS patch.esp'
@@ -2604,7 +2609,7 @@ plugins:
     tag: [ C.Light ]
   - name: 'Luminosity Lighting Overhaul.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/16830' ]
-    group: *highPriorityGroup
+    group: *lightingEnhancerGroup
     after:
       - 'Alternate Start - Live Another Life.esp'
       - 'Immersive Citizens - OCS patch.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2413,24 +2413,11 @@ plugins:
       - 'ELE_SSE.esp'
       - 'ELFX - Hardcore.esp'
       - 'RLO - Interiors.esp'
-    after:
-      - 'Alternate Start - Live Another Life.esp'
-      - 'Immersive Citizens - AI Overhaul.esp'
-      - 'Immersive Citizens - OCS patch.esp'
-      - 'MissingEZsFixed.esp'
-      - 'MissingEZs_AllExteriors.esp'
-      - 'Open Cities Skyrim.esp'
     clean:
       - crc: 0x06339952
         util: 'SSEEdit v4.0.3'
   - name: 'ELFX - Hardcore.esp'
     group: *lightingEnhancerGroup
-    after:
-      - 'Alternate Start - Live Another Life.esp'
-      - 'Immersive Citizens - OCS patch.esp'
-      - 'MissingEZsFixed.esp'
-      - 'MissingEZs_AllExteriors.esp'
-      - 'Open Cities Skyrim.esp'
     inc:
       - 'ELE_SSE.esp'
       - 'ELFXEnhancer.esp'
@@ -2455,29 +2442,6 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/1377/'
         name: 'Enhanced Lighting for ENB'
     group: *lightingEnhancerGroup
-    after:
-      - 'Alternate Start - Live Another Life.esp'
-      - 'Ars Metallica.esp'
-      - 'Book Covers Skyrim - Lost Library.esp'
-      - 'Book Covers Skyrim.esp'
-      - 'EmbersHD.esp'
-      - 'Open Cities Skyrim.esp'
-      - 'Immersive Citizens - OCS patch.esp'
-      - 'Immersive Citizens - AI Overhaul.esp'
-      - 'Inigo.esp'
-      - 'Ivarstead.esp'
-      - 'Karthwasten.esp'
-      - 'LightngDuringStorm.esp'
-      - 'MissingEZsFixed.esp'
-      - 'MissingEZs_AllExteriors.esp'
-      - 'MLU.esp'
-      - 'Relationship Dialogue Overhaul.esp'
-      - 'RelightingSkyrim_SSE.esp'
-      - 'Shor''s Stone.esp'
-      - 'SkyrimImprovedPuddles-DG-HF-DB.esp'
-      - 'Soljund''s Sinkhole.esp'
-      - 'TheChoiceIsYours.esp'
-      - 'Whistling Mine.esp'
     inc:
       - 'ELFXEnhancer.esp'
       - 'ELFX - Hardcore.esp'
@@ -2594,12 +2558,6 @@ plugins:
   - name: 'Luminosity - Lightweight Lighting.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/16830' ]
     group: *lightingEnhancerGroup
-    after:
-      - 'Alternate Start - Live Another Life.esp'
-      - 'Immersive Citizens - OCS patch.esp'
-      - 'MissingEZsFixed.esp'
-      - 'MissingEZs_AllExteriors.esp'
-      - 'Open Cities Skyrim.esp'
     inc:
       - 'ELE_SSE.esp'
       - 'ELFXEnhancer.esp'
@@ -2610,12 +2568,6 @@ plugins:
   - name: 'Luminosity Lighting Overhaul.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/16830' ]
     group: *lightingEnhancerGroup
-    after:
-      - 'Alternate Start - Live Another Life.esp'
-      - 'Immersive Citizens - OCS patch.esp'
-      - 'MissingEZsFixed.esp'
-      - 'MissingEZs_AllExteriors.esp'
-      - 'Open Cities Skyrim.esp'
     inc:
       - 'ELE_SSE.esp'
       - 'ELFXEnhancer.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2412,6 +2412,8 @@ plugins:
     inc:
       - 'ELE_SSE.esp'
       - 'ELFX - Hardcore.esp'
+      - 'Luminosity - Lightweight Lighting.esp'
+      - 'Luminosity Lighting Overhaul.esp'
       - 'RLO - Interiors.esp'
     clean:
       - crc: 0x06339952
@@ -2421,6 +2423,8 @@ plugins:
     inc:
       - 'ELE_SSE.esp'
       - 'ELFXEnhancer.esp'
+      - 'Luminosity - Lightweight Lighting.esp'
+      - 'Luminosity Lighting Overhaul.esp'
       - 'RLO - Interiors.esp'
     clean:
       - crc: 0x5ECC3509
@@ -2445,6 +2449,8 @@ plugins:
     inc:
       - 'ELFXEnhancer.esp'
       - 'ELFX - Hardcore.esp'
+      - 'Luminosity - Lightweight Lighting.esp'
+      - 'Luminosity Lighting Overhaul.esp'
       - 'RLO - Interiors.esp'
     tag:
       - C.ImageSpace

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2481,6 +2481,7 @@ plugins:
       - 'ELFX - Hardcore.esp'
       - 'Luminosity - Lightweight Lighting.esp'
       - 'Luminosity Lighting Overhaul.esp'
+      - 'RLO - Interiors.esp'
     req:
       - name: '../d3d11.dll'
         display: '[ENBSeries](http://enbdev.com/download_mod_tesskyrimse.html)'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1062,8 +1062,11 @@ groups:
   - name: &highPriorityGroup High Priority Overrides
     after: [ *lowPriorityGroup ]
 
-  - name: &lateLoadersGroup Late Loaders
+  - name: &lightingEnhancerGroup Lighting Enhancers
     after: [ *highPriorityGroup ]
+
+  - name: &lateLoadersGroup Late Loaders
+    after: [ *lightingEnhancerGroup ]
 
   - name: &lvlListsGroup Leveled List Modifiers
     after: [ *lateLoadersGroup ]


### PR DESCRIPTION
Moved plugins to new group Lighting Enhancers.
- To prevent a sorting error between ENB Light & RWT.
- To reduce the complexity of the High Priority group.

Updated inc & afters for lighting plugins.
- Removed afters to give a bit more freedom if plugins are moved to a different group.
- Added missing inc to lighting plugins.