### PR TITLE
Corrections for Invent.Remove and Relev changes made in #1341

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6724,8 +6724,7 @@ plugins:
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_ArsMetallica_Patch.esp")'
     tag:
-      - -Invent
-      - Invent.Add
+      - -Invent.Remove
       - -Names
     clean:
       - crc: 0x4688FC6A

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12827,6 +12827,7 @@ plugins:
     inc: [ 'DragonBridgeBoardwalk.esp' ]
     tag:
       - Actors.AIPackages
+      - Invent.Add
       - -Invent.Remove
     clean:
       # version: 2.0.5

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10389,6 +10389,7 @@ plugins:
       - Delev
       - Outfits.Add
       - Outfits.Remove
+      - Relev
     clean:
       # version: 8.1
       - crc: 0x8A28DB11

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7579,9 +7579,7 @@ plugins:
       - *requiresMCM
       - <<: *patch3rdPartyUVCPC
         condition: 'not active("Vokrii - Trade & Barter Patch.esp") and active("Vokrii - Minimalistic Perks of Skyrim.esp")'
-    tag:
-      - -Relev
-      - Text
+    tag: [ Text ]
     clean:
       # version: 2.0
       - crc: 0x09A56806

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6724,6 +6724,7 @@ plugins:
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_ArsMetallica_Patch.esp")'
     tag:
+      - Invent.Add
       - -Invent.Remove
       - -Names
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12826,8 +12826,7 @@ plugins:
     inc: [ 'DragonBridgeBoardwalk.esp' ]
     tag:
       - Actors.AIPackages
-      - -Invent
-      - Invent.Add
+      - -Invent.Remove
     clean:
       # version: 2.0.5
       - crc: 0x88C9CF62


### PR DESCRIPTION
* Fixed implementation for removing Invent.Remove from plugins using Invent to accommodate how WB handles deprecated tags
* Added back Relev for mods that change the flags (LVLF) subrecord of leveled lists
  - Will require a manual review when the leveled list patcher is rewritten
* Also noticed that the removal of Invent.Remove doesn't seem to show up next to the plugin in LOOT even though it shows up in its metadata and is recognized by WB. Not sure if it's an issue on my end or a bug in LOOT
![plugin](https://user-images.githubusercontent.com/69141501/95148637-a56ed800-0738-11eb-90d4-0b1609fdb27e.png)
![meta](https://user-images.githubusercontent.com/69141501/95148640-a7389b80-0738-11eb-8217-0140c411162e.png)

