### PR TITLE
Update Sentient Chairs of Skyrim

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -22683,7 +22683,5 @@ plugins:
       - <<: *SKSE
         condition: 'version("MarkekrausSentientChairsOfSkyrim.esp", "4.1.0", >=)'
     clean:
-      - crc: 0xBD12E363
-        util: 'SSEEdit v4.0.4'
       - crc: 0x64014310
         util: 'SSEEdit v4.0.4'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -22679,6 +22679,9 @@ plugins:
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'Immersive Citizens - OCS patch.esp'
+    req: [ *SKSE ]
     clean:
       - crc: 0xBD12E363
+        util: 'SSEEdit v4.0.4'
+      - crc: 0x64014310
         util: 'SSEEdit v4.0.4'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -22679,7 +22679,9 @@ plugins:
     after:
       - 'Immersive Citizens - AI Overhaul.esp'
       - 'Immersive Citizens - OCS patch.esp'
-    req: [ *SKSE ]
+    req:
+      - <<: *SKSE
+        condition: 'version("MarkekrausSentientChairsOfSkyrim.esp", "4.1.0", >=)'
     clean:
       - crc: 0xBD12E363
         util: 'SSEEdit v4.0.4'


### PR DESCRIPTION
* Add new clean CRC for SCOS 4.1.0 
* version 4.1.0 of SCOS requires SKSE.