### PR TITLE
Add JK's Redbag's Solitude

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -25596,3 +25596,34 @@ plugins:
     clean:
       - crc: 0x111DD990
         util: 'SSEEdit v4.0.4b'
+
+  - name: 'JK''s RedBag''s Solitude.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/50131/'
+        name: 'JK''s RedBag''s Solitude'
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/64069/'
+        name: 'Rob''s Bug Fixes - JK''s RedBag''s Solitude'
+    msg:
+      - <<: *patchUpdateAvailable
+        subs: '[Rob''s Bug Fixes - JK''s RedBag''s Solitude](https://www.nexusmods.com/skyrimspecialedition/mods/64069/)'
+        condition: 'checksum("JK''s RedBag''s Solitude.esp", C02B497D)'
+    clean:
+      - crc: 0xC02B497D
+        util: 'SSEEdit v4.0.4b'
+      - crc: 0x4965E58B
+        util: 'SSEEdit v4.0.4b'
+  - name: 'JK''s RedBag''s Solitude - Dawn of Skyrim patch.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/50131/'
+        name: 'JK''s RedBag''s Solitude'
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/64069/'
+        name: 'Rob''s Bug Fixes - JK''s RedBag''s Solitude'
+    msg:
+      - <<: *patchUpdateAvailable
+        subs: '[Rob''s Bug Fixes - JK''s RedBag''s Solitude](https://www.nexusmods.com/skyrimspecialedition/mods/64069/)'
+        condition: 'checksum("JK''s RedBag''s Solitude - Dawn of Skyrim Patch.esp", 57A26548)'
+    clean:
+      - crc: 0x57A26548
+        util: 'SSEEdit v4.0.4b'
+      - crc: 0x930C1CE3
+        util: 'SSEEdit v4.0.4b'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -25605,7 +25605,7 @@ plugins:
         name: 'Rob''s Bug Fixes - JK''s RedBag''s Solitude'
     msg:
       - <<: *patchUpdateAvailable
-        subs: '[Rob''s Bug Fixes - JK''s RedBag''s Solitude](https://www.nexusmods.com/skyrimspecialedition/mods/64069/)'
+        subs: [ '[Rob''s Bug Fixes - JK''s RedBag''s Solitude](https://www.nexusmods.com/skyrimspecialedition/mods/64069/)' ]
         condition: 'checksum("JK''s RedBag''s Solitude.esp", C02B497D)'
     clean:
       - crc: 0xC02B497D
@@ -25620,7 +25620,7 @@ plugins:
         name: 'Rob''s Bug Fixes - JK''s RedBag''s Solitude'
     msg:
       - <<: *patchUpdateAvailable
-        subs: '[Rob''s Bug Fixes - JK''s RedBag''s Solitude](https://www.nexusmods.com/skyrimspecialedition/mods/64069/)'
+        subs: [ '[Rob''s Bug Fixes - JK''s RedBag''s Solitude](https://www.nexusmods.com/skyrimspecialedition/mods/64069/)' ]
         condition: 'checksum("JK''s RedBag''s Solitude - Dawn of Skyrim Patch.esp", 57A26548)'
     clean:
       - crc: 0x57A26548


### PR DESCRIPTION
idk how loot sorts all of these by default, but i believe the load order is supposed to be

1. jk's
2. dawn
3. jks - dawn patch
This part should already be good

4. redbag''s
5. jks redbags
6. jks redbags dawn of skyrim patch
the masters for both jks redbags files are properly set to they are good, perhaps a rule needed for RedBag's Solitude.esp