### PR TITLE
Update Racial Body Morphs

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5219,9 +5219,6 @@ plugins:
         subs: [ 'Racial Body Morphs Meshes' ]
         condition: 'not file("Meshes/Actors/Character/Character Assets/Body by Race/skeletonArgonian.nif")'
   - name: 'Racial Body Morphs( - Extreme Morphs| - Subtle)?\.esp'
-    inc:
-      - name: 'Imperious - Races of Skyrim.esp'
-        condition: 'not active("Universal Imperious Patch.esp")'
     msg:
       - <<: *useOnlyOneX
         subs: [ 'Racial Body Morphs ESP' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5229,6 +5229,21 @@ plugins:
       - <<: *useVersion
         subs: [ 'Imperious' ]
         condition: 'active("Imperious - Races of Skyrim.esp") and not active("Universal Imperious Patch.esp")'
+  - name: 'Racial Body Morphs.esp'
+    msg:
+      - <<: *alreadyInX
+        subs: [ '**Racial Body Morphs - Imperious.esp**' ]
+        condition: 'active("Racial Body Morphs - Imperious.esp")'
+  - name: 'Racial Body Morphs - Extreme Morphs.esp'
+    msg:
+      - <<: *alreadyInX
+        subs: [ '**Racial Body Morphs - Extreme Morphs - Imperious.esp**' ]
+        condition: 'active("Racial Body Morphs - Extreme Morphs - Imperious.esp")'
+  - name: 'Racial Body Morphs - Subtle.esp'
+    msg:
+      - <<: *alreadyInX
+        subs: [ '**Racial Body Morphs - Subtle - Imperious.esp**' ]
+        condition: 'active("Racial Body Morphs - Subtle - Imperious.esp")'
 
   - name: 'TheEyesOfBeauty.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/16185/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -5218,14 +5218,14 @@ plugins:
       - <<: *missingRequirementXforPlugin
         subs: [ 'Racial Body Morphs Meshes' ]
         condition: 'not file("Meshes/Actors/Character/Character Assets/Body by Race/skeletonArgonian.nif")'
-      - <<: *useOnlyOneX
-        subs: [ 'Racial Body Morphs' ]
-        condition: 'many("Racial Body Morphs( - Extreme Morphs| - Subtle)?( - Imperious)?\.esp")'
   - name: 'Racial Body Morphs( - Extreme Morphs| - Subtle)?\.esp'
     inc:
       - name: 'Imperious - Races of Skyrim.esp'
         condition: 'not active("Universal Imperious Patch.esp")'
     msg:
+      - <<: *useOnlyOneX
+        subs: [ 'Racial Body Morphs ESP' ]
+        condition: 'many("Racial Body Morphs( - Extreme Morphs| - Subtle)?\.esp")'
       - <<: *useVersion
         subs: [ 'Imperious' ]
         condition: 'active("Imperious - Races of Skyrim.esp") and not active("Universal Imperious Patch.esp")'


### PR DESCRIPTION
Discussed in the [Discord](https://discord.com/channels/473542112974077963/473542230095822848/895956503029248010)

> Only one of the 3 versions of the mod (i.e., default, subtle, extreme) should be used at a time & the Imperious patches wholly contain the version of the mod they're for (i.e., subtle Imperious patch wholly contains subtle plugin), so only one of the 6 available plugins needs to be installed at a time. The message can be updated to be clearer, & messages informing users that the Imperious patches contain their corresponding plugins can be added.