### PR TITLE
Update Unofficial Steel Soldier Armor Patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2269,6 +2269,8 @@ plugins:
     tag: [ Delev ]
   - name: 'Unofficial Forgotten Seasons Patch.esl'
     tag: [ C.Location ]
+  - name: 'Unofficial Steel Soldier Armor Patch.esl'
+    tag: [ Delev ]
   - name: 'Unofficial Umbra Patch.esl'
     tag:
       - C.Location


### PR DESCRIPTION
Needs a Delev tag, otherwise the BP will undo its change to ccBGSSSE058_LItemArmorAllBlades [LVLI:FE000813].