### PR TITLE
Update Skyrim Revamped - Loot and Encounter Zones

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7540,8 +7540,11 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1772/' ]
     tag: [ Relev ]
 
+  - name: '(Skyrim Revamped|SR).*\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/14338/'
+        name: 'Skyrim Revamped - Loot and Encounter Zones'
   - name: 'Skyrim Revamped.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/14338/' ]
     after:
       - 'LoreWorthyBandits.esp'
       - 'WACCF_Armor and Clothing Extension.esp'
@@ -7579,7 +7582,6 @@ plugins:
       - crc: 0xD3688B7B
         util: 'SSEEdit v4.0.2f'
   - name: '(Skyrim Revamped|SR) - (InsanitySorrow Weapon''s Pack|Lore Weapon Expansion Patch|Skyrim Expanded Weaponry NPC Patch|Summermyst Patch)\.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/14338/' ]
     req: [ 'Skyrim Revamped.esp' ]
     tag:
       - Delev

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7549,6 +7549,8 @@ plugins:
       - 'Weapon AF.esp'
       - 'Weapons Armor Clothing & Clutter Fixes.esp'
     tag:
+      - name: C.Name
+        condition: 'checksum("Skyrim Revamped.esp", A2D9E76A) or checksum("Skyrim Revamped.esp", 53DAAB81)'
       - Invent.Add
       - Invent.Change
       - Invent.Remove

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7540,7 +7540,7 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1772/' ]
     tag: [ Relev ]
 
-  - name: '(Skyrim Revamped|SR).*\.esp'
+  - name: '(Skyrim Revamped|SR - ).*\.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/14338/'
         name: 'Skyrim Revamped - Loot and Encounter Zones'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7549,6 +7549,12 @@ plugins:
       - 'Weapon AF.esp'
       - 'Weapons Armor Clothing & Clutter Fixes.esp'
     tag:
+      - name: -C.Encounter
+        condition: 'checksum("Skyrim Revamped.esp", 78B11FA1)'
+      - name: -C.Location
+        condition: 'checksum("Skyrim Revamped.esp", 78B11FA1)'
+      - name: -C.Name
+        condition: 'checksum("Skyrim Revamped.esp", 78B11FA1)'
       - name: C.Name
         condition: 'checksum("Skyrim Revamped.esp", A2D9E76A) or checksum("Skyrim Revamped.esp", 53DAAB81)'
       - Invent.Add

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7582,10 +7582,16 @@ plugins:
       - <<: *patchProvided
         subs: [ 'Lore Weapon Expansion' ]
         condition: 'active("Lore Weapon Expansion.esp") and not active("SR - Lore Weapon Expansion Patch.esp")'
+    dirty:
+      - <<: *quickClean
+        crc: 0xA2D9E76A
+        util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 4
     clean:
-      # version: 2.0
       - crc: 0xD3688B7B
-        util: 'SSEEdit v4.0.2f'
+        util: 'SSEEdit v4.0.3'
+      - crc: 0x78B11FA1
+        util: 'SSEEdit v4.0.3'
   - name: '(Skyrim Revamped|SR) - (InsanitySorrow Weapon''s Pack|Lore Weapon Expansion Patch|Skyrim Expanded Weaponry NPC Patch|Summermyst Patch)\.esp'
     req: [ 'Skyrim Revamped.esp' ]
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7545,6 +7545,11 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/14338/'
         name: 'Skyrim Revamped - Loot and Encounter Zones'
   - name: 'Skyrim Revamped.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/17653/'
+        name: '(SJG) OMEGA - The Modular Gameplay Overhaul for SSE Replacer'
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/33718/'
+        name: 'OMEGA Updated Replacer'
     after:
       - 'LoreWorthyBandits.esp'
       - 'WACCF_Armor and Clothing Extension.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7551,6 +7551,7 @@ plugins:
     tag:
       - Invent.Add
       - Invent.Change
+      - Invent.Remove
     msg:
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_SRLEZ_Patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7549,8 +7549,6 @@ plugins:
       - 'Weapon AF.esp'
       - 'Weapons Armor Clothing & Clutter Fixes.esp'
     tag:
-      - Delev
-      - Relev
     msg:
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_SRLEZ_Patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7544,7 +7544,6 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/14338/' ]
     after:
       - 'LoreWorthyBandits.esp'
-      - 'mrbs-uniqueloot-se.esp'
       - 'WACCF_Armor and Clothing Extension.esp'
       - 'Weapon AF.esp'
       - 'Weapons Armor Clothing & Clutter Fixes.esp'
@@ -7575,9 +7574,6 @@ plugins:
       - <<: *patchProvided
         subs: [ 'Lore Weapon Expansion' ]
         condition: 'active("Lore Weapon Expansion.esp") and not active("SR - Lore Weapon Expansion Patch.esp")'
-      - <<: *patchProvided
-        subs: [ 'Unique Loot' ]
-        condition: 'active("mrbs-uniqueloot-se.esp") and not active("Skyrim Revamped - Unique Loot Patch.esp")'
     clean:
       # version: 2.0
       - crc: 0xD3688B7B
@@ -7588,9 +7584,6 @@ plugins:
     tag:
       - Delev
       - Relev
-  - name: 'Skyrim Revamped - Unique Loot Patch.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/14338/' ]
-    tag: [ Invent ]
 
   - name: 'Skytoxin.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/13153/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7549,6 +7549,7 @@ plugins:
       - 'Weapon AF.esp'
       - 'Weapons Armor Clothing & Clutter Fixes.esp'
     tag:
+      - Invent.Add
     msg:
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_SRLEZ_Patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7550,6 +7550,7 @@ plugins:
       - 'Weapons Armor Clothing & Clutter Fixes.esp'
     tag:
       - Invent.Add
+      - Invent.Change
     msg:
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_SRLEZ_Patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7550,7 +7550,6 @@ plugins:
       - 'Weapons Armor Clothing & Clutter Fixes.esp'
     tag:
       - Delev
-      - Invent
       - Relev
     msg:
       - <<: *patch3rdParty_LotD


### PR DESCRIPTION
* Part of #1357 

* Remove tags
  - C.Encounter from OMEGA Updated replacer, it's unused.
  - C.Location from OMEGA Updated replacer, it's unused.
  - C.Name from OMEGA Updated replacer, it's unused.
  - Delev from every version, it's in the description.
  - Invent from every version, it's deprecated.
  - Relev from every version, it's in the description of each version.

* Add tags
  - C.Name to OMEGA replacer, it edits many cell names.
  - Invent.Add to every version, it adds items to many containers.
  - Invent.Change to every version, it changes item counts in many containers.
  - Invent.Remove to every version, it removes items from many containers.

* Update cleaning info
  - Version 2.0, D3688B7B
  - OMEGA Replacer Version 1.99.9, A2D9E76A
  - OMEGA Updater Version 2.3.3, 78B11FA1

* Add locations
  - Add links and names for OMEGA and OMEGA Updated replacers

* Update location
  - Share original link and name between plugin and patches

* Remove message
  - Patch provided, Unique Loot's original page was hidden, it was moved to a new page with a new plugin name, and it doesn't have an SE port.

* Remove after
  - Unique Loot, it's original page was hidden, it was moved to a new page with a new plugin name, and it doesn't have an SE port.

### For patches

* Remove entry
  - Unique Loot patch, Unique Loot's original page was hidden, it was moved to a new page with a new plugin name, and it doesn't have an SE port.