### PR TITLE
Add entries for some AI Overhaul patches

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8004,6 +8004,11 @@ plugins:
     msg:
       - <<: *patch3rdParty_RSCPC
         condition: 'active("RSChildren.esp") and not active("RSChildren + AI Overhaul Patch.esp")'
+      - <<: *patch3rdParty
+        subs:
+          - 'Open Cities Skyrim'
+          - '[AI Overhaul - Open Cites Compatibility](https://www.nexusmods.com/skyrimspecialedition/mods/38031)'
+        condition: 'active("Open Cities Skyrim.esp") and not active("AI Overhaul - Open Cities.esp")'
     clean:
       - crc: 0xAFCDE5A2
         util: 'SSEEdit v4.0.3'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4117,6 +4117,12 @@ plugins:
           - 'WARP - World Assets Recycle Project SE'
           - '[Kalilies NPCs WARP patch](https://www.nexusmods.com/skyrimspecialedition/mods/33942/)'
         condition: 'active("WARP.esp") and not active("KaliliesNPCs WARP PATCH.esp")'
+  - name: 'KaliliesNPCs - USSEP CRF AI Overhaul Patch.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/30247/' ]
+    after: [ 'AI Overhaul - Cutting Room Floor Patch.esp' ]
+    clean:
+      - crc: 0x0F741F1A
+        util: 'SSEEdit v4.0.3'
 
   - name: 'Men of Winter.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10902/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4173,6 +4173,12 @@ plugins:
         condition: 'active("Skyrim Revamped - Complete Enemy Overhaul.esp") and not active("PAN_NPCs_DG_SRCEO_Patch.esp")'
   - name: 'PAN_NPCs_DG_MLU_Patch.esp'
     after: [ 'MLU.esp' ]
+  - name: 'AI Overhaul - PAN_NPCs Patch.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/19012/' ]
+    after: [ 'AI Overhaul - Cutting Room Floor Patch.esp' ]
+    clean:
+      - crc: 0x2611A250
+        util: 'SSEEdit v4.0.3'
 
   - name: 'Serana - Hellraiser.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10088' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8007,6 +8007,14 @@ plugins:
     clean:
       - crc: 0xAFCDE5A2
         util: 'SSEEdit v4.0.3'
+  - name: 'AI Overhaul - Open Cities.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/38031/'
+        name: 'AI Overhaul - Open Cites Compatibility'
+    after: [ 'Open Cities Skyrim.esp' ]
+    clean:
+      - crc: 0x3B2E3D66
+        util: 'SSEEdit v4.0.3'
 
   - name: 'Guard Dialogue Overhaul.esp'
     url:


### PR DESCRIPTION
- added entries for 3 AI Overhaul patches to address load order issues
- the NPC overhaul patches are the ones found on their respective pages and will cause issues if not loaded after the CRF patch
- the [OCS patch](https://www.nexusmods.com/skyrimspecialedition/mods/38031) doesn't require OCS as a master, so it doesn't necessarily load after. however, it does conflict with OCS and should load after
- added notification for AI Overhaul - OCS patch if both are present