### PR TITLE
MCoW fake-esm conflict with CollegeEntry fix

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17759,7 +17759,9 @@ plugins:
 
   - name: 'MagicalCollegeofWinterhold.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/1539/' ]
-    after: [ 'CollegeEntry.esp' ]
+    after:
+      - name: 'CollegeEntry.esp'
+        condition: 'not is_master("MagicalCollegeofWinterhold.esp")'
     msg:
       - <<: *patch3rdParty_MLU
         condition: 'active("MLU.esp") and not active("MLU - MagicalCollegeofWinterhold Patch.esp")'
@@ -17768,6 +17770,10 @@ plugins:
         crc: 0x9AA2E2D1
         util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
+  - name: 'MCoW_EndofLoadOrderOverwrite.esp'
+    after:
+      - name: 'CollegeEntry.esp'
+        condition: 'is_master("MagicalCollegeofWinterhold.esp")'
 
   - name: 'Markarth Entrance Overhaul.*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/19538/' ]


### PR DESCRIPTION
Only force CollegeEntry.esp to load after MCoW if MCoW is not tagged as master.
If MCoW is a master, load the additional esp from MCoW (MCoW_EndofLoadOrderOverwrite.esp) after CollegeEntry

Check this thread for reference on the problem:
[MCoW problem](https://forums.nexusmods.com/index.php?/topic/4994715-simple-college-of-winterhold/page-201#entry97501048)