### PR TITLE
Update Improved Closefaced Helmets

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17406,6 +17406,9 @@ plugins:
       - <<: *alreadyInX
         subs: [ 'imp_helm_legend_WACCF_Patch.esp' ]
         condition: 'active("imp_helm_legend_WACCF_Patch.esp")'
+      - <<: *useInstead
+        subs: [ 'imp_helm_legend_WACCF_Patch.esp' ]
+        condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp")'
 
   - name: 'maplightfix.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17406,6 +17406,9 @@ plugins:
       - <<: *alreadyInX
         subs: [ 'imp_helm_legend_WACCF_Patch.esp' ]
         condition: 'active("imp_helm_legend_WACCF_Patch.esp")'
+      - <<: *alreadyInX
+        subs: [ 'imp_helm_legend_WACCF_AMB_Patch.esp' ]
+        condition: 'active("imp_helm_legend_WACCF_AMB_Patch.esp")'
       - <<: *useInstead
         subs: [ 'imp_helm_legend_WACCF_Patch.esp' ]
         condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17576,7 +17576,7 @@ plugins:
       - <<: *alreadyInX
         subs: [ 'DawnguardArsenal_CCOR_Patch.esp']
         condition: 'active("DawnguardArsenal_CCOR_Patch.esp")'
-  - name: '(imp_helm_legend_WACCF_Patch|ImprovedClosefacedHelmets_WACCF).esp'
+  - name: '(imp_helm_legend_WACCF_Patch|ImprovedClosefacedHelmets_WACCF)\.esp'
     msg:
       - <<: *alreadyInX
         subs: [ 'imp_helm_legend_WACCF_AMB_Patch.esp']

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17402,6 +17402,10 @@ plugins:
     after: [ 'imp_helm_USSEP.esp' ]
   - name: 'imp_helm_USSEP.esp'
     req: [ 'Unofficial Skyrim Special Edition Patch.esp' ]
+    msg:
+      - <<: *alreadyInX
+        subs: [ 'imp_helm_legend_WACCF_Patch.esp' ]
+        condition: 'active("imp_helm_legend_WACCF_Patch.esp")'
 
   - name: 'maplightfix.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10749,10 +10749,9 @@ plugins:
         condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp") and not active("imp_helm_legend_WACCF_Patch.esp") and not active("imp_helm_legend_WACCF_AMB_Patch.esp")'
     tag: [ Graphics ]
     dirty:
-      # version: 1.58
       - <<: *quickClean
         crc: 0x8491D752
-        util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 5
 
   - name: '1nivWICCloaks(NoGuards)?\.esp'
@@ -17399,23 +17398,10 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/12405/'
         name: 'Improved Closedfaced Helmets Patches'
-  - name: 'imp_helm_Immersive_Armors.esp'
-    clean:
-      # version: 1
-      - crc: 0x5C4A5C28
-        util: 'SSEEdit v4.0.2'
   - name: 'imp_helm_IDPM.esp'
     after: [ 'imp_helm_USSEP.esp' ]
-    clean:
-      # version: 1
-      - crc: 0x135E09DE
-        util: 'SSEEdit v4.0.2'
   - name: 'imp_helm_USSEP.esp'
     req: [ 'Unofficial Skyrim Special Edition Patch.esp' ]
-    clean:
-      # version: 1
-      - crc: 0x56ED0191
-        util: 'SSEEdit v4.0.2'
 
   - name: 'maplightfix.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17412,6 +17412,9 @@ plugins:
       - <<: *useInstead
         subs: [ 'imp_helm_legend_WACCF_Patch.esp' ]
         condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp")'
+      - <<: *useInstead
+        subs: [ 'imp_helm_legend_WACCF_AMB_Patch.esp' ]
+        condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp") and active("aMidianBorn_ContentAddon.esp")'
 
   - name: 'maplightfix.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17584,6 +17584,8 @@ plugins:
       - <<: *useInstead
         subs: [ 'imp_helm_legend_WACCF_AMB_Patch.esp']
         condition: 'active("aMidianBorn_ContentAddon.esp") and version("aMidianBorn_ContentAddon.esp", "2.0", >=)'
+  - name: 'ImprovedClosefacedHelmets_WACCF.esp'
+    msg: [ *obsolete ]
   - name: 'Immersive Weapons_WACCF_Patch.esp'
     msg:
       - <<: *alreadyInX

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10754,27 +10754,6 @@ plugins:
         crc: 0x8491D752
         util: '[SSEEdit v4.0.0](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 5
-  - name: 'imp_helm_(Immersive_Armors|IDPM|USSEP)\.esp'
-    url:
-      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/12405/'
-        name: 'Improved Closedfaced Helmets Patches'
-  - name: 'imp_helm_Immersive_Armors.esp'
-    clean:
-      # version: 1
-      - crc: 0x5C4A5C28
-        util: 'SSEEdit v4.0.2'
-  - name: 'imp_helm_IDPM.esp'
-    after: [ 'imp_helm_USSEP.esp' ]
-    clean:
-      # version: 1
-      - crc: 0x135E09DE
-        util: 'SSEEdit v4.0.2'
-  - name: 'imp_helm_USSEP.esp'
-    req: [ 'Unofficial Skyrim Special Edition Patch.esp' ]
-    clean:
-      # version: 1
-      - crc: 0x56ED0191
-        util: 'SSEEdit v4.0.2'
 
   - name: '1nivWICCloaks(NoGuards)?\.esp'
     url:
@@ -17415,6 +17394,28 @@ plugins:
     clean:
       - crc: 0x2042F66D
         util: 'SSEEdit v4.0.3'
+
+  - name: 'imp_helm_(Immersive_Armors|IDPM|USSEP)\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/12405/'
+        name: 'Improved Closedfaced Helmets Patches'
+  - name: 'imp_helm_Immersive_Armors.esp'
+    clean:
+      # version: 1
+      - crc: 0x5C4A5C28
+        util: 'SSEEdit v4.0.2'
+  - name: 'imp_helm_IDPM.esp'
+    after: [ 'imp_helm_USSEP.esp' ]
+    clean:
+      # version: 1
+      - crc: 0x135E09DE
+        util: 'SSEEdit v4.0.2'
+  - name: 'imp_helm_USSEP.esp'
+    req: [ 'Unofficial Skyrim Special Edition Patch.esp' ]
+    clean:
+      # version: 1
+      - crc: 0x56ED0191
+        util: 'SSEEdit v4.0.2'
 
   - name: 'maplightfix.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10734,7 +10734,7 @@ plugins:
         subs:
           - 'Immersive Armors'
           - '[Improved Closedfaced Helmets Patches](https://www.nexusmods.com/skyrimspecialedition/mods/12405)'
-        condition: 'active("Hothtrooper44_ArmorCompilation.esp") and not active("imp_helm_Immersive_Armors.esp") and not active("Weapons Armor Clothing & Clutter Fixes.esp")'
+        condition: 'active("Hothtrooper44_ArmorCompilation.esp") and not active("imp_helm_Immersive_Armors.esp")'
       - <<: *patch3rdParty
         subs:
           - 'Improved Dragon Priest Masks SE'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10746,7 +10746,7 @@ plugins:
           - '[Improved Closedfaced Helmets Patches](https://www.nexusmods.com/skyrimspecialedition/mods/12405)'
         condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("imp_helm_USSEP.esp") and not active("Weapons Armor Clothing & Clutter Fixes.esp")'
       - <<: *patch3rdParty_KPH_WACCF
-        condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp") and (checksum("imp_helm_legend.esp", 8491D752) or checksum("imp_helm_legend.esp", D7423A4E)) and not active("ImprovedClosefacedHelmets_WACCF.esp") and not active("imp_helm_legend_WACCF_Patch.esp") and not active("imp_helm_legend_WACCF_AMB_Patch.esp")'
+        condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp") and not active("imp_helm_legend_WACCF_Patch.esp") and not active("imp_helm_legend_WACCF_AMB_Patch.esp")'
     tag: [ Graphics ]
     dirty:
       # version: 1.58


### PR DESCRIPTION
* Update messages
  - patch3rdParty: WACCF patches don't include consistency changes from IA patch.
  - patch3rdParty_KPH_WACCF: Removed checks for outdated WACCF patches.

* Update cleaning info
  - Version 1.58

### For patches

* Move entries
  - Move 3rd party patches to 3rd party patches section.

* Add entry
  - ImprovedClosefacedHelmets_WACCF.esp: For message.

* Remove entry
  - imp_helm_Immersive_Armors.esp: Removed all metadata.

* Update entry name
  - (imp_helm_legend_WACCF_Patch|ImprovedClosefacedHelmets_WACCF)\.esp: Escape "." since it's a regex.

* Add messages
  - imp_helm_USSEP.esp: alreadyInX, USSEP patch is included in WACCF patch.
  - imp_helm_USSEP.esp: alreadyInX, USSEP patch is included in WACCF - AMB patch.
  - imp_helm_USSEP.esp: useInstead, USSEP patch is included in WACCF patch.
  - imp_helm_USSEP.esp: useInstead, USSEP patch is included in WACCF - AMB patch.
  - ImprovedClosefacedHelmets_WACCF.esp: obsolete, Newest WACCF patch has a different name.

* Remove cleaning info
  - Unnecessary for small patches.