### PR TITLE
Add Perks Unbound

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18845,12 +18845,12 @@ plugins:
         condition: 'active("CCOR_Vokrii.esp") and active("Vokrii - WACCF Patch.esp")'
 
 ###### Anything new can go after this (If you're not sure where to put it) ######
-# Perks Unbound -- Weapons Armor Clothing & Clutter Fixes patch
+ # Perks Unbound -- Weapons Armor Clothing & Clutter Fixes patch
   - name: 'Perks Unbound - Special Edition.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1800' ]
     msg:
       - <<: *patch3rdParty
         subs: 
-          - 'Weapons Armor Clothing & Clutter Fixes'
+          - 'Weapons Armor Clothing & Clutter Fixes (WACCF)'
           - '[Perks Unbound SSE -- WACCF patch](https://www.nexusmods.com/skyrimspecialedition/mods/46295)'
-        condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp") not active("PerksUnbound_WACCF.esp")'
+        condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp") and not active("PerksUnbound_WACCF.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18845,3 +18845,12 @@ plugins:
         condition: 'active("CCOR_Vokrii.esp") and active("Vokrii - WACCF Patch.esp")'
 
 ###### Anything new can go after this (If you're not sure where to put it) ######
+# Perks Unbound -- Weapons Armor Clothing & Clutter Fixes patch
+  - name: 'Perks Unbound - Special Edition.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1800' ]
+    msg:
+      - <<: *patch3rdParty
+        subs: 
+          - '[Weapons Armor Clothing & Clutter Fixes](https://www.nexusmods.com/skyrimspecialedition/mods/18994)'
+          - '[Perks Unbound SSE -- WACCF patch](https://www.nexusmods.com/skyrimspecialedition/mods/46295)'
+        condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp") not active("PerksUnbound_WACCF.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18851,6 +18851,6 @@ plugins:
     msg:
       - <<: *patch3rdParty
         subs: 
-          - '[Weapons Armor Clothing & Clutter Fixes](https://www.nexusmods.com/skyrimspecialedition/mods/18994)'
+          - 'Weapons Armor Clothing & Clutter Fixes'
           - '[Perks Unbound SSE -- WACCF patch](https://www.nexusmods.com/skyrimspecialedition/mods/46295)'
         condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp") not active("PerksUnbound_WACCF.esp")'


### PR DESCRIPTION
[Perks Unbound](https://www.nexusmods.com/skyrimspecialedition/mods/1800) changes perk unlocking conditions.

[WACCF](https://www.nexusmods.com/skyrimspecialedition/mods/18994) changes... a whole lotta things, including keyword conditions for material effects or friendly fire checks.

One overwrites the other. [The patch](https://www.nexusmods.com/skyrimspecialedition/mods/46295) bases from WACCF and applies Unbound's condition removals.