### PR TITLE
Update Blood on the Ice Hotfix

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1634,8 +1634,9 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/24941/' ]
     group: *fixesGroup
     msg:
-      - <<: *useInstead
-        subs: [ '[Unofficial Skyrim Special Edition Patch](https://www.nexusmods.com/skyrimspecialedition/mods/266)' ]
+      - <<: *alreadyInOrFixedByX
+        subs: [ 'Unofficial Skyrim Special Edition Patch' ]
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp")'
 
   - name: 'BugfixCompilation.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/33449/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1634,9 +1634,8 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/24941/' ]
     group: *fixesGroup
     msg:
-      - <<: *alreadyInOrFixedByX
-        subs: [ 'Unofficial Skyrim Special Edition Patch' ]
-        condition: 'active("Unofficial Skyrim Special Edition Patch.esp")'
+      - <<: *useInstead
+        subs: [ '[Unofficial Skyrim Special Edition Patch](https://www.nexusmods.com/skyrimspecialedition/mods/266)' ]
 
   - name: 'BugfixCompilation.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/33449/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1637,6 +1637,10 @@ plugins:
       - <<: *alreadyInOrFixedByX
         subs: [ 'Unofficial Skyrim Special Edition Patch' ]
         condition: 'active("Unofficial Skyrim Special Edition Patch.esp")'
+      - <<: *useInstead
+        type: error
+        subs: [ '[Unofficial Skyrim Special Edition Patch](https://www.nexusmods.com/skyrimspecialedition/mods/266/) (see [this post](https://www.afkmods.com/index.php?/topic/4682-mods-made-obsolete-by-unofficial-skyrim-special-edition-patch/))' ]
+        condition: 'not active("Unofficial Skyrim Special Edition Patch.esp")'
 
   - name: 'BugfixCompilation.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/33449/' ]


### PR DESCRIPTION
Based on the [list](https://www.afkmods.com/index.php?/topic/4682-mods-made-obsolete-by-unofficial-skyrim-special-edition-patch/) of mods made obsolete by USSEP, it apparently can actually break the quest and should be avoided altogether (Arthmoor references the USSEP version explicitly, but the issue he mentions is present in the non-USSEP version as well).

> This file serves absolutely no purpose since the triggers are enabled in aliases during MS11 and will actually BREAK the quest if you use it.