### PR TITLE
Add Enhanced Solitude Docks

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17950,6 +17950,9 @@ plugins:
 
   - name: 'Enhanced Solitude Docks.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/28349/' ]
+    clean:
+      - crc: 0x1CE94209
+        util: 'SSEEdit v4.0.4'
 
   - name: 'Enhanced Solitude SSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/27816/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17950,6 +17950,7 @@ plugins:
 
   - name: 'Enhanced Solitude Docks.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/28349/' ]
+    after: [ 'Enhanced Solitude SSE.esp' ]
     clean:
       - crc: 0x1CE94209
         util: 'SSEEdit v4.0.4'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17948,6 +17948,9 @@ plugins:
             text: 'Dieses Plugin weist auf einen Eintrag **000CB4F3** hin, der von Hearthfires.esm gelöscht wurde. Dies muss manuell vom Mod-Autor korrigiert werden.'
         condition: 'checksum("EEKs Immersive Whiterun.esp", 7CAB09F2) or checksum("EEKs Immersive Whiterun.esp", 16BF915D)'
 
+  - name: 'Enhanced Solitude Docks.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/28349/' ]
+
   - name: 'Enhanced Solitude SSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/27816/' ]
     msg:


### PR DESCRIPTION
Reported in [Discord](https://discord.com/channels/473542112974077963/496196499890241546/913518993195823145)

> Hey MacSplody , I've updates [sic] Enhanced Solitude and Enhanced Solitude Docks to mater [sic] flagged esp files.  Can I just double check that Enhanced Solitude Docks.esp is always going to load after Enhanced Solitude.esp according to LOOT.