### PR TITLE
Update Pandorable's NPCs

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4334,6 +4334,11 @@ plugins:
       - <<: *patchProvided
         subs: [ 'AI Overhaul' ]
         condition: 'active("AI Overhaul.esp") and not active("AI Overhaul - PAN_NPCs Patch.esp")'
+    clean:
+      - crc: 0x5550DC82
+        util: 'SSEEdit v4.0.3'
+      - crc: 0xA3F0ED46
+        util: 'SSEEdit v4.0.3'
   - name: 'AI Overhaul - PAN_NPCs Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/19012/' ]
     after: [ 'AI Overhaul - Cutting Room Floor Patch.esp' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4326,10 +4326,11 @@ plugins:
       - <<: *useBashTweakInstead
         subs: [ 'Tweak Actors: Opposite Gender Anims Female' ]
 
-  - name: 'PAN_NPCs.esp'
+  - name: '.*PAN_NPCs( Patch)?\.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19012/'
         name: 'Pandorable''s NPCs'
+  - name: 'PAN_NPCs.esp'
     msg:
       - <<: *patchProvided
         subs: [ 'AI Overhaul' ]
@@ -4340,7 +4341,6 @@ plugins:
       - crc: 0xA3F0ED46
         util: 'SSEEdit v4.0.3'
   - name: 'AI Overhaul - PAN_NPCs Patch.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/19012/' ]
     after: [ 'AI Overhaul - Cutting Room Floor Patch.esp' ]
 
   - name: 'PAN_NPCs_DB.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4342,9 +4342,7 @@ plugins:
   - name: 'AI Overhaul - PAN_NPCs Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/19012/' ]
     after: [ 'AI Overhaul - Cutting Room Floor Patch.esp' ]
-    clean:
-      - crc: 0x2611A250
-        util: 'SSEEdit v4.0.3'
+
   - name: 'PAN_NPCs_DB.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/30680' ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4332,6 +4332,9 @@ plugins:
         name: 'Pandorable''s NPCs'
   - name: 'PAN_NPCs.esp'
     msg:
+      - <<: *patchIncluded
+        subs: [ 'Unofficial Skyrim Special Edition Patch' ]
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and checksum("PAN_NPCs.esp", 5550DC82)'
       - <<: *patchProvided
         subs: [ 'AI Overhaul' ]
         condition: 'active("AI Overhaul.esp") and not active("AI Overhaul - PAN_NPCs Patch.esp")'


### PR DESCRIPTION
* Combine redundant location metadata.

* Add message
  - patchIncluded: USSEP version.

* Add cleaning info
  - Version 1.4: 0x5550DC82
  - Version 1.4 USSEP: 0xA3F0ED46

### For Patches
* Remove cleaning info
  - AI Overhaul: unnecessary for a clean patch.