### PR TITLE
DLC update - xEdit 4.0.4

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1979,7 +1979,7 @@ plugins:
     dirty:
       - <<: *quickClean
         crc: 0x17AB5E20
-        util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.0.4](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 334
         udr: 92
         nav: 3
@@ -2001,7 +2001,7 @@ plugins:
     dirty:
       - <<: *quickClean
         crc: 0xCC81E5D8
-        util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.0.4](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 766
         udr: 82
         nav: 57
@@ -2014,7 +2014,7 @@ plugins:
     dirty:
       - <<: *quickClean
         crc: 0xBAD9393A
-        util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.0.4](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 221
         udr: 11
         nav: 5
@@ -2032,7 +2032,7 @@ plugins:
     dirty:
       - <<: *quickClean
         crc: 0x0EB10E82
-        util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.0.4](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 81
         udr: 8
         nav: 1

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1993,11 +1993,11 @@ plugins:
       - Invent.Remove
       - Relev
     msg:
-      # (V1.5.97.0, 0x955CCA77) after QAC
+      # (V1.5.97.0, 0xADFC1487) after QAC
       - <<: *wildEdits
         type: say
         subs: [ '[Dawnguard.esm Wild Edits Cleaning Guide](https://tes5edit.github.io/docs/7-mod-cleaning-and-error-checking.html#AppendixBManuallyCleaningDawnguard)' ]
-        condition: 'checksum("Dawnguard.esm", 955CCA77)'
+        condition: 'checksum("Dawnguard.esm", ADFC1487)'
     dirty:
       - <<: *quickClean
         crc: 0xCC81E5D8


### PR DESCRIPTION
I'm not sure if the following part needs an update:

```
    msg:
      # (V1.5.97.0, 0x955CCA77) after QAC
      - <<: *wildEdits
        type: say
        subs: [ '[Dawnguard.esm Wild Edits Cleaning Guide](https://tes5edit.github.io/docs/7-mod-cleaning-and-error-checking.html#AppendixBManuallyCleaningDawnguard)' ]
        condition: 'checksum("Dawnguard.esm", 955CCA77)'
```

Everything else seems fine.