### PR TITLE
Save the Dark Brotherhood - Bash Tags

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18686,3 +18686,10 @@ plugins:
       - <<: *alreadyInOrFixedByX
         subs: [ 'aMidianBorn Content Addon SE' ]
         condition: 'active("aMidianBorn_ContentAddon.esp") and version("aMidianBorn_ContentAddon.esp", "2.0", >=)'
+
+# Save the Brotherhood
+  - name: 'SaveTheBrotherhood.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/33461' ]
+    tag:
+      - Actors.AIPackages
+      - Factions


### PR DESCRIPTION
The mod allows a mechanism for survival of the Dark Brotherhood members, allowing some to become followers. This requires adding the PotentialFollower factions, hence the Faction tag. It also adds custom sandbox AI packages, hence the AIPackages tag.