### PR TITLE
Add tag to Missing Apprentices Quest Fix

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9216,6 +9216,7 @@ plugins:
     after:
       - 'BetterQuestObjectives-CRFPatch.esp'
       - 'Book Covers Skyrim.esp'
+    tag: [ Text ]
     clean:
       # version: 1.4
       - crc: 0x059F28E6


### PR DESCRIPTION
  - Adds new text to a book, reverted by USSEP/CRF which have a text tag.