### PR TITLE
Add Lux Orbis

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -4649,6 +4649,16 @@ plugins:
       - C.Climate
       - C.ImageSpace
       - C.Light
+  - name: 'Lux Orbis( - .*)?\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/56095/'
+        name: 'Lux Orbis'
+  - name: 'Lux Orbis - Cutting Room Floor patch.esp'
+    dirty:
+      - <<: *quickClean
+        crc: 0x86D0CC7F
+        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 4
   - name: 'Lux - RedBag''s Solitude patch.esp'
     tag: [ C.Light ]
   - name: 'Lux - Rodryk''s Dragonbridge patch.esp'


### PR DESCRIPTION
[Lux Orbis](https://www.nexusmods.com/skyrimspecialedition/mods/56095/)

The regex for the location captures at least 284 plugins from the mod.

Cleaning report by **xFeywolf79** on [AFKmods](https://www.afkmods.com/index.php?/topic/5042-relz-loot-load-order-optimisation-tool/page/48/#comment-188503)
v3.3