### PR TITLE
Load AI Overhaul after Immersive Weapons

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8030,6 +8030,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/21654'
         name: 'AI Overhaul SSE'
+    after: [ 'Immersive Weapons.esp' ]
     tag:
       - Actors.ACBS
       - Actors.AIData


### PR DESCRIPTION
* So Wrye Bash keeps USSEP changes forwarded by AIO but not IW