### PR TITLE
Update Missing Encounter Zones FIXED

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1721,6 +1721,14 @@ plugins:
       - <<: *useOnlyOneX
         subs: [ 'Missing Encounter Zones FIXED' ]
         condition: 'many("MissingEZs(_AllExteriors|Fixed)\.esp")'
+  - name: 'MissingEZsFixed.esp'
+    clean:
+      - crc: 0xFE48F4ED
+        util: 'SSEEdit v4.0.3f'
+  - name: 'MissingEZs_AllExteriors.esp'
+    clean:
+      - crc: 0x28BE7164
+        util: 'SSEEdit v4.0.3f'
 
   - name: 'Modern Brawl Bug Fix.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1473/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1721,9 +1721,6 @@ plugins:
       - <<: *useOnlyOneX
         subs: [ 'Missing Encounter Zones FIXED' ]
         condition: 'many("MissingEZs(_AllExteriors|Fixed)\.esp")'
-    tag:
-      - C.Encounter
-      - C.Location
 
   - name: 'Modern Brawl Bug Fix.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1473/' ]


### PR DESCRIPTION
* Remove tags
  - Already in plugins' descriptions.
* Add cleaning info
  - Vanilla Fixes (FE48F4ED): version 2.2.
  - All Exteriors Zoned (28BE7164): version 2.2.