### PR TITLE
Add Ordering information for Save the Icerunner and Innocence Lost Alternative

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8665,6 +8665,8 @@ plugins:
 
   - name: 'InnoLostAlt.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/24236' ]
+    after:
+      - 'TheChoiceIsYours.esp'
     clean:
       # version: 2.0.4
       - crc: 0x7D8AB5D7
@@ -8851,6 +8853,14 @@ plugins:
   - name: 'Religion.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/67663/' ]
     after: [ 'Requiem.esp' ]
+
+  - name: 'SaveTheIcerunner.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/34681' ]
+    after:
+      - 'TheChoiceIsYours.esp'
+    clean:
+      - crc: 0xF57050CB
+        util: 'SSEEdit v4.0.3'
 
   - name: 'SexLab-AmorousAdventures.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/7305/' ]


### PR DESCRIPTION
Both of these mods alter quests also altered by The Choice is Yours. For these mods to function, they must be placed after The Choice is Yours in the load order.

Personally tested.