### PR TITLE
Update Book Covers Skyrim

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10969,24 +10969,26 @@ plugins:
   - name: 'Book Covers Skyrim.esp'
     url:
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/901/'
-      - 'https://bethesda.net/en/mods/skyrim/mod-detail/3071870/'
-      - 'https://bethesda.net/en/mods/skyrim/mod-detail/3072082'
-      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10'
+      - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3071870/'
+        name: 'Book Covers Skyrim - Original'
+      - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3072082/'
+        name: 'Book Covers Skyrim - Desaturated'
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/10/'
         name: 'Another Sorting Mod - Replacer Plugin'
     msg:
       - *alreadyInLotD
       - <<: *patch3rdParty
         subs:
           - 'Not So Fast - Main Quest'
-          - '[ Skylover''s Compatibility Patches ](https://www.nexusmods.com/skyrimspecialedition/mods/9849)'
+          - '[Skylover''s Compatibility Patches](https://www.nexusmods.com/skyrimspecialedition/mods/9849/)'
         condition: 'active("NotSoFast-MainQuest.esp") and not active("BCS_NotsoFast_Patch.esp")'
       - <<: *patch3rdParty
         subs:
           - 'Wintersun - Faiths of Skyrim'
-          - '[ Wintersun - Zim''s Immersive Artifacts and Book Covers Skyrim Patches ](https://www.nexusmods.com/skyrimspecialedition/mods/24228)'
+          - '[Wintersun - More Patches](https://www.nexusmods.com/skyrimspecialedition/mods/24228/)'
         condition: 'active("Wintersun - Faiths of Skyrim.esp") and not active("Wintersun - BCS Patch.esp")'
       - <<: *patch3rdParty_KPH_TCIY
-        condition: 'active("TheChoiceIsYours.esp") and not active("TCIY( |_)BCS Patch.esp")'
+        condition: 'active("TheChoiceIsYours.esp") and not active("TCIY BCS Patch.esp")'
     after:
       - 'Cutting Room Floor.esp'
       - 'Tel_Nalta.esp'
@@ -10999,21 +11001,21 @@ plugins:
       - Sound
       - Stats
     clean:
-      # version: 4.2
       - crc: 0x32587221
         util: 'SSEEdit v4.0.2f'
-      # Another Sorting Mod Replacer
       - crc: 0x00975168
         util: 'SSEEdit v4.0.3'
+
   - name: 'Book Covers Skyrim - Lost Library.esp'
     url:
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/902/'
-      - 'https://bethesda.net/en/mods/skyrim/mod-detail/3203152'
-      - 'https://bethesda.net/en/mods/skyrim/mod-detail/3203032'
+      - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3203152/'
+        name: 'BCS Lost Library - Original'
+      - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3203032/'
+        name: 'BCS Lost Library - Desaturated'
     msg: [ *alreadyInLotD ]
     tag: [ Delev ]
     clean:
-      # version: 2.2
       - crc: 0xDA570813
         util: 'SSEEdit v4.0.2f'
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10981,14 +10981,14 @@ plugins:
         subs:
           - 'Not So Fast - Main Quest'
           - '[Skylover''s Compatibility Patches](https://www.nexusmods.com/skyrimspecialedition/mods/9849/)'
-        condition: 'active("NotSoFast-MainQuest.esp") and not active("BCS_NotsoFast_Patch.esp")'
+        condition: 'active("NotSoFast-MainQuest.esp") and not active("BCS_NotsoFast_Patch.esp") and not active("Bashed Patch.*\.esp")'
       - <<: *patch3rdParty
         subs:
           - 'Wintersun - Faiths of Skyrim'
           - '[Wintersun - More Patches](https://www.nexusmods.com/skyrimspecialedition/mods/24228/)'
-        condition: 'active("Wintersun - Faiths of Skyrim.esp") and not active("Wintersun - BCS Patch.esp")'
+        condition: 'active("Wintersun - Faiths of Skyrim.esp") and not active("Wintersun - BCS Patch.esp") and not active("Bashed Patch.*\.esp")'
       - <<: *patch3rdParty_KPH_TCIY
-        condition: 'active("TheChoiceIsYours.esp") and not active("TCIY BCS Patch.esp")'
+        condition: 'active("TheChoiceIsYours.esp") and not active("TCIY BCS Patch.esp") and not active("Bashed Patch.*\.esp")'
     after:
       - 'Cutting Room Floor.esp'
       - 'Tel_Nalta.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11002,9 +11002,9 @@ plugins:
       - Stats
     clean:
       - crc: 0x32587221
-        util: 'SSEEdit v4.0.2f'
-      - crc: 0x00975168
-        util: 'SSEEdit v4.0.3'
+        util: 'SSEEdit v4.0.3f'
+      - crc: 0xEFE70941
+        util: 'SSEEdit v4.0.3f'
 
   - name: 'Book Covers Skyrim - Lost Library.esp'
     url:
@@ -11017,7 +11017,7 @@ plugins:
     tag: [ Delev ]
     clean:
       - crc: 0xDA570813
-        util: 'SSEEdit v4.0.2f'
+        util: 'SSEEdit v4.0.3f'
 
   - name: 'Chesko_WearableLantern.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/7560' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10990,7 +10990,6 @@ plugins:
       - <<: *patch3rdParty_KPH_TCIY
         condition: 'active("TheChoiceIsYours.esp") and not active("TCIY BCS Patch.esp") and not active("Bashed Patch.*\.esp")'
     after:
-      - 'Cutting Room Floor.esp'
       - 'Tel_Nalta.esp'
       - 'UnlimitedBookshelves.esp'
       - 'Weightless Books.esp'


### PR DESCRIPTION
* Update locations
  - Add names to clarify different mod pages.

* Update messages
  - Not So Fast, The Choice Is Yours, Wintersun: add conditions to hide if bashed patch is present as they can be replaced.
  - The Choice Is Yours: remove regex for patch name as name with underscore doesn't seem to exist anymore.
  - Wintersun: update patch page name.

* Remove after
  - Cutting Room Floor: proper patch or bashed patch is required to resolve conflicts, but, if BCS wins, the VMAD subrecord for FavorRunilJournal "Runil's Journal" [BOOK:000705C3] from CRF will be overwritten & can't be resolved with a bashed patch.
![image](https://user-images.githubusercontent.com/69141501/107875160-1a82b480-6e73-11eb-8e82-cc43c383105c.png)


* Update cleaning info
  - Version 4.2: 32587221.
  - ASM replacer version 4.2.19: EFE70941.
  - Lost Library version 2.2: DA570813.

* Formatting changes
  - Remove unnecessary whitespaces.
  - Add forward slashes to ends of URLs for consistency.
  - Remove unnecessary cleaning version comments.
  - Add newline to separate mods hosted on different pages.