### PR TITLE
Add cleaning information for Expanded Tel Mithryn

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -21733,9 +21733,10 @@ plugins:
 
 ###### Anything new can go after this (If you're not sure where to put it) ######
 
-  # Expanded Tel Mithryn
   - name: 'telmith.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18956' ]
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18956/'
+        name: 'Expanded Tel Mithryn'
     dirty:
       - <<: *reqManualFix
         crc: 0x0B98A6FE

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -21743,7 +21743,6 @@ plugins:
         itm: 66
         udr: 43
         nav: 2
-      # version 1.2, after QAC
       - <<: *reqManualFix
         crc: 0x75BD457C
         util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -21737,7 +21737,6 @@ plugins:
   - name: 'telmith.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18956' ]
     dirty:
-      # version 1.2
       - <<: *reqManualFix
         crc: 0x0B98A6FE
         util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -21732,3 +21732,20 @@ plugins:
     msg: [ *alreadyInOrFixedByBDSv3_0 ]
 
 ###### Anything new can go after this (If you're not sure where to put it) ######
+
+  # Expanded Tel Mithryn
+  - name: 'telmith.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18956' ]
+    dirty:
+      # version 1.2
+      - <<: *reqManualFix
+        crc: 0x0B98A6FE
+        util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 66
+        udr: 43
+        nav: 2
+      # version 1.2, after QAC
+      - <<: *reqManualFix
+        crc: 0x75BD457C
+        util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        nav: 2

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18426,6 +18426,22 @@ plugins:
       - crc: 0x028D4C07
         util: 'SSEEdit v4.0.3'
 
+  - name: 'telmith.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18956/'
+        name: 'Expanded Tel Mithryn'
+    dirty:
+      - <<: *reqManualFix
+        crc: 0x0B98A6FE
+        util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 66
+        udr: 43
+        nav: 2
+      - <<: *reqManualFix
+        crc: 0x75BD457C
+        util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        nav: 2
+
   - name: 'The Great Cities - Minor Cities and Towns.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/20272/' ]
     after:
@@ -21732,19 +21748,3 @@ plugins:
     msg: [ *alreadyInOrFixedByBDSv3_0 ]
 
 ###### Anything new can go after this (If you're not sure where to put it) ######
-
-  - name: 'telmith.esp'
-    url:
-      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18956/'
-        name: 'Expanded Tel Mithryn'
-    dirty:
-      - <<: *reqManualFix
-        crc: 0x0B98A6FE
-        util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
-        itm: 66
-        udr: 43
-        nav: 2
-      - <<: *reqManualFix
-        crc: 0x75BD457C
-        util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
-        nav: 2


### PR DESCRIPTION
Added dirty plugin information for telmith.esp from the mod [Expanded Tel Mithryn](https://www.nexusmods.com/skyrimspecialedition/mods/18956). The plugin contained 66 ITMs, 43 UDRs and 2 deleted navmeshes.