### PR TITLE
Add Requirement to Bounty Gold

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8123,6 +8123,9 @@ plugins:
   - name: 'Bounty Gold.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18571/' ]
     after: [ 'Requiem.esp' ]
+    msg:
+      - *requiresMCM
+      - *requiresMCM_VR
 
   - name: 'Coins of Tamriel( V[234])? SSE( Hardcore)? Edition\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6441/' ]


### PR DESCRIPTION
 - Requires SkyUI for MCM.