### PR TITLE
Add Torch Brightness Radius

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4887,6 +4887,18 @@ plugins:
       - Graphics
       - Stats
 
+  - name: 'Torch Brightness Radius.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5101/' ]
+    after:
+      - 'ELE_SSE.esp'
+      - 'ELFX - Hardcore.esp'
+      - 'Lux.esp'
+      - 'Luminosity Lighting Overhaul.esp'
+      - 'RLO - Interiors.esp'
+    tag:
+      - Graphics
+      - Stats
+
   - name: 'RelightingSkyrim_SSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/8586/' ]
     dirty:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4887,18 +4887,6 @@ plugins:
       - Graphics
       - Stats
 
-  - name: 'Torch Brightness Radius.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5101/' ]
-    after:
-      - 'ELE_SSE.esp'
-      - 'ELFX - Hardcore.esp'
-      - 'Lux.esp'
-      - 'Luminosity Lighting Overhaul.esp'
-      - 'RLO - Interiors.esp'
-    tag:
-      - Graphics
-      - Stats
-
   - name: 'RelightingSkyrim_SSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/8586/' ]
     dirty:
@@ -5054,6 +5042,20 @@ plugins:
         crc: 0x7925F0B7
         util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
+
+  - name: 'Torch Brightness Radius.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/5101/'
+        name: 'Torch Brightness Radius'
+    after:
+      - 'ELE_SSE.esp'
+      - 'ELFX - Hardcore.esp'
+      - 'Lux.esp'
+      - 'Luminosity Lighting Overhaul.esp'
+      - 'RLO - Interiors.esp'
+    tag:
+      - Deactivate
+      - Graphics
 
   - name: 'TrueStormsSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2472/' ]


### PR DESCRIPTION
Add [Torch Brightness Radius](https://www.nexusmods.com/skyrimspecialedition/mods/5101).

I copied the *Realistic Torch Light SE.esp* block above since these mods do different flavours of the same thing.

This fixes LOOT placing *Torch Brightness Radius.esp* before popular torch dimmers, such as *ELFX - Hardcore.esp* and *Lux.esp*.