### PR TITLE
Add "Text" bashed tag to AlchemyAdjustments.esp

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7281,6 +7281,7 @@ plugins:
       - 'EconomyOverhaulandSpeechcraftImprovementsLite.esp'
   - name: 'AlchemyAdjustments.esp'
     after: [ 'SkyTEST-RealisticAnimals&Predators.esp' ]
+    tag: [ Text ]
 
   - name: 'Ars Metallica.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/321/' ]


### PR DESCRIPTION
The tag is needed to properly display potion duration for potions that are instant in vanilla (e.g. "restore 6 health per second for 5 seconds" - the "for 5 seconds" part was lost, as it was imported from unofficial patch instead)