### PR TITLE
Update JK's Skyrim

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -19666,6 +19666,10 @@ plugins:
     inc:
       - 'Blues Skyrim.esp'
       - 'ETaC - Complete.esp'
+  - name: 'JKs_Skyrim_No_Lights_Patch.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6289/' ]
+    after:
+      - 'JKs Skyrim - Rob''s Bug Fixes.esp'
 
   - name: 'JK''s Temple of Talos.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/56971/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -19912,7 +19912,6 @@ plugins:
     inc:
       - 'Blues Skyrim.esp'
       - 'ETaC - Complete.esp'
-
   - name: 'JKs[ _]Skyrim_.*_Patch\.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/6289/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -19912,10 +19912,12 @@ plugins:
     inc:
       - 'Blues Skyrim.esp'
       - 'ETaC - Complete.esp'
-  - name: 'JKs_Skyrim_No_Lights_Patch.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/6289/' ]
-    after:
-      - 'JKs Skyrim - Rob''s Bug Fixes.esp'
+
+  - name: 'JKs[ _]Skyrim_.*_Patch\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/6289/'
+        name: 'JK''s Skyrim'
+    after: [ 'JKs Skyrim - Rob''s Bug Fixes.esp' ]
 
   - name: 'JK''s Temple of Talos.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/56971/' ]


### PR DESCRIPTION
This currently fixes the load order between [Rob's Bug Fixes - JK's Skyrim](https://www.nexusmods.com/skyrimspecialedition/mods/63379) and the no lights patch of JK's Skyrim.

Rob's plugin must be loaded before any JK's patch, should I add a `after` for all JK's Skyrim patches in the masterlist?