### PR TITLE
Update Kalilies' NPCs

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4226,7 +4226,7 @@ plugins:
         util: 'SSEEdit v4.0.3'
       - crc: 0x062B1FEB
         util: 'SSEEdit v4.0.3'
-  - name: 'Kalilies.*(CRF|Cutting Room Floor) Patch.esp'
+  - name: 'Kalilies.*(CRF|Cutting Room Floor).*\.esp'
     req: [ 'Cutting Room Floor.esp' ]
   - name: 'Kalilies NPCs + AI Overhaul + Cutting Room Floor Patch.esp'
     after: [ 'AI Overhaul - Cutting Room Floor Patch.esp' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4205,7 +4205,7 @@ plugins:
       - crc: 0xD0F78346
         util: 'SSEEdit v4.0.2f'
 
-  - name: 'Kalilies( )?NPCs( \+ AI Overhaul)?( - CRF| \+ Cutting Room Floor)?( Patch)?.esp'
+  - name: '(KaliliesNPCs|Kalilies NPCs)(?! WARP).*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/30247/' ]
   - name: 'KaliliesNPCs.esp'
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4230,9 +4230,6 @@ plugins:
     req: [ 'Cutting Room Floor.esp' ]
   - name: 'Kalilies NPCs + AI Overhaul + Cutting Room Floor Patch.esp'
     after: [ 'AI Overhaul - Cutting Room Floor Patch.esp' ]
-    clean:
-      - crc: 0x29FFA6BD
-        util: 'SSEEdit v4.0.3'
 
   - name: 'Men of Winter.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10902/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4205,8 +4205,9 @@ plugins:
       - crc: 0xD0F78346
         util: 'SSEEdit v4.0.2f'
 
-  - name: 'KaliliesNPCs.esp'
+  - name: 'Kalilies( )?NPCs( \+ AI Overhaul)?( - CRF| \+ Cutting Room Floor)?( Patch)?.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/30247/' ]
+  - name: 'KaliliesNPCs.esp'
     msg:
       - <<: *patchProvided
         subs: [ 'AI Overhaul' ]
@@ -4226,7 +4227,6 @@ plugins:
       - crc: 0x062B1FEB
         util: 'SSEEdit v4.0.3'
   - name: 'Kalilies NPCs + AI Overhaul + Cutting Room Floor Patch.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/30247/' ]
     after: [ 'AI Overhaul - Cutting Room Floor Patch.esp' ]
     clean:
       - crc: 0x29FFA6BD

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4226,6 +4226,8 @@ plugins:
         util: 'SSEEdit v4.0.3'
       - crc: 0x062B1FEB
         util: 'SSEEdit v4.0.3'
+  - name: 'Kalilies.*(CRF|Cutting Room Floor) Patch.esp'
+    req: [ 'Cutting Room Floor.esp' ]
   - name: 'Kalilies NPCs + AI Overhaul + Cutting Room Floor Patch.esp'
     after: [ 'AI Overhaul - Cutting Room Floor Patch.esp' ]
     clean:


### PR DESCRIPTION
* Added location to patches provided on mod page
  - avoided using catch-all in regex as it would include plugins not on the page
* Added requirement to both CRF patches
* Removed unnecessary clean info I added in #1296 as I now figure it's a bit silly for patches that aren't dirty