### PR TITLE
Add entry for SSELODGen Terrain plugin

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16916,3 +16916,19 @@ plugins:
         condition: 'active("CCOR_Vokrii.esp") and active("Vokrii - WACCF Patch.esp")'
 
 ###### Anything new can go after this (If you're not sure where to put it) ######
+  - name: 'SSE-Terrain-Tamriel.esm'
+    url: [ 'https://forum.step-project.com/topic/13451-xlodgen-terrain-lod-beta-for-fnv-fo3-fo4-fo4vr-tes5-sse-tes5vr-enderal' ]
+    msg:
+      - type: say
+        content:
+          - lang: en
+            text: 'This plugin is optional.'
+          - lang: de
+            text: 'Dieses Plugin ist optional.'
+          - lang: ja
+            text: 'このプラグインはオプションです。'
+          - lang: pt
+            text: 'Este plugin é opcional.'
+    clean:
+      - crc: 0x807E1071
+        util: 'SSEEdit v4.0.3'


### PR DESCRIPTION
- added message to indicate that it's optional
- clean as of 22 Aug 2020 (no version #, don't think it's updated)
- didn't really know where to put it, Modding Tools almost seemed appropriate except that it's not a generated patch