### PR TITLE
Update Guard Dialogue Overhaul SE

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8169,7 +8169,7 @@ plugins:
     after:
       - 'Audio Overhaul Skyrim.esp'
       - name: 'Guard Dialogue Overhaul.esp'
-        condition: 'checksum("Guard Dialogue Overhaul.esp", 6ABC1129) or checksum("Guard Dialogue Overhaul.esp", 5CB27D7D) or checksum("Guard Dialogue Overhaul.esp", E248614B) or checksum("Guard Dialogue Overhaul.esp", E40EDE50) or checksum("Guard Dialogue Overhaul.esp", 7D16C40A)'
+        condition: 'checksum("Guard Dialogue Overhaul.esp", 6ABC1129) or checksum("Guard Dialogue Overhaul.esp", 7D16C40A) or checksum("Guard Dialogue Overhaul.esp", A244996E)'
       - 'Immersive Sounds - Compendium.esp'
       - 'TAR-GuildMaster1stPersonFix.esp'
       - 'Undeath.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8910,13 +8910,11 @@ plugins:
       - 'Hothtrooper44_ArmorCompilation.esp'
     tag: [ Keywords ]
     clean:
-      # version: 1.4.2 Redux, True GDO Port
       - crc: 0x6ABC1129
         util: 'SSEEdit v4.0.2f'
-      # version: 1.8.1 Redux
       - crc: 0x82FE6344
         util: 'SSEEdit v4.0.2f'
-      - crc: 0x7D16C40A
+      - crc: 0xA244996E
         util: 'SSEEdit v4.0.3'
 
   - name: 'How Hard Is This Persuasion Check.esp'


### PR DESCRIPTION
* Update cleaning info
  - Version 2.14.
  - Remove comments as they can be seen in the blame.

### WACCF
* Update after
  - Add checksum for GDO SE 2.14.
  - Remove checksums for older versions of GDO SE to reduce clutter, kept 2.13 and True GDO Port from GDO Redux.