### PR TITLE
Update MorrowLoot Ultimate

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -11152,7 +11152,7 @@ plugins:
         subs:
           - 'Ars Metallica - Smithing Enhancements'
           - '[Morrowloot Ultimate - Patches](https://www.nexusmods.com/skyrimspecialedition/mods/76259/)'
-        condition: 'active("Ars Metallica.esp") and not active("MLU - Ars Metallica Patch.esp") and not active("MLU Patches Merged.esp")'
+        condition: 'active("Ars Metallica.esp") and not active("MLU - Ars Metallica.esp") and not active("MLU Patches Merged.esp")'
       - <<: *patch3rdParty
         subs:
           - 'Cutting Room Floor'


### PR DESCRIPTION
Latest version is named "MLU - Ars Metallica.esp", not "MLU - Ars Metallica Patch.esp", see https://www.nexusmods.com/skyrimspecialedition/mods/76259?tab=files.