### PR TITLE
v0.15 - SCOS v3.0.0

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -23940,3 +23940,13 @@ plugins:
         crc: 0xDC20C34C
         util: '[SSEEdit v4.0.4b](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
+
+  - name: 'MarkekrausSentientChairsOfSkyrim.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/59604' ]
+    req: [ 'Unofficial Skyrim Special Edition Patch.esp' ]
+    after:
+      - 'Immersive Citizens - AI Overhaul.esp'
+      - 'Immersive Citizens - OCS patch.esp'
+    clean:
+      - crc: 0xBD12E363
+        util: 'SSEEdit v4.0.4'


### PR DESCRIPTION
SCOS v3.0.0 needs to be loaded after Immersive Citizens AI Overhaul due to navmesh changes near Battle-Born Farm.