### PR TITLE
Add Protect Unique NPCs

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8459,8 +8459,8 @@ plugins:
         name: 'Protect Unique NPCs'
     group: *earlyLoadersGroup
     inc:
-      - 'NPCs Protected Redux.esp'
       - 'NPCs Protected and Uncapped.esp'
+      - 'NPCs Protected Redux.esp'
       - 'Protected NPCs.esp'
       - 'PyP_Legendary.esp'
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8453,6 +8453,17 @@ plugins:
     group: *earlyLoadersGroup
     tag: [ Actors.ACBS ]
 
+  - name: 'ProtectUniqueNPCs.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/49667/'
+        name: 'Protect Unique NPCs'
+    group: *earlyLoadersGroup
+    inc:
+      - 'NPCs Protected Redux.esp'
+      - 'NPCs Protected and Uncapped.esp'
+      - 'Protected NPCs.esp'
+      - 'PyP_Legendary.esp'
+
   - name: 'Ravengate.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12617/' ]
     msg: [ *includesMBBF ]


### PR DESCRIPTION
Being grouped in earlyLoadersGroup could minimize potential issues with other NPC mods.