### PR TITLE
Update Additional Clockwork

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17528,7 +17528,7 @@ plugins:
       - *PapyrusExtender
       - *SKSE
     clean:
-      - crc: 0xD692DD72
+      - crc: 0xCB190694
         util: 'SSEEdit v4.0.4b'
   - name: 'ClockworkTitleRemover.esp'
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17470,81 +17470,6 @@ plugins:
         util: '[SSEEdit v4.0.1](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 122
 
-  # Additional Clockwork
-  - name: 'Clockwork.+\.esp'
-    url:
-      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/'
-        name: 'Additional Clockwork'
-  - name: 'ClockworkBugFixes.esp'
-    clean:
-      - crc: 0x6D378755
-        util: 'SSEEdit v4.0.4b'
-  - name: 'ClockworkCourierCounterspell.esp'
-    clean:
-      - crc: 0x6ABC5154
-        util: 'SSEEdit v4.0.3'
-  - name: 'ClockworkInterestingInhabitants.esp'
-    clean:
-      - crc: 0x7292CB08
-        util: 'SSEEdit v4.0.4b'
-  - name: 'ClockworkMausoleumDummyDoorFix.esp'
-    msg:
-      - <<: *alreadyInX
-        subs: [ '"Additional Clockwork - Bug Fixes" (ClockworkBugFixes.esp)' ]
-        condition: 'active("ClockworkBugFixes.esp")'
-    clean:
-      - crc: 0xCAE2B6AE
-        util: 'SSEEdit v4.0.4'
-  - name: 'ClockworkShadowmarksCastleExt.esp'
-    msg:
-      - <<: *alreadyInX
-        subs: [ '"Additional Clockwork - Marked Shadows Merged" (ClockworkShadowmarksMerged.esp)' ]
-        condition: 'active("ClockworkShadowmarksMerged.esp")'
-    clean:
-      - crc: 0xC73F27D3
-        util: 'SSEEdit v4.0.3'
-  - name: 'ClockworkShadowmarksTermini.esp'
-    msg:
-      - <<: *alreadyInX
-        subs: [ '"Additional Clockwork - Marked Shadows Merged" (ClockworkShadowmarksMerged.esp)' ]
-        condition: 'active("ClockworkShadowmarksMerged.esp")'
-    clean:
-      - crc: 0x93BA7A0D
-        util: 'SSEEdit v4.0.3'
-  - name: 'ClockworkShadowmarksTravelRoom.esp'
-    msg:
-      - <<: *alreadyInX
-        subs: [ '"Additional Clockwork - Marked Shadows Merged" (ClockworkShadowmarksMerged.esp)' ]
-        condition: 'active("ClockworkShadowmarksMerged.esp")'
-    clean:
-      - crc: 0xEDC64E4B
-        util: 'SSEEdit v4.0.3'
-  - name: 'ClockworkShadowmarksMerged.esp'
-    clean:
-      - crc: 0xB4C1E773
-        util: 'SSEEdit v4.0.4b'
-  - name: 'ClockworkSuperiorSorting.esp'
-    req:
-      - *PapyrusExtender
-      - *SKSE
-    clean:
-      - crc: 0xCB190694
-        util: 'SSEEdit v4.0.4b'
-  - name: 'ClockworkTitleRemover.esp'
-    dirty:
-      - <<: *quickClean
-        crc: 0x913191E9
-        util: '[SSEEdit v4.0.4](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
-        udr: 3
-  - name: 'ClockworkWoodWhimWWMount.esp'
-    clean:
-      - crc: 0xCDD7795A
-        util: 'SSEEdit v4.0.4b'
-  - name: 'ClockworkWoodWhimWR.esp'
-    clean:
-      - crc: 0x3737D50C
-        util: 'SSEEdit v4.0.4b'
-
   - name: 'Darkend.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/10423/' ]
     dirty:
@@ -24529,8 +24454,99 @@ plugins:
     after: [ 'CFTO.esp' ]
     tag: [ Factions ]
 
-  ### Patches from Additional Clockwork ###
-  # Clockwork Sorting Patches #
+  # Additional Clockwork #
+  - name: 'Clockwork.+\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/'
+        name: 'Additional Clockwork'
+        
+  - name: 'ClockworkBugFixes.esp'
+    clean:
+      - crc: 0x6D378755
+        util: 'SSEEdit v4.0.4b'
+
+  - name: 'ClockworkMausoleumDummyDoorFix.esp'
+    msg:
+      - <<: *alreadyInX
+        subs: [ '"Additional Clockwork - Bug Fixes" (ClockworkBugFixes.esp)' ]
+        condition: 'active("ClockworkBugFixes.esp")'
+    clean:
+      - crc: 0xCAE2B6AE
+        util: 'SSEEdit v4.0.4'
+
+  - name: 'ClockworkCourierCounterspell.esp'
+    msg:
+      - <<: *alreadyInX
+        subs: [ '"Additional Clockwork - Bug Fixes" (ClockworkBugFixes.esp)' ]
+        condition: 'active("ClockworkBugFixes.esp")'
+    clean:
+      - crc: 0x6ABC5154
+        util: 'SSEEdit v4.0.3'
+
+  # Additional Clockwork's Content Addons #
+  - name: 'ClockworkInterestingInhabitants.esp'
+    clean:
+      - crc: 0x7292CB08
+        util: 'SSEEdit v4.0.4b'
+
+  - name: 'ClockworkShadowmarksCastleExt.esp'
+    msg:
+      - <<: *alreadyInX
+        subs: [ '"Additional Clockwork - Marked Shadows Merged" (ClockworkShadowmarksMerged.esp)' ]
+        condition: 'active("ClockworkShadowmarksMerged.esp")'
+    clean:
+      - crc: 0xC73F27D3
+        util: 'SSEEdit v4.0.3'
+
+  - name: 'ClockworkShadowmarksTermini.esp'
+    msg:
+      - <<: *alreadyInX
+        subs: [ '"Additional Clockwork - Marked Shadows Merged" (ClockworkShadowmarksMerged.esp)' ]
+        condition: 'active("ClockworkShadowmarksMerged.esp")'
+    clean:
+      - crc: 0x93BA7A0D
+        util: 'SSEEdit v4.0.3'
+
+  - name: 'ClockworkShadowmarksTravelRoom.esp'
+    msg:
+      - <<: *alreadyInX
+        subs: [ '"Additional Clockwork - Marked Shadows Merged" (ClockworkShadowmarksMerged.esp)' ]
+        condition: 'active("ClockworkShadowmarksMerged.esp")'
+    clean:
+      - crc: 0xEDC64E4B
+        util: 'SSEEdit v4.0.3'
+
+  - name: 'ClockworkShadowmarksMerged.esp'
+    clean:
+      - crc: 0xB4C1E773
+        util: 'SSEEdit v4.0.4b'
+
+  - name: 'ClockworkSuperiorSorting.esp'
+    req:
+      - *PapyrusExtender
+      - *SKSE
+    clean:
+      - crc: 0xCB190694
+        util: 'SSEEdit v4.0.4b'
+
+  - name: 'ClockworkTitleRemover.esp'
+    dirty:
+      - <<: *quickClean
+        crc: 0x913191E9
+        util: '[SSEEdit v4.0.4](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        udr: 3
+
+  - name: 'ClockworkWoodWhimWWMount.esp'
+    clean:
+      - crc: 0xCDD7795A
+        util: 'SSEEdit v4.0.4b'
+
+  - name: 'ClockworkWoodWhimWR.esp'
+    clean:
+      - crc: 0x3737D50C
+        util: 'SSEEdit v4.0.4b'
+
+  # Additional Clockwork's Sorting Patches #
   - name: 'ClockworkSorting_Food_CACO.esp'
     msg:
       - <<: *alreadyInOrFixedByX
@@ -24539,6 +24555,7 @@ plugins:
     clean:
       - crc: 0x83840648
         util: 'SSEEdit v4.0.3'
+
   - name: 'ClockworkSorting_Ing_CACO.esp'
     inc: [ 'ClockworkSorting_Ing_CCCurios.esp' ]
     msg:
@@ -24554,6 +24571,7 @@ plugins:
     clean:
       - crc: 0xFC69BF72
         util: 'SSEEdit v4.0.3'
+
   - name: 'ClockworkSorting_Ing_CCCurios.esp'
     msg:
       - <<: *alreadyInOrFixedByX
@@ -24568,6 +24586,7 @@ plugins:
     clean:
       - crc: 0x30BAFDF7
         util: 'SSEEdit v4.0.3'
+
   - name: 'ClockworkSorting_Ing_CCCurios_CACO.esp'
     msg:
       - <<: *alreadyInOrFixedByX
@@ -24576,7 +24595,8 @@ plugins:
     clean:
       - crc: 0x3297A568
         util: 'SSEEdit v4.0.3'
-  # Clockwork High Poly Project Patches #
+
+  # Additional Clockwork's High Poly Project Patches #
   - name: 'ClockworkHPPCoalsFix.esp'
     inc: [ 'ClockworkHPPHayFix.esp' ]
     msg:
@@ -24592,6 +24612,7 @@ plugins:
     clean:
       - crc: 0xA4E097B9
         util: 'SSEEdit v4.0.3'
+
   - name: 'ClockworkHPPHayFix.esp'
     msg:
       - <<: *alreadyInX
@@ -24603,6 +24624,7 @@ plugins:
     clean:
       - crc: 0xB00E3F81
         util: 'SSEEdit v4.0.3'
+
   - name: 'ClockworkHPPMergedFixes.esp'
     msg:
       - <<: *requiresResources

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17471,7 +17471,7 @@ plugins:
         itm: 122
 
   # Additional Clockwork
-  - name: 'Clockwork.+?\.esp'
+  - name: 'Clockwork.+\.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/'
         name: 'Additional Clockwork'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -24459,12 +24459,10 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/'
         name: 'Additional Clockwork'
-        
   - name: 'ClockworkBugFixes.esp'
     clean:
       - crc: 0x6D378755
         util: 'SSEEdit v4.0.4b'
-
   - name: 'ClockworkMausoleumDummyDoorFix.esp'
     msg:
       - <<: *alreadyInX
@@ -24473,7 +24471,6 @@ plugins:
     clean:
       - crc: 0xCAE2B6AE
         util: 'SSEEdit v4.0.4'
-
   - name: 'ClockworkCourierCounterspell.esp'
     msg:
       - <<: *alreadyInX
@@ -24482,13 +24479,11 @@ plugins:
     clean:
       - crc: 0x6ABC5154
         util: 'SSEEdit v4.0.3'
-
   # Additional Clockwork's Content Addons #
   - name: 'ClockworkInterestingInhabitants.esp'
     clean:
       - crc: 0x7292CB08
         util: 'SSEEdit v4.0.4b'
-
   - name: 'ClockworkShadowmarksCastleExt.esp'
     msg:
       - <<: *alreadyInX
@@ -24497,7 +24492,6 @@ plugins:
     clean:
       - crc: 0xC73F27D3
         util: 'SSEEdit v4.0.3'
-
   - name: 'ClockworkShadowmarksTermini.esp'
     msg:
       - <<: *alreadyInX
@@ -24506,7 +24500,6 @@ plugins:
     clean:
       - crc: 0x93BA7A0D
         util: 'SSEEdit v4.0.3'
-
   - name: 'ClockworkShadowmarksTravelRoom.esp'
     msg:
       - <<: *alreadyInX
@@ -24515,12 +24508,10 @@ plugins:
     clean:
       - crc: 0xEDC64E4B
         util: 'SSEEdit v4.0.3'
-
   - name: 'ClockworkShadowmarksMerged.esp'
     clean:
       - crc: 0xB4C1E773
         util: 'SSEEdit v4.0.4b'
-
   - name: 'ClockworkSuperiorSorting.esp'
     req:
       - *PapyrusExtender
@@ -24528,24 +24519,20 @@ plugins:
     clean:
       - crc: 0xCB190694
         util: 'SSEEdit v4.0.4b'
-
   - name: 'ClockworkTitleRemover.esp'
     dirty:
       - <<: *quickClean
         crc: 0x913191E9
         util: '[SSEEdit v4.0.4](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 3
-
   - name: 'ClockworkWoodWhimWWMount.esp'
     clean:
       - crc: 0xCDD7795A
         util: 'SSEEdit v4.0.4b'
-
   - name: 'ClockworkWoodWhimWR.esp'
     clean:
       - crc: 0x3737D50C
         util: 'SSEEdit v4.0.4b'
-
   # Additional Clockwork's Sorting Patches #
   - name: 'ClockworkSorting_Food_CACO.esp'
     msg:
@@ -24555,7 +24542,6 @@ plugins:
     clean:
       - crc: 0x83840648
         util: 'SSEEdit v4.0.3'
-
   - name: 'ClockworkSorting_Ing_CACO.esp'
     inc: [ 'ClockworkSorting_Ing_CCCurios.esp' ]
     msg:
@@ -24571,7 +24557,6 @@ plugins:
     clean:
       - crc: 0xFC69BF72
         util: 'SSEEdit v4.0.3'
-
   - name: 'ClockworkSorting_Ing_CCCurios.esp'
     msg:
       - <<: *alreadyInOrFixedByX
@@ -24586,7 +24571,6 @@ plugins:
     clean:
       - crc: 0x30BAFDF7
         util: 'SSEEdit v4.0.3'
-
   - name: 'ClockworkSorting_Ing_CCCurios_CACO.esp'
     msg:
       - <<: *alreadyInOrFixedByX
@@ -24595,7 +24579,6 @@ plugins:
     clean:
       - crc: 0x3297A568
         util: 'SSEEdit v4.0.3'
-
   # Additional Clockwork's High Poly Project Patches #
   - name: 'ClockworkHPPCoalsFix.esp'
     inc: [ 'ClockworkHPPHayFix.esp' ]
@@ -24612,7 +24595,6 @@ plugins:
     clean:
       - crc: 0xA4E097B9
         util: 'SSEEdit v4.0.3'
-
   - name: 'ClockworkHPPHayFix.esp'
     msg:
       - <<: *alreadyInX
@@ -24624,7 +24606,6 @@ plugins:
     clean:
       - crc: 0xB00E3F81
         util: 'SSEEdit v4.0.3'
-
   - name: 'ClockworkHPPMergedFixes.esp'
     msg:
       - <<: *requiresResources

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17471,13 +17471,15 @@ plugins:
         itm: 122
 
   # Additional Clockwork
+  - name: 'Clockwork.+?\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/'
+        name: 'Additional Clockwork'
   - name: 'ClockworkBugFixes.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/' ]
     clean:
       - crc: 0x6D378755
         util: 'SSEEdit v4.0.4b'
   - name: 'ClockworkCourierCounterspell.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/' ]
     clean:
       - crc: 0x6ABC5154
         util: 'SSEEdit v4.0.3'
@@ -17486,7 +17488,6 @@ plugins:
       - crc: 0x7292CB08
         util: 'SSEEdit v4.0.4b'
   - name: 'ClockworkMausoleumDummyDoorFix.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/' ]
     msg:
       - <<: *alreadyInX
         subs: [ '"Additional Clockwork - Bug Fixes" (ClockworkBugFixes.esp)' ]
@@ -17495,7 +17496,6 @@ plugins:
       - crc: 0xCAE2B6AE
         util: 'SSEEdit v4.0.4'
   - name: 'ClockworkShadowmarksCastleExt.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/' ]
     msg:
       - <<: *alreadyInX
         subs: [ '"Additional Clockwork - Marked Shadows Merged" (ClockworkShadowmarksMerged.esp)' ]
@@ -17504,7 +17504,6 @@ plugins:
       - crc: 0xC73F27D3
         util: 'SSEEdit v4.0.3'
   - name: 'ClockworkShadowmarksTermini.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/' ]
     msg:
       - <<: *alreadyInX
         subs: [ '"Additional Clockwork - Marked Shadows Merged" (ClockworkShadowmarksMerged.esp)' ]
@@ -17513,7 +17512,6 @@ plugins:
       - crc: 0x93BA7A0D
         util: 'SSEEdit v4.0.3'
   - name: 'ClockworkShadowmarksTravelRoom.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/' ]
     msg:
       - <<: *alreadyInX
         subs: [ '"Additional Clockwork - Marked Shadows Merged" (ClockworkShadowmarksMerged.esp)' ]
@@ -17522,7 +17520,6 @@ plugins:
       - crc: 0xEDC64E4B
         util: 'SSEEdit v4.0.3'
   - name: 'ClockworkShadowmarksMerged.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/' ]
     clean:
       - crc: 0xB4C1E773
         util: 'SSEEdit v4.0.4b'
@@ -17531,10 +17528,9 @@ plugins:
       - *PapyrusExtender
       - *SKSE
     clean:
-      - crc: 0x5CC0D0CB
+      - crc: 0xD692DD72
         util: 'SSEEdit v4.0.4b'
   - name: 'ClockworkTitleRemover.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/' ]
     dirty:
       - <<: *quickClean
         crc: 0x913191E9
@@ -24533,7 +24529,6 @@ plugins:
   ### Patches from Additional Clockwork ###
   # Clockwork Sorting Patches #
   - name: 'ClockworkSorting_Food_CACO.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/' ]
     msg:
       - <<: *alreadyInOrFixedByX
         subs: [ '"Additional Clockwork - Superior Sorting" (ClockworkSuperiorSorting.esp)' ]
@@ -24542,7 +24537,6 @@ plugins:
       - crc: 0x83840648
         util: 'SSEEdit v4.0.3'
   - name: 'ClockworkSorting_Ing_CACO.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/' ]
     inc: [ 'ClockworkSorting_Ing_CCCurios.esp' ]
     msg:
       - <<: *alreadyInOrFixedByX
@@ -24558,7 +24552,6 @@ plugins:
       - crc: 0xFC69BF72
         util: 'SSEEdit v4.0.3'
   - name: 'ClockworkSorting_Ing_CCCurios.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/' ]
     msg:
       - <<: *alreadyInOrFixedByX
         subs: [ '"Additional Clockwork - Superior Sorting" (ClockworkSuperiorSorting.esp)' ]
@@ -24573,7 +24566,6 @@ plugins:
       - crc: 0x30BAFDF7
         util: 'SSEEdit v4.0.3'
   - name: 'ClockworkSorting_Ing_CCCurios_CACO.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/' ]
     msg:
       - <<: *alreadyInOrFixedByX
         subs: [ '"Additional Clockwork - Superior Sorting" (ClockworkSuperiorSorting.esp)' ]
@@ -24583,7 +24575,6 @@ plugins:
         util: 'SSEEdit v4.0.3'
   # Clockwork High Poly Project Patches #
   - name: 'ClockworkHPPCoalsFix.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/' ]
     inc: [ 'ClockworkHPPHayFix.esp' ]
     msg:
       - <<: *alreadyInX
@@ -24599,7 +24590,6 @@ plugins:
       - crc: 0xA4E097B9
         util: 'SSEEdit v4.0.3'
   - name: 'ClockworkHPPHayFix.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/' ]
     msg:
       - <<: *alreadyInX
         subs: [ '"Additional Clockwork - High Poly Project Merged Patch" (ClockworkHPPMergedFixes.esp)' ]
@@ -24611,7 +24601,6 @@ plugins:
       - crc: 0xB00E3F81
         util: 'SSEEdit v4.0.3'
   - name: 'ClockworkHPPMergedFixes.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/' ]
     msg:
       - <<: *requiresResources
         subs: [ '[Static Mesh Improvement Mod](https://www.nexusmods.com/skyrimspecialedition/mods/659/)' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17538,7 +17538,7 @@ plugins:
         udr: 3
   - name: 'ClockworkWoodWhimWWMount.esp'
     clean:
-      - crc: 0x405D5EA1
+      - crc: 0xCDD7795A
         util: 'SSEEdit v4.0.4b'
   - name: 'ClockworkWoodWhimWR.esp'
     clean:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17537,9 +17537,12 @@ plugins:
         util: '[SSEEdit v4.0.4](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 3
   - name: 'ClockworkWoodWhimWWMount.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/47087/' ]
     clean:
       - crc: 0x405D5EA1
+        util: 'SSEEdit v4.0.4b'
+  - name: 'ClockworkWoodWhimWR.esp'
+    clean:
+      - crc: 0x3737D50C
         util: 'SSEEdit v4.0.4b'
 
   - name: 'Darkend.esp'


### PR DESCRIPTION
Update the Masterlist entry to...
* Reflect Additional Clockwork's 3.0.1 update
* Add a missing plugin
* Move the `URL` key into a regex for Additional Clockwork plugins

As a note for the regex, it _can_ be modified later to accommodate other plugins that start with `Clockwork` (using fancy-schmancy stuff like Negative Lookaheads). I did a quick run-through in VS Code to see if any other plugins would match, and it didn't find any.