### PR TITLE
Add Worldspace Settings Group

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6743,13 +6743,7 @@ plugins:
 
   - name: 'NoGrassINCaves.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12431' ]
-    group: *cellSettingsGroup
-    after:
-      # Group afters to prevent sorting errors
-      - 'MissingEZs_AllExteriors.esp'
-      - 'MissingEZsFixed.esp'
-      - 'Soulmancer Soundtrack - NoVindDun.esp'
-      - 'Unique Region Names.esp'
+    group: *worldSettingsGroup
 
   - name: 'NoGrassINCities.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18768' ]
@@ -16303,7 +16297,6 @@ plugins:
       # Group afters, to prevent sorting errors
       - 'MissingEZs_AllExteriors.esp'
       - 'MissingEZsFixed.esp'
-      - 'NoGrassINCaves.esp'
     msg:
       - <<: *missingRequirementXforPlugin
         type: error

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1448,15 +1448,15 @@ groups:
   - name: &lvlListsGroup Leveled List Modifiers
     after: [ *kSpeakGroup ]
 
-  - name: &dynamicPatchGroup Dynamic Patches
+  - name: &worldSettingsGroup Worldspace Settings
+    description: 'A group for modules that need to be loaded late to preserve worldspace settings.'
     after: [ *lvlListsGroup ]
 
-  - name: &mapGroup Maps
-    description: 'A group for Map & Map Marker plugins that need to be loaded late to preserve worldspace changes.'
-    after: [ *dynamicPatchGroup ]
+  - name: &dynamicPatchGroup Dynamic Patches
+    after: [ *worldSettingsGroup ]
 
   - name: &lateChangesGroup Late Fixes & Changes
-    after: [ *mapGroup ]
+    after: [ *dynamicPatchGroup ]
 
   - name: &dynamicLODGroup Dynamic LOD
     after: [ *lateChangesGroup ]
@@ -2006,7 +2006,7 @@ plugins:
 ###### Fixes ######
   - name: 'Allinonefpsfix.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/21073/' ]
-    group: *lateLoadersGroup
+    group: *worldSettingsGroup
     dirty:
       - <<: *quickClean
         crc: 0xFF589033
@@ -2549,7 +2549,7 @@ plugins:
 
   - name: 'EzEWorldMapSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/7012/' ]
-    group: *mapGroup
+    group: *worldSettingsGroup
 
   - name: 'IcePenguinWorldMap(classic|Paper)?\.esp'
     url:
@@ -2576,7 +2576,7 @@ plugins:
       - crc: 0xC1050661
         util: 'SSEEdit v4.0.3'
   - name: 'IcePenguinWorldMapPaper.esp'
-    group: *mapGroup
+    group: *worldSettingsGroup
     after:
       - 'Atlas Legendary.esp'
       - 'Atlas Legendary OCS.esp'
@@ -2605,7 +2605,7 @@ plugins:
 
   - name: 'Paper World Map.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10836/' ]
-    group: *mapGroup
+    group: *worldSettingsGroup
     after:
       - 'Atlas Legendary.esp'
       - 'Atlas Legendary OCS.esp'
@@ -2639,7 +2639,7 @@ plugins:
 
   - name: 'Atlas Map Markers.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/24104' ]
-    group: *mapGroup
+    group: *worldSettingsGroup
     after:
       - 'Complete Alchemy & Cooking Overhaul.esp'
       - 'MLU.esp'
@@ -2656,7 +2656,7 @@ plugins:
 
   - name: 'Atlas Legendary( OCS)?.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/14493' ]
-    group: *mapGroup
+    group: *worldSettingsGroup
     after:
       - 'Complete Alchemy & Cooking Overhaul.esp'
       - 'MLU.esp'
@@ -2675,7 +2675,7 @@ plugins:
     url:
       - 'https://www.afkmods.com/index.php?/files/file/1896-dawnguard-map-markers/'
       - 'https://www.nexusmods.com/skyrimspecialedition/mods/20931'
-    group: *mapGroup
+    group: *worldSettingsGroup
     after:
       - 'Atlas Legendary.esp'
       - 'Atlas Legendary OCS.esp'
@@ -6753,7 +6753,7 @@ plugins:
 
   - name: 'NoGrassINCities.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18768' ]
-    group: *lateChangesGroup
+    group: *worldSettingsGroup
 
   - name: 'NorthernGrass.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/25459/' ]


### PR DESCRIPTION
Removing map group and replacing it with a generic group for mods that alter world space settings.
The group has been placed before the bashed patch because some of these mods can still be patched by it.
Forcing these mods after the bashed patch isn't really fixing anything, they'll need to be patched in either case.