### PR TITLE
masterlist.yaml update: TESL - LS

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -15777,7 +15777,7 @@ plugins:
         condition: 'active("Aetherius.esp") and not active("TESL-LS-AddonAetherius.esp")'
       - <<: *patchIncluded
         subs: [ 'Apocalypse' ]
-        condition: 'active("Apocalypse - Magic of Skyrim.esp") and not active("TESL-LS-AddonApoc.esp")'
+        condition: 'active("Apocalypse - Magic of Skyrim.esp") and not active("TESL-LS-AddonApocalypse.esp")'
       - <<: *patchIncluded
         subs: [ 'Imperious' ]
         condition: 'active("Imperious - Races of Skyrim.esp") and not active("TESL-LS-AddonImperious.esp")'


### PR DESCRIPTION
TESL - LS changed it's Apocalypse compatibility ESP from TESL-LS-AddonApoc.esp to TESL-LS-AddonApocalypse.esp I reflected the change in the yaml