### PR TITLE
Add Serio's Enhanced Dragons Redone

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5474,6 +5474,9 @@ plugins:
         condition: 'many("Rebalanced Encounter Zones.*\.esp")'
         subs: [ 'Rebalanced Encounter Zones' ]
 
+  - name: 'Serio''s Enhanced Dragons Redone.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/27061/' ]
+
   - name: 'Skyrim Immersive Creatures Special Edition.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/12680/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5476,6 +5476,9 @@ plugins:
 
   - name: 'Serio''s Enhanced Dragons Redone.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/27061/' ]
+    tag:
+      - Actors.ACBS
+      - SpellStats
     dirty:
       - <<: *quickClean
         crc: 0xC3D70E5A

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5481,6 +5481,15 @@ plugins:
       - 'Serio''s Enhanced Dragons.esp'
     msg:
       - *requiresMCM
+      - <<: *patchProvided
+        subs: [ 'Deadly Dragons' ]
+        condition: 'active("DeadlyDragons.esp") and not active("SEDR Deadly Dragons Compatibility Patch.esp") and not active("SEDR DD UD Compatibility Patch.esp") and not active("SEDR KSDO2 DD Compatibility Patch.esp") and not active("SEDR Ultimate Deadly Enhanced Dragons Overhaul Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'KS Dragon Overhaul 2' ]
+        condition: 'active("KS Dragon Overhaul 2.esp") and not active("SEDR KS Dragons 2 Compatibility Patch.esp") and not active("SEDR KSDO2 DD Compatibility Patch.esp") and not active("SEDR KSDO2 UD Compatibility Patch.esp") and not active("SEDR Ultimate Deadly Enhanced Dragons Overhaul Patch.esp")'
+      - <<: *patchProvided
+        subs: [ 'Ultimate Dragons SE' ]
+        condition: 'active("UltimateDragons.esp") and not active("SEDR Ultimate Dragons Compatibility Patch.esp") and not active("SEDR DD UD Compatibility Patch.esp") and not active("SEDR KSDO2 UD Compatibility Patch.esp") and not active("SEDR Ultimate Deadly Enhanced Dragons Overhaul Patch.esp")'
     tag:
       - Actors.ACBS
       - SpellStats

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5476,6 +5476,11 @@ plugins:
 
   - name: 'Serio''s Enhanced Dragons Redone.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/27061/' ]
+    dirty:
+      - <<: *quickClean
+        crc: 0xC3D70E5A
+        util: '[SSEEdit v4.0.3f](https://www.nexusmods.com/skyrimspecialedition/mods/164/)'
+        itm: 22
 
   - name: 'Skyrim Immersive Creatures Special Edition.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5480,7 +5480,6 @@ plugins:
       - 'Elemental_Dragons.esp'
       - 'Serio''s Enhanced Dragons.esp'
     msg:
-      - *requiresMCM
       - <<: *patchProvided
         subs: [ 'Deadly Dragons' ]
         condition: 'active("DeadlyDragons.esp") and not active("SEDR Deadly Dragons Compatibility Patch.esp") and not active("SEDR DD UD Compatibility Patch.esp") and not active("SEDR KSDO2 DD Compatibility Patch.esp") and not active("SEDR Ultimate Deadly Enhanced Dragons Overhaul Patch.esp")'
@@ -5490,6 +5489,7 @@ plugins:
       - <<: *patchProvided
         subs: [ 'Ultimate Dragons SE' ]
         condition: 'active("UltimateDragons.esp") and not active("SEDR Ultimate Dragons Compatibility Patch.esp") and not active("SEDR DD UD Compatibility Patch.esp") and not active("SEDR KSDO2 UD Compatibility Patch.esp") and not active("SEDR Ultimate Deadly Enhanced Dragons Overhaul Patch.esp")'
+      - *requiresMCM
     tag:
       - Actors.ACBS
       - SpellStats

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5476,6 +5476,9 @@ plugins:
 
   - name: 'Serio''s Enhanced Dragons Redone.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/27061/' ]
+    inc:
+      - 'Elemental_Dragons.esp'
+      - 'Serio''s Enhanced Dragons.esp'
     msg:
       - *requiresMCM
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5476,6 +5476,8 @@ plugins:
 
   - name: 'Serio''s Enhanced Dragons Redone.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/27061/' ]
+    msg:
+      - *requiresMCM
     tag:
       - Actors.ACBS
       - SpellStats


### PR DESCRIPTION
* Add entry
  - Serio's Enhanced Dragons Redone.

* Add location
  - Serio's Enhanced Dragons Redone @ Nexus: https://www.nexusmods.com/skyrimspecialedition/mods/27061/

* Add incompatible plugins
  - Elemental Dragons Special Edition.
  - Serio's Enhanced Dragons.

* Add messages
  - patchProvided: Deadly Dragons.
  - patchProvided: KS Dragon Overhaul 2.
  - patchProvided: Ultimate Dragons SE.
  - requiresMCM.

* Add tags
  - Actors.ACBS: changes Level Mult & Calc max level of multiple Actors (e.g. MQ206Alduin [NPC_:0004424A]).
  - SpellStats: adds Ignore Resistance SPIT flag to multiple Spells (e.g. VoiceDragonrend2 "Dragonrend" [SPEL:00028315]).

* Add cleaning info
  - Version 1.23.