### PR TITLE
Update Kalilies' NPCs messages

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4358,11 +4358,6 @@ plugins:
       - <<: *patchProvided
         subs: [ 'Cutting Room Floor' ]
         condition: 'active("Cutting Room Floor.esp") and not active("KaliliesNPCs - CRF Patch.esp") and not active("Kalilies NPCs + AI Overhaul + Cutting Room Floor Patch.esp")'
-      - <<: *patch3rdParty
-        subs:
-          - 'WARP - World Assets Recycle Project SE'
-          - '[Kalilies NPCs WARP patch](https://www.nexusmods.com/skyrimspecialedition/mods/33942/)'
-        condition: 'active("WARP.esp") and not active("KaliliesNPCs WARP PATCH.esp")'
     tag: [ Outfits.Remove ]
     clean:
       - crc: 0xB9CF4F08

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4349,6 +4349,9 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/30247/' ]
   - name: 'KaliliesNPCs.esp'
     msg:
+      - <<: *patchIncluded
+        subs: [ 'Unofficial Skyrim Special Edition Patch' ]
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and checksum("KaliliesNPCs.esp", 062B1FEB)'
       - <<: *patchProvided
         subs: [ 'AI Overhaul' ]
         condition: 'active("AI Overhaul.esp") and not active("Kalilies NPCs + AI Overhaul Patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4357,7 +4357,7 @@ plugins:
         condition: 'active("AI Overhaul.esp") and not active("Kalilies NPCs + AI Overhaul Patch.esp") and not active("Bashed Patch.*\.esp")'
       - <<: *patchProvided
         subs: [ 'Cutting Room Floor' ]
-        condition: 'active("Cutting Room Floor.esp") and not active("KaliliesNPCs - CRF Patch.esp") and not active("Kalilies NPCs + AI Overhaul + Cutting Room Floor Patch.esp")'
+        condition: 'active("Cutting Room Floor.esp") and not active("KaliliesNPCs - CRF Patch.esp") and not active("Kalilies NPCs + AI Overhaul + Cutting Room Floor Patch.esp") and not active("Bashed Patch.*\.esp")'
     tag: [ Outfits.Remove ]
     clean:
       - crc: 0xB9CF4F08

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4354,7 +4354,7 @@ plugins:
         condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and checksum("KaliliesNPCs.esp", 062B1FEB)'
       - <<: *patchProvided
         subs: [ 'AI Overhaul' ]
-        condition: 'active("AI Overhaul.esp") and not active("Kalilies NPCs + AI Overhaul Patch.esp")'
+        condition: 'active("AI Overhaul.esp") and not active("Kalilies NPCs + AI Overhaul Patch.esp") and not active("Bashed Patch.*\.esp")'
       - <<: *patchProvided
         subs: [ 'Cutting Room Floor' ]
         condition: 'active("Cutting Room Floor.esp") and not active("KaliliesNPCs - CRF Patch.esp") and not active("Kalilies NPCs + AI Overhaul + Cutting Room Floor Patch.esp")'


### PR DESCRIPTION
* Add message
  - patchIncluded: USSEP patch.

* Remove message
  - patch3rdParty: WARP patch, WARP's page has been hidden for months and will likely be replaced by a new mod.

* Update messages
  - patchProvided: AI Overhaul patch, can be patched with Bashed patch.
  - patchProvided: Cutting Room Floor patch, can be patched with Bashed patch (including 3-way patch).