### PR TITLE
Update BOTI.esp metadata

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10348,7 +10348,6 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/6126/'
         name: 'Blood on the Ice Redux'
     after: [ 'Quest Conflict Fixes.esp' ]
-    inc: [ 'FSA_FindingSusannaAlive.esp' ]
     msg:
       - <<: *alsoUseX
         subs: [ '[Fuz Ro D-oh - Silent Voice](https://www.nexusmods.com/skyrimspecialedition/mods/15109)' ]


### PR DESCRIPTION
Blood on the Ice Redux is _not_ incompatible with Finding Susana Alive. In fact, the author recommends that they are paired together:

> ...If you want to prevent this problem for good, check SomethingObscure's mod Finding Susanna Alive.