### PR TITLE
Add Group for Alchemy Overhauls

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1664,12 +1664,16 @@ groups:
     after: [ *racesGroup ]
 
   - name: &craftingGroup Crafting
-    description: 'A group for modules that modify or expand crafting systems such as Alchemy, or Smithing.'
+    description: 'A group for modules that modify or expand crafting systems.'
     after: [ *economyGroup ]
+
+  - name: &alchemyOverhaulsGroup Alchemy Overhauls
+    description: 'A group for modules that overhaul the alchemy system.'
+    after: [ *craftingGroup ]
 
   - name: &perksGroup Skills & Perks
     description: 'A group for modules that modify or add new Skills and Perks.'
-    after: [ *craftingGroup ]
+    after: [ *alchemyOverhaulsGroup ]
 
   - name: &vampireGameplayGroup Vampire Gameplay Overhauls
     description: 'A group for modules that overhaul gameplay for Vampire player characters.'


### PR DESCRIPTION
- A group for modules that overhaul the Alchemy system.
- Adding to split up crafting group, to allow groups to be placed after CCOR and before CACO.
- It will also remove the need to set group specific load after rules for CCOR and other alchemy overhauls.