### PR TITLE
Update Better Dynamic Snow

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2038,12 +2038,14 @@ plugins:
     inc:
       - name: 'SKSE/Plugins/ShaderTools.dll'
         display: 'SSE Parallax Shader Fix'
+        condition: 'file("skse/plugins/shaders/03[\dA-F]{6}_Parallax_Vc\w*_Snow(_Aam)?\.ps\.hlsl")'
       - name: 'SKSE/Plugins/SSEShaderTools.dll'
         display: 'SSE Parallax Shader Fix AE'
+        condition: 'file("skse/plugins/shaders/03[\dA-F]{6}_Parallax_Vc\w*_Snow(_Aam)?\.ps\.hlsl")'
     msg:
       - <<: *useVersion
         subs: [ '2.11' ]
-        condition: 'file("skse/plugins/(SSE)?ShaderTools\.dll")'
+        condition: 'file("skse/plugins/shaders/03[\dA-F]{6}_Parallax_Vc\w*_Snow(_Aam)?\.ps\.hlsl")'
     clean:
       - crc: 0xE555B811
         util: 'SSEEdit v4.0.4c'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2045,7 +2045,7 @@ plugins:
     msg:
       - <<: *useVersion
         subs: [ '2.11' ]
-        condition: 'file("skse/plugins/shaders/03[\dA-F]{6}_Parallax_Vc\w*_Snow(_Aam)?\.ps\.hlsl")'
+        condition: 'file("skse/plugins/(SSE)?ShaderTools\.dll") and file("skse/plugins/shaders/03[\dA-F]{6}_Parallax_Vc\w*_Snow(_Aam)?\.ps\.hlsl")'
     clean:
       - crc: 0xE555B811
         util: 'SSEEdit v4.0.4c'


### PR DESCRIPTION
Shader Tools Updated (SDU) uses the same DLL name and can be substituted into Parallax Shader Fix (PSF), but does not come with the shader files. The snow shaders are the actual conflict with Better Dynamic Snow 3 (BDS).

This updates BDS3's conditionals to specifically check for the shader files so the version warning doesn't appear when a user has SDU installed for other purposes.