### PR TITLE
Load "SurWR.esp" after "Landscape and Water Fixes - Patch - LFfGM.esp"

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -24640,6 +24640,7 @@ plugins:
         name: 'Capital Whiterun Expansion'
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/63355/'
         name: 'Rob''s Bug Fixes - Capital Whiterun Expansion'
+    after: [ 'Landscape and Water Fixes - Patch - LFfGM.esp' ]
     msg:
       - <<: *patchUpdateAvailable
         subs: [ '[Rob''s Bug Fixes - Capital Whiterun Expansion](https://www.nexusmods.com/skyrimspecialedition/mods/63355/)' ]


### PR DESCRIPTION
`SurWR.esp`
[Capital Whiterun Expansion](https://www.nexusmods.com/skyrimspecialedition/mods/37982/)
[Rob's Bug Fixes - Capital Whiterun Expansion](https://www.nexusmods.com/skyrimspecialedition/mods/63355/)

`Landscape and Water Fixes - Patch - LFfGM.esp` (Landscape Fixes for Grass Mods)
[Skyrim Landscape and Water Fixes](https://www.nexusmods.com/skyrimspecialedition/mods/26138/)

Discord user **initiumx** pointed out [on Discord](https://discord.com/channels/473542112974077963/496196499890241546/1206348767297544264), that Nexus user **nexsmdz2** found:

![grafik](https://github.com/loot/skyrimse/assets/10406657/aa07ef85-783a-41e3-b84a-5ca18aedfa2b)

As such, add a rule to load `SurWR.esp` after `Landscape and Water Fixes - Patch - LFfGM.esp`.
