### PR TITLE
Update ZIA & WACCF patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -15673,8 +15673,8 @@ plugins:
       - <<: *patch3rdParty
         subs:
           - 'Weapons Armor Clothing and Clutter Fixes'
-          - '[Zim''s Immersive Artifacts - WACCF Patch](https://www.nexusmods.com/skyrimspecialedition/mods/19489/)'
-        condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp") and not active("ZIA_WACCF_Patch.esp")'
+          - '[kryptopyr''s Patch Hub](https://www.nexusmods.com/skyrimspecialedition/mods/19518)'
+        condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp") and not active("zimsimmersiveartifacts_waccf_patch.esp")'
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_ZimsImmersiveArtifacts_Patch.esp")'
     tag:


### PR DESCRIPTION
Needed as old patch (https://www.nexusmods.com/skyrimspecialedition/mods/19489/) has been removed from nexus.