### PR TITLE
Remove Hunterborn after for CACO

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6891,7 +6891,6 @@ plugins:
         name: 'Hunterborn SE'
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/17993/'
         name: 'Hunterborn SE MCM'
-    after: [ 'Complete Alchemy & Cooking Overhaul.esp' ]
     msg:
       - <<: *patch3rdParty_KPH_CACO
         condition: 'active("Complete Alchemy & Cooking Overhaul.esp") and not active("Hunterborn_CACO-SE_Patch.esp")'


### PR DESCRIPTION
  - This order was only set this way due to recommendation included with patch readme for KPH CACO Hunterborn patch.
  - Patch provided on Hunterborn MCM page patches all conflicts, so the order no longer matters.
  - Removing as Hunterborn is set to load before RND. Which would set the order as CACO -> Hunterborn -> RND.
  - RND also conflicts with CACO and patches I've checked only patch for RND -> CACO order.