### PR TITLE
Update Unofficial Elven Hunter Armor Patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2265,6 +2265,8 @@ plugins:
     group: *fixesGroup
   - name: 'Unofficial Arcane Archer Pack Patch.esl'
     tag: [ SpellStats ]
+  - name: 'Unofficial Elven Hunter Armor Patch.esl'
+    tag: [ Delev ]
   - name: 'Unofficial Forgotten Seasons Patch.esl'
     tag: [ C.Location ]
   - name: 'Unofficial Umbra Patch.esl'


### PR DESCRIPTION
Needs a Delev tag, otherwise the BP will undo its change to ccBGSSSE064_LItemArmorHelmets50 [LVLI:FE000804].