### PR TITLE
Add tags and load-after rules for Realistic Needs and Diseases

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6716,6 +6716,14 @@ plugins:
     url:
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/3487'
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/23799'
+    after:
+      - 'Hunterborn.esp'
+      - 'Weapons Armor Clothing & Clutter Fixes.esp'
+    tag:
+      - Delev
+      - Graphics
+      - Keywords
+      - Relev
     dirty:
       - <<: *quickClean
         crc: 0xB35FFCC4


### PR DESCRIPTION
- Hunterborn and WACCF undo effects changes that are best addressed by loading RNAD after

- tags are to forward leveled list, graphics, and keyword changes undone by mods like USSEP

- this is all done with [RNAD 2](https://www.nexusmods.com/skyrimspecialedition/mods/23799) and [HB + MCM](https://www.nexusmods.com/skyrimspecialedition/mods/17993), but these changes should benefit other versions as well