### PR TITLE
Add New Groups

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1678,8 +1678,12 @@ groups:
     description: 'A group for mods that provide alternative starting choices.'
     after: [ *coreGroup ]
 
-  - name: &lowPriorityGroup Low Priority Overrides
+  - name: &followerFrameworksGroup Follower Frameworks
+    description: 'A group for mods that extend the follower system.'
     after: [ *altStartGroup ]
+
+  - name: &lowPriorityGroup Low Priority Overrides
+    after: [ *followerFrameworksGroup ]
 
   - name: &highPriorityGroup High Priority Overrides
     after: [ *lowPriorityGroup ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1674,8 +1674,12 @@ groups:
   - name: &coreGroup Core Mods
     after: [ *vampireGameplayGroup ]
 
-  - name: &lowPriorityGroup Low Priority Overrides
+  - name: &altStartGroup Alternate Start
+    description: 'A group for mods that provide alternative starting choices.'
     after: [ *coreGroup ]
+
+  - name: &lowPriorityGroup Low Priority Overrides
+    after: [ *altStartGroup ]
 
   - name: &highPriorityGroup High Priority Overrides
     after: [ *lowPriorityGroup ]


### PR DESCRIPTION
Adding groups for Alt Start mods and follower frameworks.
So that the low priority group can be split up and the core group is freed up to move ICAIO earlier.
