### PR TITLE
Add Identity Crisis

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18717,3 +18717,15 @@ plugins:
     tag:
       - Actors.AIPackages
       - Factions
+
+# Identity Crisis
+  - name: 'Identity Crisis.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/39634' ]
+    inc:
+      - name: 'BSHeartland.esm'
+        display: 'Beyond Skyrim - Bruma SE'
+        condition: 'not active("BS Bruma Patch.esp")'
+    msg:
+      - <<: *patchProvided
+        subs: '[Beyond Skyrim - Bruma SE](https://www.nexusmods.com/skyrimspecialedition/mods/10917)'
+        condition: 'active("BSHeartland.esm") and not active("BS Bruma Patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18727,5 +18727,5 @@ plugins:
         condition: 'not active("BS Bruma Patch.esp")'
     msg:
       - <<: *patchProvided
-        subs: '[Beyond Skyrim - Bruma SE](https://www.nexusmods.com/skyrimspecialedition/mods/10917)'
+        subs: [ 'Beyond Skyrim - Bruma SE' ]
         condition: 'active("BSHeartland.esm") and not active("BS Bruma Patch.esp")'


### PR DESCRIPTION
This is a refactor of https://github.com/loot/skyrimse/pull/1600 using the suggested messages.

[Identity Crisis](https://www.nexusmods.com/skyrimspecialedition/mods/39634)
[Beyond Skyrim: Bruma](https://www.nexusmods.com/skyrimspecialedition/mods/10917)

With both mods loaded, the game is largely broken, with the game's main worldspace not being loadable. There are at least two bug threads on Beyond Skyrim - Bruma's nexus page with players "trapped indoors", or "trapped in cities", or just unable to exit onto the main worldspace. This behavior [is known](https://forums.nexusmods.com/index.php?/topic/5818982-beyond-skyrim-bruma-se/page-396#entry80205298), with a patch existing but evidently players are not being made aware of this.

The use of the incompatibility tag, coupled to the patch message, should convey to users to use the patch when both mods are desired.