### PR TITLE
Update tags for a few mods

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6281,6 +6281,8 @@ plugins:
       - Invent.Remove
       - Keywords
       - Text
+  - name: 'Crossbow Integration - USSEP.esp'
+    tag: [ Text ]
 
   - name: 'EBM_Train(10|25|50|99)x.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10580/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1098,6 +1098,7 @@ plugins:
       - Delev
       - Invent.Add
       - Invent.Change
+      - Keywords
     dirty:
       - <<: *quickClean
         crc: 0x17AB5E20

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6268,6 +6268,10 @@ plugins:
         util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 9
 
+  - name: 'Creation Club Integration - Studded Dragonscale.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/29020/' ]
+    tag: [ Keywords ]
+
   - name: 'EBM_Train(10|25|50|99)x.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10580/' ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6280,6 +6280,7 @@ plugins:
       - Invent.Add
       - Invent.Remove
       - Keywords
+      - Text
 
   - name: 'EBM_Train(10|25|50|99)x.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10580/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6277,6 +6277,7 @@ plugins:
   - name: 'Crossbow Integration.esp'
     tag:
       - -Actors.Stats
+      - Invent.Add
 
   - name: 'EBM_Train(10|25|50|99)x.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10580/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6272,6 +6272,12 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/29020/' ]
     tag: [ Keywords ]
 
+  - name: 'Crossbow Integration.*/.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/28766/' ]
+  - name: 'Crossbow Integration.esp'
+    tag:
+      - -Actors.Stats
+
   - name: 'EBM_Train(10|25|50|99)x.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10580/' ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6279,6 +6279,7 @@ plugins:
       - -Actors.Stats
       - Invent.Add
       - Invent.Remove
+      - Keywords
 
   - name: 'EBM_Train(10|25|50|99)x.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10580/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6278,6 +6278,7 @@ plugins:
     tag:
       - -Actors.Stats
       - Invent.Add
+      - Invent.Remove
 
   - name: 'EBM_Train(10|25|50|99)x.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10580/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1148,6 +1148,7 @@ plugins:
       - C.Location
       - Invent.Add
       - Invent.Remove
+      - Text
     dirty:
       - <<: *quickClean
         crc: 0x0EB10E82

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2655,6 +2655,7 @@ plugins:
             text: 'Benötigt Ressourcen (Models, Texturen usw. Plugins werden nicht benötigt.) von %1%.'
         subs: [ '[Skyrim Particle Patch for ENB-SSE](http://enbseries.enbdev.com/forum/viewtopic.php?t=1499)' ]
         condition: 'not file("textures/effects/gradients/gradillusiondark01m.dds")'
+    tag: [ Graphics ]
 
   - name: 'ImprovedHearthfireLighting.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/721' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6589,6 +6589,8 @@ plugins:
     clean:
       - crc: 0x5A8460BA
         util: 'SSEEdit v4.0.3'
+  - name: 'URN Extended_Telengard.esp'
+    tag: [ -C.Location ]
 
   - name: 'YASH2.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2430/' ]


### PR DESCRIPTION
* Fixes #1422 
* Update.esm
  - Add Keywords: adds keywords to armors for Survival Mode that are sometimes reverted by older mods e.g. Unlimited Bookshelves.

* Dragonborn.esm
  - Add Text: edits descriptions that are reverted by some mods e.g. Improved Daedric Artifacts.

* ENB Light
  - Add Graphics: edits casting art of multiple magic effects.

* Unique Region Names - Telengard Patch
  - Remove C.Location: forwards from Telengard which already has C.Location anyway.

* Creation Club Integration for Alternative Armors - Dragonscale
  - Add Keywords: adds keywords to a few armors.

* Crossbow Integration
  - Remove Actors.Stats: stats change for DLC1Vanik (02003D03) isn't mentioned by author or related to mod.
  - Add Invent.Add: adds leveled items to many containers and NPCs. Replaces Invent in plugin description.
  - Add Invent.Remove: removes items from multiple NPCs. Replaces Invent in plugin description.
  - Add Keywords: adds keywords to a few weapons.
  - Add Text: edits the description of a load screen (02017F95).

* Crossbow Integration - USSEP Patch
  - Add Text: edits description of a load screen (02017F95) to be more consistent with USSEP.