### PR TITLE
Update Improved closefaced helmets

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17219,7 +17219,7 @@ plugins:
         subs:
           - 'Unofficial Skyrim Special Edition Patch'
           - '[Improved Closedfaced Helmets Patches](https://www.nexusmods.com/skyrimspecialedition/mods/12405/)'
-        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("imp_helm_USSEP.esp") and not active("Weapons Armor Clothing & Clutter Fixes.esp") and not active("Requiem.esp")'
+        condition: 'active("Unofficial Skyrim Special Edition Patch.esp") and not active("imp_helm_USSEP.esp") and not active("Weapons Armor Clothing & Clutter Fixes.esp") and not active("Requiem.esp") and not checksum("imp_helm_legend.esp", 9CC32D4D)'
       - <<: *patch3rdParty_KPH_WACCF
         condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp") and not active("imp_helm_legend_WACCF_Patch.esp") and not active("imp_helm_legend_WACCF_AMB_Patch.esp")'
       - <<: *patch3rdParty_RPC


### PR DESCRIPTION
Add a checksum condition to remove the "missing USSEP patch" message if using [Improved Closefaced Helmets - Fixes](https://www.nexusmods.com/skyrimspecialedition/mods/85514) which forwards edits from USSEP.