### PR TITLE
Update BugFixesSSE condition

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8109,7 +8109,7 @@ plugins:
     msg:
       - <<: *alsoUseX
         subs: [ '**[Bug Fixes](https://www.nexusmods.com/skyrimspecialedition/mods/33261/)** OR **[Scrambled Bugs](https://www.nexusmods.com/skyrimspecialedition/mods/43532/)**' ]
-        condition: 'not file("NetScriptFramework/Plugins/BugFixesSSE.dll") and not file("DLLPlugins/ScrambledBugs.dll")'
+        condition: 'not file("SKSE/Plugins/BugFixesSSE.dll") and not file("DLLPlugins/ScrambledBugs.dll")'
       - <<: *compatNotes
         subs: [ 'https://wiki.fireundubh.com/mods/master-of-disguise#compatibility' ]
       - *missingRequirementAddrLibforPlugin
@@ -14026,7 +14026,7 @@ plugins:
       - <<: *alsoUseX
         type: warn
         subs: [ '[Bug Fixes SSE](https://www.nexusmods.com/skyrimspecialedition/mods/33261/)' ]
-        condition: 'not file("NetScriptFramework/Plugins/BugFixesSSE.dll")'
+        condition: 'not file("SKSE/Plugins/BugFixesSSE.dll")'
       - <<: *compatNotes
         subs: [ 'https://www.nexusmods.com/skyrimspecialedition/articles/22/' ]
       - *includesMBBF


### PR DESCRIPTION
Version 5 of [BugFixes SSE](https://www.nexusmods.com/skyrimspecialedition/mods/33261) now uses `SKSE/Plugins/` instead of `NetScriptFramework/Plugins/` as it's folder structure.

As such, update these conditions for `Master of Disguise - Special Edition.esp` and `Ordinator - Perks of Skyrim.esp`.