### PR TITLE
Fix link for Silent Voice VR

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -78,7 +78,7 @@ common:
 
   - &SilentVoice_VR
     name: 'SKSE/Plugins/Fuz Ro D''oh.dll'
-    display: '[Fuz Ro D-oh - Silent Voice VR (Alpha 3)](https://github.com/shadeMe/Fuz-Ro-D-oh-64/issues/2#issuecomment-633285465/)'
+    display: '[Fuz Ro D-oh - Silent Voice VR (Alpha 3)](https://github.com/shadeMe/Fuz-Ro-D-oh-64/issues/2#issuecomment-633285465)'
     condition: 'file("SkyrimVR.esm")'
 
   - &SKSE


### PR DESCRIPTION
 - It doesn't jump straight to the comment, if the closing slash is added.