### PR TITLE
Ultimate Combat/Wildcat/Smilodon corrections

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7076,7 +7076,6 @@ plugins:
       - *includesMBBF
   - name: 'Smilodon - Combat of Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2824/' ]
-    after: [ 'UltimateCombat.esp' ]
     msg:
       - <<: *compatNotes
         subs: [ 'https://www.nexusmods.com/skyrimspecialedition/articles/119' ]
@@ -7098,7 +7097,6 @@ plugins:
 
   - name: 'UltimateCombat.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/17196/' ]
-    after: [ 'Wildcat - Combat of Skyrim.esp' ]
     clean:
       - crc: 0x547BBCED
         util: 'SSEEdit v4.0.3'


### PR DESCRIPTION
Removed unnecessary "load after Ultimate Combat" from Smilodon.
Removed unnecessary "load after Wildcat" from Ultimate Combat.