### PR TITLE
Add Sentient Chairs of Skyrim

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -22625,3 +22625,13 @@ plugins:
         crc: 0xDC20C34C
         util: '[SSEEdit v4.0.4b](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
+
+  - name: 'MarkekrausSentientChairsOfSkyrim.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/59604' ]
+    req: [ 'Unofficial Skyrim Special Edition Patch.esp' ]
+    after:
+      - 'Immersive Citizens - AI Overhaul.esp'
+      - 'Immersive Citizens - OCS patch.esp'
+    clean:
+      - crc: 0xBD12E363
+        util: 'SSEEdit v4.0.4'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -22627,8 +22627,7 @@ plugins:
         itm: 2
 
   - name: 'MarkekrausSentientChairsOfSkyrim.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/59604' ]
-    req: [ 'Unofficial Skyrim Special Edition Patch.esp' ]
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/59604/' ]
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'Immersive Citizens - OCS patch.esp'


### PR DESCRIPTION
SCOS v3.0.0 needs to be loaded after Immersive Citizens AI Overhaul due to navmesh changes near Battle-Born Farm.