### PR TITLE
Add bash tags for AI Overhaul

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7884,6 +7884,16 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/21654'
         name: 'AI Overhaul SSE'
+    tag:
+      - Actors.ACBS
+      - Actors.AIData
+      - Actors.AIPackages
+      - Actors.CombatStyle
+      - Actors.Spells
+      - Actors.Stats
+      - Factions
+      - Invent.Add
+      - NPC.AIPackageOverrides
     msg:
       - <<: *patch3rdParty_RSCPC
         condition: 'active("RSChildren.esp") and not active("RSChildren + AI Overhaul Patch.esp")'


### PR DESCRIPTION
- Actors.ACBS, Actors.AIData, Actors.AIPackages, and NPC.AIPackageOverrides forward changes made to most NPCs and should be forwarded
- the rest forward changes made to a couple of NPCs (note: the following lists are not complete, i may have missed a few NPCs)
  - Actors.CombatStyle: Anoriath
  - Actors.Spells: Agni
  - Actors.Stats: Agni, Malur Seloth, Nelacar, Quintus Navale
  - Factions: Adrianne Avenicci, Player
  - Invent.Add: Adrianne Avenicci, Proventus Avenicci
- faction and inventory edits should be forwarded
- combat style seems relevant to the mod and probably should be forwarded
- spell and stats edits aren't critical, so they can be removed if they don't seem worth it (i'd personally keep them)
- these are changes that weren't forwarded from USSEP, didn't consider tags for them
- i also only looked at NPC_ records. other records are changed, but i haven't considered tags for them yet