### PR TITLE
Remove RDO - Infinite Gold for Merchants Patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18674,10 +18674,6 @@ plugins:
       - name: 'SKSE/Plugins/FlatMapMarkersSSE.dll'
         display: '[Flat Map Markers SSE](https://www.nexusmods.com/skyrimspecialedition/mods/22122/)'
 
-  - name: 'RDO - Infinite Gold for Merchants patch.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/31271' ]
-    req: [ 'Infinite Gold For Merchants.esp' ]
-
   - name: 'The Great Cities of JK''s (North|Skyrim) - Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/33687/' ]
   - name: 'The Great Cities of JK''s North - Patch.esp'


### PR DESCRIPTION
* Version 1.0.1 adds Infinite Gold For Merchants.esp as a master.