### PR TITLE
Add bash tag to Convenient Horses

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7807,6 +7807,8 @@ plugins:
       - 'AmazingFollowerTweaks.esp'
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'Relationship Dialogue Overhaul.esp'
+    tag:
+      - Text
     msg:
       - type: info
         condition: 'active("AmazingFollowerTweaks.esp")'


### PR DESCRIPTION
added Text tag to address conflict with USSEP (since it has Text tag too and overwrites an edit by CH)