### PR TITLE
Update afters for ELFX Fixes

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2633,10 +2633,14 @@ plugins:
         util: 'SSEEdit v4.0.3'
   - name: 'ELFX Fixes Ragged Flagon Fix.esp'
     after:
+      - 'ELE_SSE.esp'
       - 'ELFXEnhancer.esp'
       - 'ELFX - Hardcore.esp'
       - 'ELFX Fixes.esp'
+      - 'Luminosity Lighting Overhaul.esp'
+      - 'RLO - Interiors.esp'
       - 'RealisticWaterTwo.esp'
+      - 'WSEnhancer.esp'
     tag:
       - C.Light
       - C.Water

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2625,11 +2625,6 @@ plugins:
 
   - name: 'ELFX Fixes.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/25498' ]
-    after:
-      - 'Alternate Start - Live Another Life.esp'
-      - 'Immersive Citizens - AI Overhaul.esp'
-      - 'MLU.esp'
-      - 'Open Cities Skyrim.esp'
     tag:
       - C.Light
       - C.Water

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2625,6 +2625,7 @@ plugins:
 
   - name: 'ELFX Fixes.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/25498' ]
+    after: [ 'Skysan_ELFX_SMIM_Fix.esp' ]
     tag:
       - C.Light
       - C.Water


### PR DESCRIPTION
Removing afters from `ELFX Fixes.esp` as they cause some order issues when also using `LoS II - Tamriel Master Lights.esp` from [Lanterns Of Skyrim II](https://www.nexusmods.com/skyrimspecialedition/mods/30817).

Adding afters to `ELFX Fixes Ragged Flagon Fix.esp` for all known lighting enhancers.