### PR TITLE
Update Nemesis and FNIS compatibility

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1642,6 +1642,7 @@ globals:
     condition: 'file("Nemesis_Engine/Nemesis Unlimited Behavior Engine.exe")'
   # Nemesis and FNIS compatibility
   - <<: *useOnlyOneX
+    type: warn
     subs: [ '**Fores New Idles in Skyrim** or **Nemesis Unlimited Behavior Engine**' ]
     condition: 'file("Nemesis_Engine/Nemesis Unlimited Behavior Engine.exe") and file("tools/GenerateFNIS_for_Users/GenerateFNISforUsers.exe")'
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1644,7 +1644,7 @@ globals:
   - <<: *useOnlyOneX
     type: warn
     subs: [ '**Fores New Idles in Skyrim** or **Nemesis Unlimited Behavior Engine**' ]
-    condition: 'file("Nemesis_Engine/Nemesis Unlimited Behavior Engine.exe") and file("tools/GenerateFNIS_for_Users/GenerateFNISforUsers.exe")'
+    condition: 'file("Nemesis_Engine/Nemesis Unlimited Behavior Engine.exe") and file("tools/GenerateFNIS_for_Users/GenerateFNISforUsers.exe") and not file("scripts/FNISCreatureVersion.pex")'
 
 # Skyrim Script Extender - Required Scripts
   - type: warn


### PR DESCRIPTION
For anyone following this guide [Use FNIS and NEMESIS Together](https://www.nexusmods.com/skyrimspecialedition/mods/54702).
Change message type to warning, and disable use only one if FNIS creature pack is installed.
Nemesis does not support creature animations at this time, so this is the only way to use mods requiring them at the moment.