### PR TITLE
Update Skyrim Particle Patch for ENB

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1915,6 +1915,28 @@ plugins:
       - <<: *alsoUseX
         subs: [ '[ENB Helper SE](https://www.nexusmods.com/skyrimspecialedition/mods/23174)' ]
         condition: 'file("../skse64_loader.exe") and file("../d3d11.dll") and not file("skse/plugins/ENBHelperSE.dll")'
+      - type: say
+        content:
+          - lang: en
+            text: 'When using **%1%**, it''s recommended that you deactivate or delete this ESP file, but keep the resources (e.g. meshes, textures) installed with this mod.'
+          - lang: de
+            text: 'Beim Nutzen von **%1%** ist es empfohlen, dass Sie die ESP-Datei deaktivieren oder löschen, aber die mitgelieferten Mittel (z.B Meshes, Texturen) beibehalten die mit dieser Mod mitinstalliert wurden.'
+          - lang: ja
+            text: '**%1%**を使用中の場合。このespファイルは無効化あるいは削除するのはおすすめしますが、このmodによってインストールされたリソース(メッシュ、テクスチャなど)はそのままにしておいてください。'
+          - lang: ko
+            text: '**%1%** 모드를 사용중일 떈, 이 ESP 파일을 삭제하고 함께 설치된 리소스(예: 메쉬, 텍스쳐)만 남겨두는 걸 권장합니다.'
+          - lang: pl
+            text: 'Używając **%1%**, jest rekomendowane abyś dezaktywował lub usunął ten plik ESP, ale pozostawił zasoby (siatki, tekstury) zainstalowane z tym modem.'
+          - lang: pt
+            text: 'Ao utilizar **%1%**, é recomendado que você desative ou apage este ficheiro ESP, mas mantenha os recursos (ex. meshes, texturas) instalados por este mod.'
+          - lang: pt_BR
+            text: 'Quando se usa **%1%**, é recomendado que você desative ou delete este arquivo ESP, mas que mantenha os recursos (ex. meshes, texturas) que vieram com esse mod.'
+          - lang: ru
+            text: 'Пока используется **%1%**, рекомендуется отключить или удалить esp этого мода, но оставить установленные ресурсы (meshes, textures).'
+          - lang: sv
+            text: 'När du använder **%1%** är det rekommenderat att du avaktiverar eller tar bort denna ESP-fil, men behåll resurserna (meshar och texturer) installerade med denna mod.'
+        subs: [ '[ENB Helper SE](https://www.nexusmods.com/skyrimspecialedition/mods/23174)' ]
+        condition: 'file("skse/plugins/ENBHelperSE.dll") and active("Particle Patch for ENB SSE.esp")'
     tag:
       - C.Climate
       - C.ImageSpace

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1911,6 +1911,10 @@ plugins:
 
   - name: 'Particle Patch for ENB SSE.esp'
     url: [ 'http://enbseries.enbdev.com/forum/viewtopic.php?t=1499' ]
+    msg:
+      - <<: *alsoUseX
+        subs: [ '[ENB Helper SE](https://www.nexusmods.com/skyrimspecialedition/mods/23174)' ]
+        condition: 'file("../skse64_loader.exe") and file("../d3d11.dll") and not file("skse/plugins/ENBHelperSE.dll")'
     tag:
       - C.Climate
       - C.ImageSpace


### PR DESCRIPTION
* Based on [this post](http://enbseries.enbdev.com/forum/viewtopic.php?f=6&t=1499&start=1420#p84446) by the author
* Plugin is only needed by people who use ENB but not SKSE, but ENB Helper is preferred
* Preferred alsoUseX over alreadyInOrFixedByX or useInstead as only the plugin is deprecated, not the resources
* Wanted to use deletePlugin, but the sentence about it being a requirement would be inaccurate
* Instead copied the contents of deletePlugin and removed the sentence about a requirement from each translation as well
  - pt_BR was unchanged as it already doesn't seem to mention a requirement