### PR TITLE
Update Guard Dialogue Overhaul

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9041,7 +9041,7 @@ plugins:
         util: 'SSEEdit v4.0.2f'
       - crc: 0x82FE6344
         util: 'SSEEdit v4.0.2f'
-      - crc: 0xA244996E
+      - crc: 0x15C41030
         util: 'SSEEdit v4.0.3'
 
   - name: 'How Hard Is This Persuasion Check.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8297,7 +8297,7 @@ plugins:
     inc: [ 'Race Scale Remover.esp' ]
     after:
       - name: 'Guard Dialogue Overhaul.esp'
-        condition: 'checksum("Guard Dialogue Overhaul.esp", 6ABC1129) or checksum("Guard Dialogue Overhaul.esp", 7D16C40A) or checksum("Guard Dialogue Overhaul.esp", A244996E)'
+        condition: 'checksum("Guard Dialogue Overhaul.esp", 6ABC1129) or checksum("Guard Dialogue Overhaul.esp", A244996E) or checksum("Guard Dialogue Overhaul.esp", 15C41030)'
       - 'TAR-GuildMaster1stPersonFix.esp'
       - name: 'Undeath.esp'
         condition: 'checksum("Undeath.esp", EB75A960)'


### PR DESCRIPTION
Fixes #1537 
* Update after
  - WACCF: Add checksum for new GDO 2.15.
  - WACCF: Remove checksum for old GDO 2.13.
* Update cleaning info
  - Version 2.15.