### PR TITLE
Update cleaning info for some mods

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18073,9 +18073,6 @@ plugins:
   - name: 'SSE-Terrain-Tamriel.esm'
     url: [ 'https://forum.step-project.com/topic/13451-xlodgen-terrain-lod-beta-for-fnv-fo3-fo4-fo4vr-tes5-sse-tes5vr-enderal' ]
     msg: [ *optional ]
-    clean:
-      - crc: 0x807E1071
-        util: 'SSEEdit v4.0.3'
 
   - name: 'Disease Descriptions.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/26992' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5923,24 +5923,6 @@ plugins:
         type: say
         subs: [ 'RBB - JKs Skyrim Patch.esp' ]
         condition: 'active("RBB - USSEP Patch.esp") and active("RBB - JKs Skyrim Patch.esp")'
-  - name: 'RBB - JKs Skyrim Patch.esp'
-    msg:
-      # after QAC
-      - <<: *wildEdits
-        type: say
-        subs: [ 'Remove records **000096F3**, **000097BF**, **000093BD**, & **0000939C** from RBB - JKs Skyrim Patch.esp.' ]
-        condition: 'checksum("RBB - JKs Skyrim Patch.esp", 882F7F3C)'
-    dirty:
-      - <<: *quickClean
-        crc: 0xA6132870
-        util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
-        itm: 4
-  - name: 'RBB - Telengard Patch.esp'
-    msg:
-      - <<: *wildEdits
-        type: say
-        subs: [ 'Remove record **00000D74** from RBB - Telengard Patch.esp.' ]
-        condition: 'checksum("RBB - Telengard Patch.esp", 6F8AE1F7)'
 
   - name: 'Realistic Treeline.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18046/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6393,6 +6393,9 @@ plugins:
       - Invent.Remove
       - Keywords
       - Text
+    clean:
+      - crc: 0xC3FFCD87
+        util: 'SSEEdit v4.0.3'
   - name: 'Crossbow Integration - USSEP.esp'
     tag: [ Text ]
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2370,11 +2370,11 @@ plugins:
         subs: [ 'Sacrosanct' ]
         condition: 'active("Sacrosanct - Vampires of Skyrim.esp") and not active("TESL-LS-AddonSacrosanct.esp")'
     clean:
-      - crc: 0x029F183B
+      - crc: 0x09BB88B3
         util: 'SSEEdit v4.0.3'
-      - crc: 0xA48BC3D8
+      - crc: 0x45B51807
         util: 'SSEEdit v4.0.3'
-      - crc: 0x35D1D933
+      - crc: 0xF84D6866
         util: 'SSEEdit v4.0.3'
   - name: 'TESL-LS-AddonSacrosanct.esp'
     tag: [ Text ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10109,7 +10109,7 @@ plugins:
       - <<: *patch3rdParty_KPH_CACO
         condition: 'active("Complete Alchemy & Cooking Overhaul.esp") and not active("CACO_Growl_Patch.esp")'
     clean:
-      - crc: 0xA9CE7065
+      - crc: 0x041CC3FF
         util: 'SSEEdit v4.0.3'
 
   - name: 'Lock_Overhaul.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9042,7 +9042,7 @@ plugins:
         condition: 'active("LustmordVampireArmor.esp") and not active("SDA-LustmordPatch.esp")'
     tag: [ Keywords ]
     clean:
-      - crc: 0xD47EABA0
+      - crc: 0x61AFBCBD
         util: 'SSEEdit v4.0.3'
 
   - name: 'Serana Dialogue Edit.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6383,6 +6383,9 @@ plugins:
   - name: 'Creation Club Integration - Studded Dragonscale.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/29020/' ]
     tag: [ Keywords ]
+    clean:
+      - crc: 0x7CD91DCE
+        util: 'SSEEdit v4.0.3'
 
   - name: 'Crossbow Integration.*/.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/28766/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1189,7 +1189,7 @@ plugins:
   - name: 'ccbgssse060-ba_dragonscale.esl'
     dirty:
       - <<: *quickClean
-        crc: 0xE4469CC6
+        crc: 0x29681D18
         util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
   # Alternative Armors - Dwarven Mail


### PR DESCRIPTION
* Add cleaning info
  - Creation Club Integration - Studded Dragonscale: version 2.1.2.
  - Crossbow Integration: version 2.1.0.

* Remove cleaning info
  - RBB - JK's Skyrim patch: version 4.0, clean checksum unnecessary for patch.
  - RBB - Telengard patch: version 4.0, ditto.
  - xLODGen Terrain plugin: unnecessary for utility plugin.

* Update cleaning info
  - Alternative Armors - Dragonscale (CC): as of 2020-10-28.
  - Growl - Werebeasts of Skyrim: version 2.3.0.
  - Serana Dialogue Add-On: version 1.9.4.
  - TESL Loading Screens - Tweaks and Addons: version 1.5 100% 09BB88B3, 50% 45B51807, 30% F84D6866.