### PR TITLE
CACO - Beyond Skyrim Bruma Patch version 2.0

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -27978,11 +27978,6 @@ plugins:
       # version: 1.0
       - crc: 0x6B00626D
         util: 'SSEEdit v4.0.2f'
-  - name: 'CACO Rare Curios Patch.esp'
-    msg:
-      - <<: *alreadyInX
-        subs: [ 'CACO_Bruma_Rare Curios_Patch.esp' ]
-        condition: 'active("CACO Rare Curios Patch.esp") and active("CACO_Bruma_Rare Curios_Patch.esp")'
   - name: '(CACO|WACCF)_Survival Mode_Patch\.esp'
     inc: [ 'WACCF Survival Mode Fixes.esp' ]
   - name: 'CACO_USSEP_Patch.esp'


### PR DESCRIPTION
https://github.com/loot/skyrimse/issues/2854

CACO - Bruma - Rare Curios Patch: Patch now requires the Rare Curios CACO patch from kryptopyr's Patch Hub. Updated to favor Rare Curios records (for improved compatibility).