### PR TITLE
Changes to DLC entries

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1154,9 +1154,7 @@ plugins:
         nav: 5
   - name: 'Dragonborn.esm'
     group: *dlcGroup
-    after:
-      - 'Dawnguard.esm'
-      - 'HearthFires.esm'
+    after: [ 'HearthFires.esm' ]
     tag:
       - Invent.Add
       - Invent.Remove

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1130,7 +1130,7 @@ plugins:
       # (V1.5.97.0, 0x955CCA77) after QAC
       - <<: *wildEdits
         type: say
-        subs: [ '[Dawnguard.esm Wild Edits Cleaning Guide](https://tes5edit.github.io/docs/6-mod-cleaning-and-error-checking.html#AppendixBManuallyCleaningDawnguard)' ]
+        subs: [ '[Dawnguard.esm Wild Edits Cleaning Guide](https://tes5edit.github.io/docs/7-mod-cleaning-and-error-checking.html#AppendixBManuallyCleaningDawnguard)' ]
         condition: 'checksum("Dawnguard.esm", 955CCA77)'
     dirty:
       - <<: *quickClean

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1108,6 +1108,8 @@ plugins:
       - C.Regions
       - C.Water
       - Delev
+      - Invent.Add
+      - Invent.Change
     dirty:
       - <<: *quickClean
         crc: 0x17AB5E20
@@ -1121,7 +1123,8 @@ plugins:
       - C.Location
       - C.Regions
       - Delev
-      - Invent
+      - Invent.Add
+      - Invent.Remove
       - Relev
     msg:
       # (V1.5.97.0, 0x955CCA77) after QAC
@@ -1141,7 +1144,7 @@ plugins:
     after: [ 'Dawnguard.esm' ]
     tag:
       - C.Location
-      - Invent
+      - Invent.Add
     dirty:
       - <<: *quickClean
         crc: 0xBAD9393A
@@ -1155,8 +1158,8 @@ plugins:
       - 'Dawnguard.esm'
       - 'HearthFires.esm'
     tag:
-      - Invent
-      - Relev
+      - Invent.Add
+      - Invent.Remove
     dirty:
       - <<: *quickClean
         crc: 0x0EB10E82


### PR DESCRIPTION
* added Invent.Add and Invent.Change to Update.esm
  - list of relevant records: 000ABD9E, 000B2035, 00078C0C
* replaced deprecated Invent tags with appropriate new tags
* removed Relev tag from Dragonborn.esm
  - someone may have added it for this record, 00105242, but Relev doesn't forward the LVLD change
* inventory and leveled list tags were the only i considered
* updated wild edits guide URL
* removed unnecessary load rule
  - Hearthfire already loads after Dawnguard because of line 1141