### PR TITLE
 Define load order for WICO and HoS patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5701,7 +5701,9 @@ plugins:
 
   - name: 'WICO - Immersive People.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2136/' ]
-    after: [ 'Heights_of_Skyrim.esp' ]
+    after:
+      - 'Heights_of_Skyrim.esp'
+      - 'HOS - USSEP Patch.esp'
 
 ###### Character Appearance - Presets ######
   - name: 'AsharaSkyrimCharacterPresetsReplacer.esp'


### PR DESCRIPTION
Similar to #1960: WICO should load after not only HoS, but also the newly-introduced HoS-USSEP patch.