### PR TITLE
Update Unique Region Names

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6754,7 +6754,9 @@ plugins:
         itm: 773
 
   - name: '(Unique Region Names|URN.*)\.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/11750/' ]
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/11750/'
+        name: 'Unique Region Names'
   - name: 'Unique Region Names.esp'
     group: *lowPriorityGroup
     after:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6753,7 +6753,7 @@ plugins:
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 773
 
-  - name: '(Unique Region Names|URN.*)\.esp'
+  - name: '(Unique Region Names|URN_.*)\.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/11750/'
         name: 'Unique Region Names'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12496,8 +12496,6 @@ plugins:
       # ICAIO - Default
       - crc: 0x8EEAB63F
         util: 'SSEEdit v4.0.3'
-  - name: 'CC_Ferry_Patch.esp'
-    after: [ 'Unique Region Names.esp' ]
 
   - name: 'Caveoftheforgotten.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/13499/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6753,7 +6753,7 @@ plugins:
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 773
 
-  - name: '(Unique Region Names|URN.*).esp'
+  - name: '(Unique Region Names|URN.*)\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/11750/' ]
   - name: 'Unique Region Names.esp'
     group: *lowPriorityGroup

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6776,6 +6776,8 @@ plugins:
     clean:
       - crc: 0xCE7B2414
         util: 'SSEEdit v4.0.3'
+  - name: 'URN_CastleVolkiharFerry.esp'
+    inc: [ 'CC_Ferry_Patch.esp' ]
   - name: 'URN Extended.esp'
     group: *fixesGroup
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6774,7 +6774,7 @@ plugins:
         type: say
         condition: 'version("Unique Region Names.esp", "5.0.0", >=) and not version("Unique Region Names.esp", "5.0.2", >=)'
     clean:
-      - crc: 0xCE7B2414
+      - crc: 0x85CA5093
         util: 'SSEEdit v4.0.3'
   - name: 'URN_CastleVolkiharFerry.esp'
     inc: [ 'CC_Ferry_Patch.esp' ]


### PR DESCRIPTION
* Update location
  - Escape . character as it's in a regex.
  - Add name for clarity.
  - Exclude URN Extended plugins as they've been moved to a new page.

* Update cleaning info
  - Version 5.0.8.

### Castle Volkihar ferry add-on
* Add incompatibility
  - Conflicts with CC's ferry add-on in a way that's best resolved by choosing one or the other.

### Convenient Carriages ferry add-on
* Remove after
  - Major conflict has been resolved, URN should now load after via group to prevent remaining conflicts.