### PR TITLE
Remove requirement from CBBE Morphs plugin

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3820,8 +3820,6 @@ plugins:
       - name: 'CalienteTools/BodySlide/BodySlide.exe'
         display: '[BodySlide and Outfit Studio](https://www.nexusmods.com/skyrimspecialedition/mods/201)'
       - 'CBBE.esp'
-      - name: 'meshes/actors/character/character assets/femalebody.tri'
-        display: 'RaceMenu Morph Files (Included in CBBE installer)'
       - name: 'RaceMenu.esp'
         display: '[RaceMenu Special Edition](https://www.nexusmods.com/skyrimspecialedition/mods/19080/)'
     clean:


### PR DESCRIPTION
  - Optional Morph Files are not required for the plugin to work.