### PR TITLE
Add Zim's Improved Dremora tags & 3rd party patches

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18576,19 +18576,19 @@ plugins:
       - 'mjhKhajiitSpeak.esp'
 
   # Zim's Improved Dremora
-  - name: 'Zim's Improved Dremora.esp'
+  - name: "Zim's Improved Dremora.esp"
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12128' ]
     after: [ 'MLU.esp' ]
     msg:
       - <<: *patch3rdParty
         subs:
           - 'The Unofficial Skyrim Special Edition Patch (USSEP)'
-          - '[Zim's Improved Dremora -- USSEP Patch](https://www.nexusmods.com/skyrimspecialedition/mods/45399)'
+          - "[Zim's Improved Dremora -- USSEP Patch](https://www.nexusmods.com/skyrimspecialedition/mods/45399)"
         condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Zim's Improved Dremora  -- USSEP patch.esp")'
       - <<: *patch3rdParty
         subs:
           - 'No Animals Report Crimes (NARC)'
-          - '[Zim's Improved Dremora -- NARC Patch](https://www.nexusmods.com/skyrimspecialedition/mods/45397)'
+          - "[Zim's Improved Dremora -- NARC Patch](https://www.nexusmods.com/skyrimspecialedition/mods/45397)"
         condition: 'active("NARC SE for Vanilla.esp") and not active("Zim's Dremora Improvements -- NARC patch.esp")'
     tag:
       - Invent.Add

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18574,3 +18574,24 @@ plugins:
     after:
       - 'BA_KhajiitSpeakRedux_MAIN.esp'
       - 'mjhKhajiitSpeak.esp'
+
+  # Zim's Improved Dremora
+  - name: 'Zim's Improved Dremora.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12128' ]
+    after: [ 'MLU.esp' ]
+    msg:
+      - <<: *patch3rdParty
+        subs:
+          - 'The Unofficial Skyrim Special Edition Patch (USSEP)'
+          - '[Zim's Improved Dremora -- USSEP Patch](https://www.nexusmods.com/skyrimspecialedition/mods/45399)'
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Zim's Improved Dremora  -- USSEP patch.esp")'
+      - <<: *patch3rdParty
+        subs:
+          - 'No Animals Report Crimes (NARC)'
+          - '[Zim's Improved Dremora -- NARC Patch](https://www.nexusmods.com/skyrimspecialedition/mods/45397)'
+        condition: 'active("NARC SE for Vanilla.esp") and not active("Zim's Dremora Improvements -- NARC patch.esp")'
+    tag:
+      - Invent.Add
+      - Invent.Remove
+      - Names
+      - Relev

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18584,12 +18584,12 @@ plugins:
         subs:
           - 'The Unofficial Skyrim Special Edition Patch (USSEP)'
           - "[Zim's Improved Dremora -- USSEP Patch](https://www.nexusmods.com/skyrimspecialedition/mods/45399)"
-        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Zim's Improved Dremora  -- USSEP patch.esp")'
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Zim\u0027s Improved Dremora  -- USSEP patch.esp")'
       - <<: *patch3rdParty
         subs:
           - 'No Animals Report Crimes (NARC)'
           - "[Zim's Improved Dremora -- NARC Patch](https://www.nexusmods.com/skyrimspecialedition/mods/45397)"
-        condition: 'active("NARC SE for Vanilla.esp") and not active("Zim's Dremora Improvements -- NARC patch.esp")'
+        condition: 'active("NARC SE for Vanilla.esp") and not active("Zim\u0027s Dremora Improvements -- NARC patch.esp")'
     tag:
       - Invent.Add
       - Invent.Remove

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18576,20 +18576,20 @@ plugins:
       - 'mjhKhajiitSpeak.esp'
 
   # Zim's Improved Dremora
-  - name: "Zim's Improved Dremora.esp"
+  - name: 'Zim''s Improved Dremora.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12128' ]
     after: [ 'MLU.esp' ]
     msg:
       - <<: *patch3rdParty
         subs:
           - 'The Unofficial Skyrim Special Edition Patch (USSEP)'
-          - "[Zim's Improved Dremora -- USSEP Patch](https://www.nexusmods.com/skyrimspecialedition/mods/45399)"
-        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Zim\u0027s Improved Dremora -- USSEP patch.esp")'
+          - '[Zim''s Improved Dremora -- USSEP Patch](https://www.nexusmods.com/skyrimspecialedition/mods/45399)'
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Zim''s Improved Dremora -- USSEP patch.esp")'
       - <<: *patch3rdParty
         subs:
           - 'No Animals Report Crimes (NARC)'
-          - "[Zim's Improved Dremora -- NARC Patch](https://www.nexusmods.com/skyrimspecialedition/mods/45397)"
-        condition: 'active("NARC SE for Vanilla.esp") and not active("Zim\u0027s Dremora Improvements -- NARC patch.esp")'
+          - '[Zim''s Improved Dremora -- NARC Patch](https://www.nexusmods.com/skyrimspecialedition/mods/45397)'
+        condition: 'active("NARC SE for Vanilla.esp") and not active("Zim''s Dremora Improvements -- NARC patch.esp")'
     tag:
       - Invent.Add
       - Invent.Remove

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18584,7 +18584,7 @@ plugins:
         subs:
           - 'The Unofficial Skyrim Special Edition Patch (USSEP)'
           - "[Zim's Improved Dremora -- USSEP Patch](https://www.nexusmods.com/skyrimspecialedition/mods/45399)"
-        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Zim\u0027s Improved Dremora  -- USSEP patch.esp")'
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("Zim\u0027s Improved Dremora -- USSEP patch.esp")'
       - <<: *patch3rdParty
         subs:
           - 'No Animals Report Crimes (NARC)'


### PR DESCRIPTION
Masterlist tested locally; syntax passed and file-names matched plugins as expected.

Zim's Improved Dremora (ZID) alters an NPC's default outfit; MLU alters other records from the NPC; ZID after MLU allows a bashed patch to merge changes correctly.

Tags:
ZID adds stuff to containers like NPC inventories (hence Invent.Add), removes from merchant inventories (hence Invent.Remove), removes the names of some NPCs (hence Names), and changes the quantity of leveled NPCs (hence Relev).