### PR TITLE
Drop tag from Bring Out Your Dead

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14185,7 +14185,6 @@ plugins:
     after:
       - 'Verdant - A Skyrim Grass Plugin SSE Version.esp'
       - 'ViscousGrass.esp'
-    tag: [ C.Location ]
     clean:
       # version: 4.0.7
       - crc: 0xB6FC130C


### PR DESCRIPTION
Already included in the description. Has been that way for at least two years.