### PR TITLE
Falkreath Hauntings - Add Do not clean message

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5287,10 +5287,7 @@ plugins:
 
   - name: 'ogFalkreathHauntings.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/20733/' ]
-    msg:
-      - type: say
-        content: 'Do not clean. "Dirty" edits are intentional and required for the mod to function.'
-        lang: eng
+    msg: [ *doNotClean ]
 
   - name: 'Rebalanced Encounter Zones.*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/25/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5287,11 +5287,10 @@ plugins:
 
   - name: 'ogFalkreathHauntings.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/20733/' ]
-    dirty:
-      - <<: *quickClean
-        crc: 0xF302A166
-        util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
-        itm: 3
+    msg:
+      - type: say
+        content: 'Do not clean. "Dirty" edits are intentional and required for the mod to function.'
+        lang: eng
 
   - name: 'Rebalanced Encounter Zones.*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/25/' ]


### PR DESCRIPTION
opusGlass' [Falkreath Hauntings](https://www.nexusmods.com/skyrimspecialedition/mods/20733/) contains 3 ITMs. These are required in order to for the Lady Ilinalta encounter to work properly. They are edits to flow data so that the freezing effect that the boss battle happens as is scripted. Water mods and any other mod that edits flow data in that location will cause the water not to freeze and render the boss battle impossible to complete.