### PR TITLE
Remove Qaxe's Winterhold Rebuild

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18438,7 +18438,6 @@ plugins:
     inc:
       - 'ExpandedWinterholdRuins.esp'
       - 'Less desolate Winterhold.esp'
-      - 'QaxeWinterholdRebuild.esp'
       - 'sm_jobasha_bookshop.esp'
       - 'sm_winterholdtemple.esp'
       - 'The Great City of Winterhold.esp'


### PR DESCRIPTION
Deleted mod, removing related metadata.
https://www.nexusmods.com/skyrimspecialedition/mods/10727/