### PR TITLE
Edit entry for Toccata as Elisif

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4212,10 +4212,11 @@ plugins:
 
   - name: 'Toccata as Elisif.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12713/' ]
+    after: [ 'PAN_NPCs.esp' ]
     clean:
       # version: 1.4.2
       - crc: 0xC2C81AD6
-        util: 'SSEEdit v4.0.2f'
+        util: 'SSEEdit v4.0.3'
 
 ###### Character Appearance - Presets ######
   - name: 'AsharaSkyrimCharacterPresetsReplacer.esp'


### PR DESCRIPTION
- should load after Pan's NPC overhaul as that mod also overhauls Elisif, making this one redundant otherwise
- updated the cleaning info at the same time, no change in checksum