### PR TITLE
Update Ryn's Whiterun City Limits

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -22793,7 +22793,7 @@ plugins:
         subs:
           - 'CC Tundra Homestead'
           - '[Whiterun Exteriors Patch Collection](https://www.nexusmods.com/skyrimspecialedition/mods/78920/)'
-        condition: 'active("cceejsse001-hstead.esm") and not active("Ryns Whiterun City Limits - (Iggath )?Tundra Homestead Patch\.esp")'
+        condition: 'active("cceejsse001-hstead.esm") and not active("Ryns Whiterun City Limits - (Iggath )?Tundra Homestead Patch\.esp") and not active("JKs Ryns Whiterun Exterior - CC Tundra Homestead patch.esp")'
       - <<: *patch3rdParty
         subs:
           - 'eFPS - Exterior FPS boost'


### PR DESCRIPTION
Extend the condition for Ryn's Whiterun City Limits and CC Tundra Homestead patch to account for the JKs Ryns Whiterun combo patch.