### PR TITLE
Define load order for WICO and Heights of Skyrim

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5692,6 +5692,10 @@ plugins:
       - crc: 0xC2C81AD6
         util: 'SSEEdit v4.0.3'
 
+  - name: 'WICO - Immersive People.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2136' ]
+    after: [ 'Heights_of_Skyrim.esp' ]
+
 ###### Character Appearance - Presets ######
   - name: 'AsharaSkyrimCharacterPresetsReplacer.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2406/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5693,7 +5693,7 @@ plugins:
         util: 'SSEEdit v4.0.3'
 
   - name: 'WICO - Immersive People.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2136' ]
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2136/' ]
     after: [ 'Heights_of_Skyrim.esp' ]
 
 ###### Character Appearance - Presets ######


### PR DESCRIPTION
I found that loading `WICO - Immersive People.esp` before `Heights_of_Skyrim.esp` resulted in some NPCs having black faces. Changing that order resolved the issue, so I created an entry for the two mods in the master list.

To verify that this is indeed necessary, I ran the following procedure:
1. Install [WICO](https://www.nexusmods.com/skyrimspecialedition/mods/2136) (VNL 0.9f) (core files only during installer)
2. Install [Heights of Skyrim](https://www.nexusmods.com/skyrimspecialedition/mods/52057) (v1.02) (ESP or ESP-FE does not matter)
3. Use the following load order:
    ```
    <Skyrim + DLC>
    WICO - Immersive Character.esp
    WICO - Immersive People.esp
    Heights_of_Skyrim.esp
    ```
4. Start a new game.
5. Execute `player.moveto 0001a68d` in the console as soon as possible, during the first cutscene.
6. Once something is visible, do the moveto again and immediately execute `tfc`.
7. Move around a bit to find Andurs. **He incorrectly has a black face.**
8. Exit the game and change the load order to
    ```
    <Skyrim + DLC>
    WICO - Immersive Character.esp
    Heights_of_Skyrim.esp
    WICO - Immersive People.esp
    ```
9. Repeat steps 4 through 7. **Andurs no longer has a black face.**

To verify that my patch is correct, I repeated steps 1 through 9 above, but replaced step 8 by using LOOT to sort the entries using the masterlist in this PR.