### PR TITLE
Update Zim's Immersive Artifacts

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17273,8 +17273,6 @@ plugins:
           - 'Weapons Armor Clothing and Clutter Fixes'
           - '[kryptopyr''s Patch Hub](https://www.nexusmods.com/skyrimspecialedition/mods/19518)'
         condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp") and not active("zimsimmersiveartifacts_waccf_patch.esp")'
-      - <<: *patch3rdParty_LotD
-        condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_ZimsImmersiveArtifacts_Patch.esp")'
     tag:
       - EffectStats
       - EnchantmentStats

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -24381,8 +24381,6 @@ plugins:
       - 'DBM_CRF_Patch.esp'
       - 'Qw_ACE_CRF Patch.esp'
       - 'Qw_WACCF_CRF Patch.esp'
-  - name: 'DBM_ZimsImmersiveArtifacts_Patch.esp'
-    after: [ 'ZIA_WACCF_Patch.esp' ]
   ### Legacy of the Dragonborn ADD-ONS ###
   - name: '(DBM_)?RelicHunter(_Grass_Patch)?.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/12253/' ]


### PR DESCRIPTION
Patch no longer required. 
From LOTD page;
Removed : The Zim's Complete conflict resolution patch (No longer needed)