### PR TITLE
Remove Skylover's Compatibility Patches

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9908,11 +9908,6 @@ plugins:
     group: *economyGroup
     inc: [ 'WACCF_BashedPatchLvlListFix.esp' ]
     msg:
-      - <<: *patch3rdParty
-        subs:
-          - 'Not So Fast - Main Quest'
-          - '[Skylover''s Compatibility Patches](https://www.nexusmods.com/skyrimspecialedition/mods/9849/)'
-        condition: 'active("NotSoFast-MainQuest.esp") and not active("MLU NotSoFast Patch.esp")'
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_MorrowlootUltimate_Patch.esp") and (version("LegacyoftheDragonborn.esm", "5.0.24", >=) or (not checksum("LegacyoftheDragonborn.esm", 31563183) and not checksum("LegacyoftheDragonborn.esm", 6736FB94) and not checksum("LegacyoftheDragonborn.esm", CB82480D)))'
       - <<: *patchProvided

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -13549,11 +13549,6 @@ plugins:
       - *alreadyInLotD
       - <<: *patch3rdParty
         subs:
-          - 'Not So Fast - Main Quest'
-          - '[Skylover''s Compatibility Patches](https://www.nexusmods.com/skyrimspecialedition/mods/9849/)'
-        condition: 'active("NotSoFast-MainQuest.esp") and not active("BCS_NotsoFast_Patch.esp") and not active("Bashed Patch.*\.esp")'
-      - <<: *patch3rdParty
-        subs:
           - 'Wintersun - Faiths of Skyrim'
           - '[Wintersun - More Patches](https://www.nexusmods.com/skyrimspecialedition/mods/24228/)'
         condition: 'active("Wintersun - Faiths of Skyrim.esp") and not active("Wintersun - BCS Patch.esp") and not active("Bashed Patch.*\.esp")'


### PR DESCRIPTION
Reported on LOOT mod page.

![image](https://user-images.githubusercontent.com/1944639/136734532-4e3cb403-11b9-439d-8cbe-0b2204dec959.png)

Mod deleted [Skylover's Compatibility Patches](https://www.nexusmods.com/skyrimspecialedition/mods/9849/).