### PR TITLE
Removing false information: Dawnguard Epilogues

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9718,7 +9718,11 @@ plugins:
       # version:  1.0r
       - crc: 0x53109251
         util: 'SSEEdit v4.0.2f'
-
+        
+  - name: 'Dawnguard&VolkiharArtifactsQuests.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12098' ]
+    msg: [ *doNotClean ]
+    
   - name: 'Dwarfsphere.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/15996/' ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9718,7 +9718,6 @@ plugins:
       # version:  1.0r
       - crc: 0x53109251
         util: 'SSEEdit v4.0.2f'
-        
   - name: 'Dawnguard&VolkiharArtifactsQuests.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12098' ]
     msg: [ *doNotClean ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9719,15 +9719,6 @@ plugins:
       - crc: 0x53109251
         util: 'SSEEdit v4.0.2f'
 
-  - name: 'Dawnguard&VolkiharArtifactsQuests.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12098' ]
-    inc: [ *LotD_v5 ]
-    dirty:
-      - <<: *quickClean
-        crc: 0xA887288B
-        util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
-        itm: 4
-
   - name: 'Dwarfsphere.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/15996/' ]
     msg:


### PR DESCRIPTION
As the mod author of Dawnguard and Clan Volkihar Epilogues (Dawnguard&VolkiharArtifactsQuests.esp), I can tell you with certainty that Legacy of the Dragonborn, and my mod, are not incompatible. I've used them side-by-side since I made it, even with V5 of Legacy, and they work together without a problem.

Likewise, the 4 itms are false reports, and are needed for the mod to work.