### PR TITLE
Require new plugin-provided patch for TCIY

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -13180,7 +13180,7 @@ plugins:
           - '[Wintersun - More Patches](https://www.nexusmods.com/skyrimspecialedition/mods/24228/)'
         condition: 'active("Wintersun - Faiths of Skyrim.esp") and not active("Wintersun - BCS Patch.esp") and not active("Bashed Patch.*\.esp")'
       - <<: *patch3rdParty_KPH_TCIY
-        condition: 'active("TheChoiceIsYours.esp") and not active("TCIY BCS Patch.esp") and not active("Bashed Patch.*\.esp")'
+        condition: 'active("TheChoiceIsYours.esp") and not active("TCIY( |_)BCS Patch.esp") and not active("Bashed Patch.*\.esp")'
     after:
       - 'Tel_Nalta.esp'
       - 'UnlimitedBookshelves.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -13180,7 +13180,7 @@ plugins:
           - '[Wintersun - More Patches](https://www.nexusmods.com/skyrimspecialedition/mods/24228/)'
         condition: 'active("Wintersun - Faiths of Skyrim.esp") and not active("Wintersun - BCS Patch.esp") and not active("Bashed Patch.*\.esp")'
       - <<: *patch3rdParty_KPH_TCIY
-        condition: 'active("TheChoiceIsYours.esp") and not active("TCIY( |_)BCS Patch.esp") and not active("Bashed Patch.*\.esp")'
+        condition: 'active("TheChoiceIsYours.esp") and not active("TCIY( |_)BCS Patch\.esp") and not active("Bashed Patch.*\.esp")'
     after:
       - 'Tel_Nalta.esp'
       - 'UnlimitedBookshelves.esp'


### PR DESCRIPTION
[The Choice is Yours](https://www.nexusmods.com/skyrimspecialedition/mods/3850) (TCIY) and [Book Covers Skyrim](https://www.nexusmods.com/skyrimspecialedition/mods/901/) (BCS) require a patch to work together. Previously, this patch was found on [kryptopyr's Patch Hub](https://www.nexusmods.com/skyrimspecialedition/mods/19518/), but the patch is now provided by TCIY.

This PR
1. changes the name of the patch from `TCIY BCS Patch.esp` to `TCIY_BCS Patch.esp`,
2. changes the message from `patch3rdParty_KPH_TCIY` to `patchIncluded`, and
3. moves the patch from BCS to TCIY.

Additionally, this PR still allows a bashed patch to resolve the conflict instead (not tested, but based on old patch specification). I also see that there's a patch specification for `Legacyofthedragonborn.esm` right above the new patch specification that has the eerily similar name `BCS_TCIY_Patch.esp`, but I did not touch that because I did not use Legacy of the Dragonborn.

I have verified locally that the message is displayed correctly when the patch is absent or the old patch is used, and that the message is not displayed if the new patch is used.