### PR TITLE
Update Better Dynamic Snow

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1887,8 +1887,6 @@ plugins:
     tag: [ Graphics ]
   - name: 'Better Dynamic Snow.esp'
     msg:
-      - <<: *obsolete
-        condition: 'not file("skse/plugins/ShaderTools.dll")'
       - <<: *patch3rdParty
         subs:
           - 'Majestic Mountains'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1876,6 +1876,11 @@ plugins:
         subs: [ 'Better Dynamic Snow ESP' ]
         condition: 'many("Better Dynamic Snow( SE)?\.esp")'
   - name: 'Better Dynamic Snow SE.esp'
+    inc:
+      - name: 'SKSE/Plugins/ShaderTools.dll'
+        display: 'SSE Parallax Shader Fix'
+      - name: 'SKSE/Plugins/SSEShaderTools.dll'
+        display: 'SSE Parallax Shader Fix AE'
     clean:
       - crc: 0x1E8DF8AF
         util: 'SSEEdit v4.0.3h (Hotfix 1)'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1884,7 +1884,7 @@ plugins:
     msg:
       - <<: *useVersion
         subs: [ '2.11' ]
-        condition: 'file("skse/plugins/(SSE)?\ShaderTools.dll")'
+        condition: 'file("skse/plugins/(SSE)?ShaderTools\.dll")'
     clean:
       - crc: 0x1E8DF8AF
         util: 'SSEEdit v4.0.3h (Hotfix 1)'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1881,6 +1881,10 @@ plugins:
         display: 'SSE Parallax Shader Fix'
       - name: 'SKSE/Plugins/SSEShaderTools.dll'
         display: 'SSE Parallax Shader Fix AE'
+    msg:
+      - <<: *useVersion
+        subs: [ '2.11' ]
+        condition: 'file("skse/plugins/(SSE)?\ShaderTools.dll")'
     clean:
       - crc: 0x1E8DF8AF
         util: 'SSEEdit v4.0.3h (Hotfix 1)'


### PR DESCRIPTION
@TechAngel85 provided the information that v2.11 of [BDS](https://www.nexusmods.com/skyrimspecialedition/mods/9121) isn't actually obsolete, and that we should display a warning if SSE Parallax Shader Fix is used in conjunction with BDS v3.0+.

> Depending on your point of view. V2.11 remains up primarily for those using parallax, yes. However, it's still a perfectly viable option without parallax too. Some users prefer the older method used in v2.11 due to it being a bit more accurate and more selective of what is and isn't covered by the mod. I will still provide hotfixes to the file, if there are ever any needed, however development on that version is complete. So in other words, it's still perfectly viable and shouldn't be listed as obsolete or requiring the use of any other mods to be installed for it's use.
> 
> What should be there, if it's not. Is if that DLL is found with BDS v3's plugin name, then that should produce a warning.
> 
> No one should be using v3 with parallax. Doesn't work unless something has changed since the last time I looked into it all.
> 
> So, remove that for v2 and add the warning for v3, if it's not present already. You could put in the warning to use v2.11 rather than v3.

[SSE Parallax Shader Fix](https://www.nexusmods.com/skyrimspecialedition/mods/31963) also has two versions now, pre and post AE versions, so update the corresponding condition.