### PR TITLE
Add/update various tags, cleaning info, and messages

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16870,6 +16870,11 @@ plugins:
       - <<: *alreadyInX
         subs: [ 'kryptopyr''s Patch Hub - CCOR & Cloaks of Skyrim Patch' ]
         condition: 'active("Cloaks_CCOR_Patch.esp")'
+  - name: 'Qw_ACE_CRF Patch.esp'
+    tag: [ Keywords ]
+    clean:
+      - crc: 0xE2B0065F
+        util: 'SSEEdit v4.0.3'
   - name: 'Qw_DeadlySpellImpacts_AOS Patch.esp'
     tag:
       - Graphics

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7393,7 +7393,9 @@ plugins:
       - 'Undeath.esp'
       - 'UnlimitedBookshelves.esp'
       - 'unofficial skyrim survival patch.esp'
-    tag: [ Text ]
+    tag:
+      - Sound
+      - Text
     msg:
       - <<: *compatNotes
         subs: [ 'https://forums.nexusmods.com/index.php?/topic/6871717-waccf-compatibility/?p=62448162' ]
@@ -7404,7 +7406,6 @@ plugins:
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_WACCF_Patch.esp")'
     clean:
-      # version: 2.1
       - crc: 0xBBDE0D60
         util: 'SSEEdit v4.0.3'
   - name: 'WACCF_BashedPatchLvlListFix.esp'
@@ -7423,7 +7424,6 @@ plugins:
           - lang: pt
             text: 'Este plugin é opcional.'
     clean:
-      # version: 2.1
       - crc: 0xFC0B6550
         util: 'SSEEdit v4.0.3'
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8922,12 +8922,10 @@ plugins:
     tag:
       - C.Encounter
       - C.Music
-    dirty:
-      # version: 1.0
-      - <<: *quickClean
-        crc: 0x9985DFF3
-        util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
-        itm: 1
+      - Keywords
+    clean:
+      - crc: 0xD0BBADB1
+        util: 'SSEEdit v4.0.3'
 
   - name: 'NotSoFast-MageGuild.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5686/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14065,10 +14065,10 @@ plugins:
       - 'SoundsofSkyrimComplete.esp'
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
       - 'ViscousGrass.esp'
+    tag: [ Keywords ]
     clean:
-      # version: 2.0.4
       - crc: 0xF1BFA9D1
-        util: 'SSEEdit v4.0.2'
+        util: 'SSEEdit v4.0.3'
 
   - name: 'SkyHavenTempleRestored.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10647' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -261,6 +261,18 @@ common:
         text: '已过时。请升级到最新版本。 %1%'
     subs: [ '' ]
 
+  - &optional
+    type: say
+    content:
+      - lang: en
+        text: 'This plugin is optional.'
+      - lang: de
+        text: 'Dieses Plugin ist optional.'
+      - lang: ja
+        text: 'このプラグインはオプションです。'
+      - lang: pt
+        text: 'Este plugin é opcional.'
+
   - &patch3rdParty
     type: say
     content:
@@ -2248,17 +2260,7 @@ plugins:
   - name: 'RaceMenuPlugin.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/19080/' ]
     req: [ 'RaceMenu.esp' ]
-    msg:
-      - type: say
-        content:
-          - lang: en
-            text: 'This plugin is optional.'
-          - lang: de
-            text: 'Dieses Plugin ist optional.'
-          - lang: ja
-            text: 'このプラグインはオプションです。'
-          - lang: pt
-            text: 'Este plugin é opcional.'
+    msg: [ *optional ]
     clean:
       - crc: 0x8FF336FE
         util: 'SSEEdit v4.0.3'
@@ -7423,17 +7425,8 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18994/' ]
     group: *lvlListsGroup
     msg:
+      - *optional
       - *requiresBashOrSmash
-      - type: say
-        content:
-          - lang: en
-            text: 'This plugin is optional.'
-          - lang: de
-            text: 'Dieses Plugin ist optional.'
-          - lang: ja
-            text: 'このプラグインはオプションです。'
-          - lang: pt
-            text: 'Este plugin é opcional.'
     clean:
       - crc: 0xFC0B6550
         util: 'SSEEdit v4.0.3'
@@ -16942,17 +16935,7 @@ plugins:
 ###### Anything new can go after this (If you're not sure where to put it) ######
   - name: 'SSE-Terrain-Tamriel.esm'
     url: [ 'https://forum.step-project.com/topic/13451-xlodgen-terrain-lod-beta-for-fnv-fo3-fo4-fo4vr-tes5-sse-tes5vr-enderal' ]
-    msg:
-      - type: say
-        content:
-          - lang: en
-            text: 'This plugin is optional.'
-          - lang: de
-            text: 'Dieses Plugin ist optional.'
-          - lang: ja
-            text: 'このプラグインはオプションです。'
-          - lang: pt
-            text: 'Este plugin é opcional.'
+    msg: [ *optional ]
     clean:
       - crc: 0x807E1071
         util: 'SSEEdit v4.0.3'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6766,6 +6766,12 @@ plugins:
         crc: 0x04954404
         util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
+  - name: 'RNAD_FF_Patch.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/23799' ]
+    tag: [ Graphics ]
+    clean:
+      - crc: 0xD2FA0750
+        util: 'SSEEdit v4.0.3'
 
   - name: 'SAFO.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16940,3 +16940,19 @@ plugins:
         condition: 'active("CCOR_Vokrii.esp") and active("Vokrii - WACCF Patch.esp")'
 
 ###### Anything new can go after this (If you're not sure where to put it) ######
+  - name: 'SSE-Terrain-Tamriel.esm'
+    url: [ 'https://forum.step-project.com/topic/13451-xlodgen-terrain-lod-beta-for-fnv-fo3-fo4-fo4vr-tes5-sse-tes5vr-enderal' ]
+    msg:
+      - type: say
+        content:
+          - lang: en
+            text: 'This plugin is optional.'
+          - lang: de
+            text: 'Dieses Plugin ist optional.'
+          - lang: ja
+            text: 'このプラグインはオプションです。'
+          - lang: pt
+            text: 'Este plugin é opcional.'
+    clean:
+      - crc: 0x807E1071
+        util: 'SSEEdit v4.0.3'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3770,6 +3770,17 @@ plugins:
       - 'TeenDolls - Lewd.esp'
       - 'TeenDolls - Physics(Official).esp'
 
+  - name: 'TheEyesOfBeauty.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/16185' ]
+    dirty:
+      - <<: *quickClean
+        crc: 0xB7F697EB
+        util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 2
+    clean:
+      - crc: 0x8E61D0D1
+        util: 'SSEEdit v4.0.3'
+
 ###### Character Appearance - Children ######
   - name: 'aAxeRSCtweaks.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/16044' ]


### PR DESCRIPTION
- created entries for RN&D 2 - Frostfall patch, Qwinn's ACE - CRF patch, The Eyes of Beauty, and SEELODGen terrain plugin
- added tags for RN&D 2 - FF patch, Shor's Stone, Notice Board - DB patch, Qwinn's ACE - CRF patch, and WACCF
- added cleaning info for new entries, especially The Eyes of Beauty, verified/updated rest along the way
- added message to indicate SSELODGen terrain plugin is optional as it's only needed for generating terrain LOD but harmless if left in
- unsure where to put the SSELODGen plugin as it's a modding tool but not generated by the user
- a more ambitious change that can be left out if it's excessive: created a common message for optional plugins as a few plugins use it and more probably could. it would also be easier for translators and contributors