### PR TITLE
Update True Storms - Obsidian Weathers Patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3728,15 +3728,7 @@ plugins:
         util: 'SSEEdit v4.0.3'
   - name:  'True Storms - Obsidian Weathers - Patch .esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12125/' ]
-    inc:
-      - 'Obsidian_TS_Patch_Luminous.esp'
-      - 'Obsidian_TS_Patch_Spectral.esp'
-      - 'Obsidian_TS_Patch_Luminous_WaterFix.esp'
-      - 'Obsidian_TS_Patch_Spectral_WaterFix.esp '
-      - 'Obsidian Weathers - Wander Patch.esp'
-    clean:
-      - crc: 0x795E49B4
-        util: 'SSEEdit v4.0.3'
+    inc: [ 'Obsidian Weathers - Wander Patch.esp' ]
 
   - name: 'Obsidian In Cathedral.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/27831' ]


### PR DESCRIPTION
* Remove incompatibilities
  - Already included in the concerned plugins' metadata.

* Remove cleaning info
  - Unnecessary for clean patch.