### PR TITLE
Add Serana Dialogue Add-On

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8474,6 +8474,10 @@ plugins:
       - crc: 0xF3EF2798
         util: 'SSEEdit v4.0.2f'
 
+  - name: '(SeranaDialogAddon|SDA).*\.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/32161/' ]
+  - name: 'SeranaDialogAddon.esp'
+
   - name: 'Serana Dialogue Edit.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/16222/' ]
     after: [ 'Relationship Dialogue Overhaul.esp' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8477,6 +8477,7 @@ plugins:
   - name: '(SeranaDialogAddon|SDA).*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/32161/' ]
   - name: 'SeranaDialogAddon.esp'
+    inc: [ 'Marry Me Serana.esp' ]
     msg:
       - <<: *patchProvided
         subs: [ 'DX Crimson Blood Armor' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8477,6 +8477,7 @@ plugins:
   - name: '(SeranaDialogAddon|SDA).*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/32161/' ]
   - name: 'SeranaDialogAddon.esp'
+    tag: [ Keywords ]
 
   - name: 'Serana Dialogue Edit.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/16222/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8479,6 +8479,9 @@ plugins:
   - name: 'SeranaDialogAddon.esp'
     inc: [ 'Marry Me Serana.esp' ]
     msg:
+      - <<: *alsoUseX
+        subs: [ '[Serana Dialogue Edit](https://www.nexusmods.com/skyrimspecialedition/mods/16222/)' ]
+        condition: 'not active("Serana Dialogue Edit.esp")'
       - <<: *patchProvided
         subs: [ 'DX Crimson Blood Armor' ]
         condition: 'active("Crimson Blood Armor.esp") and not active("SDA- DX CBlood Patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8485,6 +8485,9 @@ plugins:
         subs: [ 'Lustmord Vampire Armor' ]
         condition: 'active("LustmordVampireArmor.esp") and not active("SDA-LustmordPatch.esp")'
     tag: [ Keywords ]
+    clean:
+      - crc: 0x2F3126C1
+        util: 'SSEEdit v4.0.3'
 
   - name: 'Serana Dialogue Edit.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/16222/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8477,6 +8477,10 @@ plugins:
   - name: '(SeranaDialogAddon|SDA).*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/32161/' ]
   - name: 'SeranaDialogAddon.esp'
+    msg:
+      - <<: *patchProvided
+        subs: [ 'Lustmord Vampire Armor' ]
+        condition: 'active("LustmordVampireArmor.esp") and not active("SDA-LustmordPatch.esp")'
     tag: [ Keywords ]
 
   - name: 'Serana Dialogue Edit.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8479,6 +8479,9 @@ plugins:
   - name: 'SeranaDialogAddon.esp'
     msg:
       - <<: *patchProvided
+        subs: [ 'DX Crimson Blood Armor' ]
+        condition: 'active("Crimson Blood Armor.esp") and not active("SDA- DX CBlood Patch.esp")'
+      - <<: *patchProvided
         subs: [ 'Lustmord Vampire Armor' ]
         condition: 'active("LustmordVampireArmor.esp") and not active("SDA-LustmordPatch.esp")'
     tag: [ Keywords ]


### PR DESCRIPTION
* Added location for plugin and patches
* Incompatible with mods that make Serana marriable (e.g. [Marry Me Serana](https://www.nexusmods.com/skyrimspecialedition/mods/21938/)) as it has its own custom implementation
* Added [SDE](https://www.nexusmods.com/skyrimspecialedition/mods/16222/) recommendation as this mod was designed as a companion to it, but it isn't a hard requirement
* Added messages for some patches included on mod page
  - DX Crimson Armor is a bit of a mess as there are 2 versions ([UNP](https://www.nexusmods.com/skyrimspecialedition/mods/29451/) & [CBBE](https://www.nexusmods.com/skyrimspecialedition/mods/29197/)) with multiple versions of the plugin each (2 for UNP, 7 for CBBE). Figured a basic message would be enough, but I could list out all the checksums if that's preferred
  - There are more patches for mods I avoid, so I'd rather avoid potentially poorly implementing and supporting them
* Added Keywords tag
  - all included LCTN records
* Added cleaning info
  - 1.8.2