### PR TITLE
Update tags for Cutting Room Floor

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12028,6 +12028,7 @@ plugins:
     tag:
       - -Actors.DeathItem
       - -C.RecordFlags
+      - EnchantmentStats
       - Factions
       - Invent.Add
       - Invent.Remove

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12026,15 +12026,7 @@ plugins:
         condition: 'active("TheChoiceIsYours.esp") and not active("TCIY_CRF_Patch.esp")'
       - *patch3rdPartySRPC
     tag:
-      - C.Location
-      - C.Owner
-      - C.RecordFlags
-      - Delev
       - Factions
-      - Graphics
-      - Invent
-      - Names
-      - Stats
     clean:
       - crc: 0xE71FE395
         util: 'SSEEdit v4.0.3'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12027,6 +12027,8 @@ plugins:
       - *patch3rdPartySRPC
     tag:
       - Factions
+      - Invent.Add
+      - Invent.Remove
     clean:
       - crc: 0xE71FE395
         util: 'SSEEdit v4.0.3'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12028,6 +12028,7 @@ plugins:
     tag:
       - -Actors.DeathItem
       - -C.RecordFlags
+      - EffectStats
       - EnchantmentStats
       - Factions
       - Invent.Add

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12031,6 +12031,8 @@ plugins:
       - Factions
       - Invent.Add
       - Invent.Remove
+      - Outfits.Add
+      - Outfits.Remove
     clean:
       - crc: 0xE71FE395
         util: 'SSEEdit v4.0.3'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12026,6 +12026,7 @@ plugins:
         condition: 'active("TheChoiceIsYours.esp") and not active("TCIY_CRF_Patch.esp")'
       - *patch3rdPartySRPC
     tag:
+      - -Actors.DeathItem
       - Factions
       - Invent.Add
       - Invent.Remove

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12035,6 +12035,7 @@ plugins:
       - Invent.Remove
       - Outfits.Add
       - Outfits.Remove
+      - SpellStats
     clean:
       - crc: 0xE71FE395
         util: 'SSEEdit v4.0.3'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12027,6 +12027,7 @@ plugins:
       - *patch3rdPartySRPC
     tag:
       - -Actors.DeathItem
+      - -C.RecordFlags
       - Factions
       - Invent.Add
       - Invent.Remove


### PR DESCRIPTION
* Removed tags already in plugin description
* Invent is in description, added Invent.Add & Invent.Remove in case author wants to update & replace deprecated tags (#1357)
* Removed unnecessary tags (Actors.DeathItem & C.RecordFlags) in description
* Added EffectStats, EnchantmentStats, Outfits.Add, Outfits.Remove, & SpellStats