### PR TITLE
Update Nether's Follower Framework

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10724,7 +10724,7 @@ plugins:
     after: [ 'AmazingFollowerTweaks.esp' ]
 
   - name: 'nwsFollowerFramework.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18076/' ]
+    url: [ 'https://www.patreon.com/posts/nethers-follower-53262094/' ]
     group: *followerFrameworksGroup
     after: [ 'Qw_BeyondReach_USSEP Patch.esp' ]
     req: [ *SKSE ]


### PR DESCRIPTION
Nexus mod page deleted.
https://www.nexusmods.com/skyrimspecialedition/mods/18076/
Now hosted on Patreon for free.
https://www.patreon.com/posts/nethers-follower-53262094/