### PR TITLE
Update enbdev url

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1003,7 +1003,7 @@ globals:
   - <<: *versionXIncY
     subs:
       - '**SKSE Plugin ([ENB Helper SE](https://www.nexusmods.com/skyrimspecialedition/mods/23174/))**'
-      - '[ENBSeries](https://enbdev.com/download_mod_tesskyrimse.html)'
+      - '[ENBSeries](http://enbdev.com/download_mod_tesskyrimse.htm)'
     condition: 'file("SKSE/Plugins/ENBHelperSE.dll") and file("../d3d11.dll") and version("SKSE/Plugins/ENBHelperSE.dll", "1.3.1.0", ==) and product_version("../d3d11.dll", "0.3.7.1", <)'
 
 # Plugin Requirements
@@ -1014,7 +1014,7 @@ globals:
   # ENBSeries
   - <<: *missingRequirementXforY
     subs:
-      - '[ENBSeries](https://enbdev.com/download_mod_tesskyrimse.html)'
+      - '[ENBSeries](http://enbdev.com/download_mod_tesskyrimse.htm)'
       - '[ENB Helper SE](https://www.nexusmods.com/skyrimspecialedition/mods/23174/)'
     condition: 'file("SKSE/Plugins/ENBHelperSE.dll") and not file("../d3d11.dll")'
   # DLL Loaders


### PR DESCRIPTION
Update url to end in `htm`, before it was `html`.
Also change `https` back to `http`, as enbdev.com doesn't seem to support it.