### PR TITLE
Update Kalilies' NPCs

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4555,7 +4555,7 @@ plugins:
     msg:
       - <<: *patchIncluded
         subs: [ 'Unofficial Skyrim Special Edition Patch' ]
-        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and checksum("KaliliesNPCs.esp", 062B1FEB)'
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and checksum("KaliliesNPCs.esp", 9B789EF8)'
       - <<: *patchProvided
         subs: [ 'AI Overhaul' ]
         condition: 'active("AI Overhaul.esp") and not active("Kalilies NPCs + AI Overhaul Patch.esp") and not active("Bashed Patch.*\.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4564,10 +4564,10 @@ plugins:
         condition: 'active("Cutting Room Floor.esp") and not active("KaliliesNPCs - CRF Patch.esp") and not active("Kalilies NPCs + AI Overhaul + Cutting Room Floor Patch.esp") and not active("Bashed Patch.*\.esp")'
     tag: [ Outfits.Remove ]
     clean:
-      - crc: 0xB9CF4F08
-        util: 'SSEEdit v4.0.3'
-      - crc: 0x062B1FEB
-        util: 'SSEEdit v4.0.3'
+      - crc: 0xD3921C56
+        util: 'SSEEdit v4.0.3f'
+      - crc: 0x9B789EF8
+        util: 'SSEEdit v4.0.3f'
   - name: 'Kalilies.*(CRF|Cutting Room Floor).*\.esp'
     req: [ 'Cutting Room Floor.esp' ]
   - name: 'Kalilies NPCs + AI Overhaul + Cutting Room Floor Patch.esp'


### PR DESCRIPTION
* Update message
  - Update checksum for non-USSEP version.

* Update cleaning info
  - USSEP version 2.4: D3921C56.
  - Non-USSEP version 2.4: 9B789EF8.