### PR TITLE
Updates for Convenient Carriages & Unique Region Names

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6450,8 +6450,9 @@ plugins:
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 773
 
-  - name: 'Unique Region Names.esp'
+  - name: '(Unique Region Names|URN.*).esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/11750/' ]
+  - name: 'Unique Region Names.esp'
     group: *lowPriorityGroup
     after:
       - name: 'Immersive Citizens - AI Overhaul.esp'
@@ -6473,7 +6474,6 @@ plugins:
       - crc: 0xCE7B2414
         util: 'SSEEdit v4.0.3'
   - name: 'URN Extended.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/11750/' ]
     group: *fixesGroup
     clean:
       - crc: 0x5A8460BA

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11873,6 +11873,8 @@ plugins:
       # ICAIO - Default
       - crc: 0x8EEAB63F
         util: 'SSEEdit v4.0.3'
+  - name: 'CC_Ferry_Patch.esp'
+    after: [ 'Unique Region Names.esp' ]
 
   - name: 'Caveoftheforgotten.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/13499/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11829,8 +11829,9 @@ plugins:
       - crc: 0xB6FC130C
         util: 'SSEEdit v4.0.3'
 
-  - name: 'Convenient Carriages.esp'
+  - name: '(Convenient Carriages|CC_.*).esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12693/' ]
+  - name: 'Convenient Carriages.esp'
     after:
       - 'Clockwork.esp'
       - 'COTN - Dawnstar.esp'


### PR DESCRIPTION
Before load after rule:
* 0201A521
![conflict0](https://user-images.githubusercontent.com/69141501/94987937-b93ef200-051e-11eb-95ff-1fc2a010d3dd.png)

After load after rule:
* 00008E96
![conflict1](https://user-images.githubusercontent.com/69141501/94987951-c956d180-051e-11eb-8f84-4e9d9f049201.png)
* 0000B4B9
![conflict2](https://user-images.githubusercontent.com/69141501/94987959-d70c5700-051e-11eb-8135-e25996bf7adf.png)

* Updated locations for patches/add-ons for each mod while I was at it