### PR TITLE
Beyond Skyrim: Bruma & Identity Crisis

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12260,6 +12260,10 @@ plugins:
         condition: 'active("Complete Alchemy & Cooking Overhaul.esp") and active("ccbgssse037-curios.esl") and not active("CACO_Bruma_Rare Curios_Patch.esp")'
       - <<: *patch3rdPartyUVCPC
         condition: 'not active("Vokrii - Bruma Patch.esp") and active("Vokrii - Minimalistic Perks of Skyrim.esp")'
+      - <<: *patchProvided
+        subs:
+          - 'Identity Crisis'
+        condition: 'active("BSHeartland.esm") and active("Identity Crisis.esp") and not active("BS Bruma Patch.esp")'
     tag:
       - Actors.ACBS
       - Actors.CombatStyle

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12262,7 +12262,7 @@ plugins:
         condition: 'not active("Vokrii - Bruma Patch.esp") and active("Vokrii - Minimalistic Perks of Skyrim.esp")'
       - <<: *patchProvided
         subs:
-          - 'Identity Crisis'
+          - '[Identity Crisis](https://www.nexusmods.com/skyrimspecialedition/mods/39634)'
         condition: 'active("BSHeartland.esm") and active("Identity Crisis.esp") and not active("BS Bruma Patch.esp")'
     tag:
       - Actors.ACBS


### PR DESCRIPTION
[Identity Crisis](https://www.nexusmods.com/skyrimspecialedition/mods/39634)
[Beyond Skyrim: Bruma](https://www.nexusmods.com/skyrimspecialedition/mods/10917)

With both mods loaded, the game is largely broken, with players trapped within interiors. This is apparently [known behavior](https://forums.nexusmods.com/index.php?/topic/5818982-beyond-skyrim-bruma-se/page-396#entry80205298) (4th item in the Common Issues list).

The note _"a compatibility patch is provided at X"_ is technically accurate, so I used that, but is there a _"yell at players to install this or their game will be very broken"_ giant popup box of blinking red text..?