### PR TITLE
Update SSELODGen Terrain Plugin

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1834,6 +1834,11 @@ plugins:
       - crc: 0x8BC0D944
         util: 'SSEEdit v4.0.3'
 
+###### Modding Tools - Plugins ######
+  - name: 'SSE-Terrain-Tamriel.esm'
+    url: [ 'https://forum.step-project.com/topic/13451-xlodgen-terrain-lod-beta-for-fnv-fo3-fo4-fo4vr-tes5-sse-tes5vr-enderal' ]
+    msg: [ *optional ]
+
 ###### Modding Tools - Generated Files ######
   - name: 'Automated Leveled List Addition.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/25395/' ]
@@ -18660,10 +18665,6 @@ plugins:
         condition: 'active("CCOR_Vokrii.esp") and active("Vokrii - WACCF Patch.esp")'
 
 ###### Anything new can go after this (If you're not sure where to put it) ######
-  - name: 'SSE-Terrain-Tamriel.esm'
-    url: [ 'https://forum.step-project.com/topic/13451-xlodgen-terrain-lod-beta-for-fnv-fo3-fo4-fo4vr-tes5-sse-tes5vr-enderal' ]
-    msg: [ *optional ]
-
   - name: 'Disease Descriptions.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/26992' ]
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1835,7 +1835,7 @@ plugins:
         util: 'SSEEdit v4.0.3'
 
 ###### Modding Tools - Plugins ######
-  - name: 'SSE-Terrain-Tamriel.esm'
+  - name: 'SSE-Terrain-Tamriel(-Extend)?\.esm'
     url: [ 'https://forum.step-project.com/topic/13451-xlodgen-terrain-lod-beta-for-fnv-fo3-fo4-fo4vr-tes5-sse-tes5vr-enderal' ]
     msg: [ *optional ]
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1836,7 +1836,7 @@ plugins:
 
 ###### Modding Tools - Plugins ######
   - name: 'SSE-Terrain-Tamriel(-Extend)?\.esm'
-    url: [ 'https://forum.step-project.com/topic/13451-xlodgen-terrain-lod-beta-for-fnv-fo3-fo4-fo4vr-tes5-sse-tes5vr-enderal' ]
+    url: [ 'https://stepmodifications.org/forum/topic/13451-xlodgen-terrain-lod-beta-71-for-fnv-fo3-fo4-fo4vr-tes5-sse-tes5vr-enderal/' ]
     msg: [ *optional ]
 
 ###### Modding Tools - Generated Files ######

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1837,7 +1837,11 @@ plugins:
 ###### Modding Tools - Plugins ######
   - name: 'SSE-Terrain-Tamriel(-Extend)?\.esm'
     url: [ 'https://stepmodifications.org/forum/topic/13451-xlodgen-terrain-lod-beta-71-for-fnv-fo3-fo4-fo4vr-tes5-sse-tes5vr-enderal/' ]
-    msg: [ *optional ]
+    msg:
+      - *optional
+      - <<: *useOnlyOneX
+        subs: [ 'SSELODGen terrain plugin' ]
+        condition: 'many("SSE-Terrain-Tamriel(-Extend)?\.esm")'
 
 ###### Modding Tools - Generated Files ######
   - name: 'Automated Leveled List Addition.esp'


### PR DESCRIPTION
* Move entry
  - Move SSELODGen terrain plugin to new Modding Tools - Plugins category.

* Update entry name
  - Include extended terrain plugin.

* Update location
  - New URL.

* Add message
  - useOnlyOneX: only one needed for generation.