### PR TITLE
Add Bash Tags for various SimonMagus616 mods

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -15049,7 +15049,7 @@ plugins:
       - Text
   - name: 'HandtoHandArmor.esp'
     tag: [ Text ]
-  - name: 'HandtoHandLocksmith.esp'
+  - name: 'HandToHandLocksmith.esp'
     tag: [ Text ]
   - name: 'H2HBooksAndTrainers.esp'
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11958,16 +11958,20 @@ plugins:
         condition: 'active("FleshFX.esp") and not active("Mysticism_FleshFX_Patch.esp") and not active("Bashed Patch.*\.esp")'
     tag:
       - Actors.ACBS
+      - Actors.Perks.Add
       - Actors.RecordFlags
       - Actors.Spells
       - Actors.Stats
       - Actors.Voice
       - EffectStats
+      - Enchantments
+      - EnchantmentStats
       - Factions
       - Graphics
       - Invent.Add
       - Invent.Remove
       - Keywords
+      - Relev
       - Sound
       - SpellStats
       - Stats
@@ -12060,6 +12064,15 @@ plugins:
         crc: 0x647371BC
         util: '[SSEEdit v4.0.4](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 23
+
+  - name: 'Pilgrim.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/54099' ]
+    tag:
+      - EffectStats
+      - Graphics
+      - Keywords
+      - Names
+      - Text
 
   - name: 'Pinpoint Explosion.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/21899/' ]
@@ -14921,6 +14934,7 @@ plugins:
         condition: 'file("Vokriinator( Black)?\.esp")'
     tag:
       - EffectStats
+      - EnchantmentStats
       - -Invent.Add
       - -Invent.Remove
       - Keywords
@@ -15023,6 +15037,30 @@ plugins:
         util: '[SSEEdit v4.0.3g](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
 
+  - name: 'HandtoHand.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/59790/' ]
+    tag:
+      - Names
+      - Text
+  - name: 'HandtoHandArmor.esp'
+    tag:
+      - Names
+      - Text
+  - name: 'HandtoHandLocksmith.esp'
+    tag:
+      - Names
+      - Text
+  - name: 'H2HBooksAndTrainers.esp'
+    tag:
+      - Actors.Factions
+      - Actors.Stats
+      - Invent.Add
+      - Invent.Remove
+      - Keywords
+      - NPC.Class
+      - NPC.DefaultOutfit
+      - Stats
+
   - name: 'Lock_Overhaul.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/14927/' ]
     # Checksum for Ordinator version is volatile, see git log for full explanation of after & requiremnt
@@ -15053,6 +15091,13 @@ plugins:
         crc: 0x031E3B09
         util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 41
+
+  - name: 'Manbeast.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/44746/' ]
+    tag:
+      - Actors.Factions
+      - Actors.Stats
+      - Text
 
   - name: 'Moonlight Tales Special Edition.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2803/' ]
@@ -15228,6 +15273,12 @@ plugins:
     clean:
       - crc: 0x9570442B
         util: 'SSEEdit v4.0.3'
+
+  - name: 'Scion.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/41639' ]
+    tag:
+      - SpellStats
+      - Text
 
   - name: 'Simple Skill Books.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/27186/' ]
@@ -17544,6 +17595,21 @@ plugins:
   - name: 'ThaneWeaponsReborn.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/8387/' ]
     msg: [ *alreadyInLotD ]
+
+  - name: 'Thaumaturgy.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/57138/' ]
+    tag:
+      - EffectStats
+      - Enchantments
+      - EnchantmentStats
+      - Graphics
+      - Keywords
+      - Relev
+      - Stats
+      - Text
+  - name: 'ThaumaturgyJumpBoots.esp'
+    tag:
+      - EnchantmentStats
 
   - name: 'The Infinity Gauntlet.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/25556/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -12066,7 +12066,9 @@ plugins:
         itm: 23
 
   - name: 'Pilgrim.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/54099' ]
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/54099/'
+        name: 'Pilgrim - A Religion Overhaul'
     tag:
       - EffectStats
       - Graphics
@@ -15037,19 +15039,18 @@ plugins:
         util: '[SSEEdit v4.0.3g](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
 
+  - name: '(HandtoHand(Armor|Locksmith)?|H2HBooksAndTrainers)\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/59790/'
+        name: 'Hand to Hand - An Adamant Addon'
   - name: 'HandtoHand.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/59790/' ]
     tag:
       - Names
       - Text
   - name: 'HandtoHandArmor.esp'
-    tag:
-      - Names
-      - Text
+    tag: [ Text ]
   - name: 'HandtoHandLocksmith.esp'
-    tag:
-      - Names
-      - Text
+    tag: [ Text ]
   - name: 'H2HBooksAndTrainers.esp'
     tag:
       - Actors.Factions
@@ -15058,7 +15059,6 @@ plugins:
       - Invent.Remove
       - Keywords
       - NPC.Class
-      - NPC.DefaultOutfit
       - Stats
 
   - name: 'Lock_Overhaul.esp'
@@ -15093,7 +15093,9 @@ plugins:
         itm: 41
 
   - name: 'Manbeast.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/44746/' ]
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/44746/'
+        name: 'Manbeast - A Werewolf Overhaul'
     tag:
       - Actors.Factions
       - Actors.Stats
@@ -15275,7 +15277,9 @@ plugins:
         util: 'SSEEdit v4.0.3'
 
   - name: 'Scion.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/41639' ]
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/41639/'
+        name: 'Scion - A Vampire Overhaul'
     tag:
       - SpellStats
       - Text
@@ -17596,8 +17600,11 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/8387/' ]
     msg: [ *alreadyInLotD ]
 
+  - name: 'Thaumaturgy(JumpBoots)?\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/57138/'
+        name: 'Thaumaturgy - An Enchanting Overhaul'
   - name: 'Thaumaturgy.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/57138/' ]
     tag:
       - EffectStats
       - Enchantments
@@ -17608,8 +17615,7 @@ plugins:
       - Stats
       - Text
   - name: 'ThaumaturgyJumpBoots.esp'
-    tag:
-      - EnchantmentStats
+    tag: [ EnchantmentStats ]
 
   - name: 'The Infinity Gauntlet.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/25556/' ]


### PR DESCRIPTION
Adds bash tags for assorted SimonMagus mods.

Non obvious changes include:

### Mysticism
* **Actors.Perks.Add**: Mysticism adds a Ritual of Power perk to the Spectral Wolf Summon
* **Relev**: resolves issues in the Illusion staff leveled items where Mysticism is attempting to remove the Staff of Courage and Bash wants to add it back to the leveled lists.

### Hand to Hand (H2HBooksAndTrainers addon)
(Most changes are to Chief Mauhulakh and Ma'jhad to make them into hand to hand skill trainers)
* **Actors.Factions**: Adds npcs to the Hand to Hand skill trainer faction
* **Actors.Stats**: Increases Chief Mauhulakh's stamina
* **Invent.Add**: Adds a few Hand to Hand skill books to various containers
* **Invent.Remove**: Removes Chief Mauhulakh's battleaxe, since he's supposed to be a hand to hand trainer
* **NPC.Class**: Changes classes to Hand to Hand Master/Hand to Hand expert.