### PR TITLE
aMidianBorn Content Add on and Survival Patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18607,7 +18607,6 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19154'
         name: 'Survival Mode Patch Collection'
     msg:
-    msg:
       - <<: *alreadyInOrFixedByX
         subs: [ 'aMidianBorn Content Addon SE' ]
         condition: 'active("aMidianBorn_ContentAddon.esp") and version("aMidianBorn_ContentAddon.esp", "2.0", >=)'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18607,5 +18607,7 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19154'
         name: 'Survival Mode Patch Collection'
     msg:
-      - <<: *obsolete
-        subs: [ '[aMidianBorn_ContentAddon.esp](https://www.nexusmods.com/skyrimspecialedition/mods/35390)' ]
+    msg:
+      - <<: *alreadyInOrFixedByX
+        subs: [ 'aMidianBorn Content Addon SE' ]
+        condition: 'active("aMidianBorn_ContentAddon.esp") and version("aMidianBorn_ContentAddon.esp", "2.0", >=)'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18600,3 +18600,12 @@ plugins:
       - Invent.Remove
       - Names
       - Relev
+
+# Surival Mode Patches - aMidianBorn Content Add-on
+  - name: 'Survival Mode Patches - AMB Content Addon.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/19154'
+        name: 'Survival Mode Patch Collection'
+    msg:
+      - <<: *obsolete
+        subs: [ '[aMidianBorn_ContentAddon.esp](https://www.nexusmods.com/skyrimspecialedition/mods/35390)' ]


### PR DESCRIPTION
Per the Survival Mode Patches description: "Patches armors to get survival keywords and updates the companions script to include the SSE 1.5 changes."

The mod contains no scripts, compiled or source; its property edits land on items not referenced at all (i.e. orphaned, like "ArmorEbonyHelmetGilded"), or introduce the CCO_ArmorPerkScript script to the VMAD (e.g. "ArmorEbonyHelmetSilver_AMB"), whereas this usage has been dropped from Complete Crafting Overhaul in favor of the perk applying via keywords like "WAF_ArmorPerkSilver". aMidianBorn's Content Add-On already incorporates those keyword (both for the perk, as well as for survival warmth rating, which are sourced in Update.exe, so all SSE players should have them).

The patch also contains invalid references to alternate textures that can not be resolved, per SSEedit v4.0.3

The patch removes keywords added by AMB, and modifies other data, like value, weight, and names.

It seems to me the patch is not needed, as AMB already incorporates its desired survival changes. If anything, the patch rebalances AMB content beyond what the description states, sometimes rolling back updates.