### PR TITLE
Add Thieves' Night On the Town -- Tnott

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -29009,6 +29009,13 @@ plugins:
 
   - name: 'mpThievesNightOnTheTown.esp'
     url:
-      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/42069'
-        name: "Thieves' Night On the Town -- Tnott"
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/42069/'
+        name: 'Thieves'' Night On the Town -- Tnott'
     after: [ 'Thieves Guild Requirements.esp' ]
+    tag:
+      - C.Locklist
+      - C.MiscFlags
+      - C.Owner
+      - Keywords
+      - Names
+

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -29014,8 +29014,6 @@ plugins:
     after: [ 'Thieves Guild Requirements.esp' ]
     tag:
       - C.Locklist
-      - C.MiscFlags
       - C.Owner
       - Keywords
       - Names
-

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -29006,3 +29006,9 @@ plugins:
     clean:
       - crc: 0xC5B99C7E
         util: 'SSEEdit v4.0.4'
+
+  - name: 'mpThievesNightOnTheTown.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/42069'
+        name: "Thieves' Night On the Town -- Tnott"
+    after: [ 'Thieves Guild Requirements.esp' ]


### PR DESCRIPTION
[Thieves Guild Requirements](https://www.nexusmods.com/skyrimspecialedition/mods/33256) and [Thieves' Night on the Town](https://www.nexusmods.com/skyrimspecialedition/mods/42069)

Both plugins declare entries for MarkarthNepossHouse "Nepos's House" [CELL:00016DFB]

Thieves Guild Requirements adds a persistent reference. Thieves Night on the Town changes the cell's flags and locklist.

Both modifications play fine together, but loading TGR after Tnott will undo Tnott's changes; loading Tnott after TGR will preserve the changes from both.

If submission needs style cleaning / adjustment, please advise.