### PR TITLE
Update tags for JaySUS Swords SE

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -13653,6 +13653,10 @@ plugins:
       - crc: 0x8BB38B17
         util: 'SSEEdit v4.0.3'
   - name: 'JSwordsD.esm'
+    tag:
+      - Delev
+      - Invent.Add
+      - Invent.Remove
     msg:
       - <<: *patchIncluded
         subs: [ 'Immersive Weapons' ]


### PR DESCRIPTION
- Needs Delev for CWSoldierSonsGear [LVLI:000A6E7A], otherwise the BP will immediately undo JSwords' removal of the steel dagger.
- The Invent tags are needed for a couple NPCs, where JSwords removes an iron weapon to add one of its weapons instead.

Regular JSwords.esm doesn't need any tags, it only includes new records.