### PR TITLE
Update cleaning info for vanilla masters

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -1126,7 +1126,6 @@ plugins:
       - crc: 0xEA917D0B
         util: 'SSEEdit v4.0.4c'
     # v1.6.1170.0
-    clean:
       - crc: 0xEA917D0B
         util: 'SSEEdit v4.1.5d'
   # Saints & Seducers

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -899,15 +899,11 @@ plugins:
         udr: 93
         nav: 3
       # v1.6.1170.0
-      - <<: *reqManualFix
+      - <<: *quickClean
         crc: 0xE6BA88BB
         util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 386
         udr: 93
-        nav: 3
-      - <<: *reqManualFix
-        crc: 0xA14EED01
-        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         nav: 3
       # GOG v1.6.659
       - <<: *quickClean
@@ -961,20 +957,11 @@ plugins:
         udr: 82
         nav: 59
       # v1.6.1170.0
-      - <<: *reqManualFix
+      - <<: *quickClean
         crc: 0xD399544A
         util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 842
         udr: 82
-        nav: 59
-      - <<: *reqManualFix
-        crc: 0xA62C1C10
-        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
-        itm: 7
-        nav: 59
-      - <<: *reqManualFix
-        crc: 0xA5AB2927
-        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         nav: 59
       # GOG v1.6.659
       - <<: *quickClean
@@ -1018,15 +1005,11 @@ plugins:
         udr: 11
         nav: 5
       # v1.6.1170.0
-      - <<: *reqManualFix
+      - <<: *quickClean
         crc: 0xA1EC149B
         util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 221
         udr: 11
-        nav: 5
-      - <<: *reqManualFix
-        crc: 0x2913D707
-        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         nav: 5
       # GOG v1.6.659
       - <<: *quickClean
@@ -1078,15 +1061,11 @@ plugins:
         udr: 8
         nav: 1
       # v1.6.1170.0
-      - <<: *reqManualFix
+      - <<: *quickClean
         crc: 0x1120165C
         util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 88
         udr: 8
-        nav: 1
-      - <<: *reqManualFix
-        crc: 0x077954E6
-        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         nav: 1
       # GOG v1.6.659
       - <<: *quickClean
@@ -1119,16 +1098,12 @@ plugins:
         util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
         udr: 4
-    # v1.6.1170.0
-    dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0x70E3300E
         util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
         udr: 4
-    clean:
-      - crc: 0x6B3BE132
-        util: 'SSEEdit v4.1.5d'
   # Survival Mode
   - name: 'ccqdrsse001-survivalmode.esl'
     tag:
@@ -1140,15 +1115,11 @@ plugins:
         crc: 0x87023079
         util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    # v1.6.1170.0
-    dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0x25BC177E
         util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
-    clean:
-      - crc: 0x518EFEB6
-        util: 'SSEEdit v4.1.5d'
   # Rare Curios
   - name: 'ccbgssse037-curios.esl'
     clean:
@@ -1169,135 +1140,162 @@ plugins:
         crc: 0xA3D900E1
         util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
-    # v1.6.1170.0
-    dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xEBBC9DA9
         util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
-    clean:
-      - crc: 0x84B79395
-        util: 'SSEEdit v4.1.5d'
   # Resource Pack
   - name: '_ResourcePack.esl'
-    # v1.6.1170.0
+    group: *ccGroup
     clean:
+      # v1.6.1170.0
       - crc: 0x7898501C
         util: 'SSEEdit v4.1.5d'
-    group: *ccGroup
   ### Anniversary Edition ###
   # Adventurer's Backpack
   - name: 'ccfsvsse001-backpacks.esl'
     clean:
+      # v1.6.1170.0
       - crc: 0x515E986E
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Alternative Armors - Daedric Mail
   - name: 'ccbgssse051-ba_daedricmail.esl'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xED0DAC61
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
   # Alternative Armors - Daedric Plate
   - name: 'ccbgssse050-ba_daedric.esl'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xFA1BF723
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
   # Alternative Armors - Dragon Plate
   - name: 'ccbgssse059-ba_dragonplate.esl'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xA6E40E02
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 4
   # Alternative Armors - Dragonscale
   - name: 'ccbgssse060-ba_dragonscale.esl'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xFFCEF134
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
   # Alternative Armors - Dwarven Mail
   - name: 'ccbgssse062-ba_dwarvenmail.esl'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xC7B82470
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
   # Alternative Armors - Dwarven Plate
   - name: 'ccbgssse061-ba_dwarven.esl'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0x96DA6A08
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
   # Alternative Armors - Ebony Plate
   - name: 'ccbgssse063-ba_ebony.esl'
     clean:
       - crc: 0x28D1727F
         util: 'SSEEdit v4.0.4c'
+      # v1.6.1170.0
+      - crc: 0x9E48FF0A
+        util: 'SSEEdit v4.1.5d'
   # Alternative Armors - Elven Hunter
   - name: 'ccbgssse064-ba_elven.esl'
     clean:
       - crc: 0xF67CFF9B
         util: 'SSEEdit v4.0.4c'
+      # v1.6.1170.0
+      - crc: 0x166B47DB
+        util: 'SSEEdit v4.1.5d'
   # Alternative Armors - Iron
   - name: 'ccbgssse052-ba_iron.esl'
     clean:
+      # v1.6.1170.0
       - crc: 0x44CC9684
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Alternative Armors - Leather
   - name: 'ccbgssse053-ba_leather.esl'
     clean:
       - crc: 0xC280B67C
         util: 'SSEEdit v4.0.4c'
+      # v1.6.1170.0
+      - crc: 0x48F3C56D
+        util: 'SSEEdit v4.1.5d'
   # Alternative Armors - Orcish Plate
   - name: 'ccbgssse054-ba_orcish.esl'
     clean:
+      # v1.6.1170.0
       - crc: 0x1799B889
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Alternative Armors - Orcish Scaled
   - name: 'ccbgssse055-ba_orcishscaled.esl'
     clean:
       - crc: 0x19E55E2C
         util: 'SSEEdit v4.0.4c'
+      # v1.6.1170.0
+      - crc: 0x2EF68848
+        util: 'SSEEdit v4.1.5d'
   # Alternative Armors - Silver
   - name: 'ccbgssse056-ba_silver.esl'
     clean:
       - crc: 0xA67387E9
         util: 'SSEEdit v4.0.4c'
+      # v1.6.1170.0
+      - crc: 0x64FFF02D
+        util: 'SSEEdit v4.1.5d'
   # Alternative Armors - Stalhrim Fur
   - name: 'ccbgssse057-ba_stalhrim.esl'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xB0337665
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
   # Alternative Armors - Steel Soldier
   - name: 'ccbgssse058-ba_steel.esl'
     clean:
       - crc: 0x482C80EF
         util: 'SSEEdit v4.0.4c'
+      # v1.6.1170.0
+      - crc: 0xE7376E05
+        util: 'SSEEdit v4.1.5d'
   # Arcane Accessories
   - name: 'ccbgssse014-spellpack01.esl'
     msg: [ *patch3rdParty_SRPC_Redux ]
     clean:
+      # v1.6.1170.0
       - crc: 0x612F5721
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Arcane Archer Pack
   - name: 'ccbgssse002-exoticarrows.esl'
     msg: [ *patch3rdParty_SRPC_Redux ]
     clean:
+      # v1.6.1170.0
       - crc: 0x51D308C0
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Arms of Chaos
   - name: 'ccpewsse002-armsofchaos.esl'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xD8F7F985
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 9
   # Bittercup
   - name: 'cckrtsse001_altar.esl'
@@ -1314,9 +1312,10 @@ plugins:
       - C.Water
       - Graphics
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xCE4A252F
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 10
         udr: 12
         nav: 5
@@ -1336,6 +1335,11 @@ plugins:
         crc: 0x2A44A95B
         util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
+      # v1.6.1170.0
+      - <<: *quickClean
+        crc: 0x0F0EF2C6
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 1
   # Bone Wolf
   - name: 'ccbgssse036-petbwolf.esl'
     tag:
@@ -1345,29 +1349,40 @@ plugins:
     clean:
       - crc: 0xDF613F47
         util: 'SSEEdit v4.0.4c'
+      # v1.6.1170.0
+      - crc: 0xEFB58F1E
+        util: 'SSEEdit v4.1.5d'
   # Bow of Shadows
   - name: 'ccbgssse038-bowofshadows.esl'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xCF70E2A1
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
   # Camping
   - name: 'ccqdrsse002-firewood.esl'
     clean:
+      # v1.6.1170.0
       - crc: 0x31D3A629
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Chrysamere
   - name: 'ccbgssse007-chrysamere.esl'
     clean:
+      # v1.6.1170.0
       - crc: 0xE4DB0C51
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Civil War Champions
   - name: 'ccffbsse001-imperialdragon.esl'
     dirty:
       - <<: *quickClean
         crc: 0xB61EB1F5
         util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 6
+      # v1.6.1170.0
+      - <<: *quickClean
+        crc: 0x0B80C411
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 6
   # Dawnfang & Duskfang
   - name: 'ccbgssse013-dawnfang.esl'
@@ -1381,8 +1396,9 @@ plugins:
       - C.Name
       - C.Water
     clean:
+      # v1.6.1170.0
       - crc: 0xC4E35D25
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Dead Man's Dread
   - name: 'ccbgssse031-advcyrus.esm'
     dirty:
@@ -1390,16 +1406,23 @@ plugins:
         crc: 0xBF898B88
         util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 11
+      # v1.6.1170.0
+      - <<: *quickClean
+        crc: 0xBD8332C6
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 11
   # Divine Crusader
   - name: 'ccmtysse001-knightsofthenine.esl'
     clean:
+      # v1.6.1170.0
       - crc: 0x3D17B0EB
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Dwarven Armored Mudcrab
   - name: 'ccbgssse010-petdwarvenarmoredmudcrab.esl'
     clean:
+      # v1.6.1170.0
       - crc: 0x00A63157
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Elite Crossbows
   - name: 'ccbgssse043-crosselv.esl'
     tag:
@@ -1412,15 +1435,19 @@ plugins:
       - Graphics
       - Names
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0x9F926A70
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 4
   # Expanded Crossbow Pack
   - name: 'ccffbsse002-crossbowpack.esl'
     clean:
       - crc: 0xF3442D86
         util: 'SSEEdit v4.0.4c'
+      # v1.6.1170.0
+      - crc: 0xCE88C511
+        util: 'SSEEdit v4.1.5d'
   # Farming
   - name: 'ccvsvsse004-beafarmer.esl'
     tag:
@@ -1434,22 +1461,25 @@ plugins:
       - C.Water
       - Graphics
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xC84E56C2
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
         udr: 14
   # Fearsome Fists
   - name: 'cccbhsse001-gaunt.esl'
     clean:
+      # v1.6.1170.0
       - crc: 0xB2682AA4
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Forgotten Seasons
   - name: 'cctwbsse001-puzzledungeon.esm'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0x25D6FE7B
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 8
         udr: 1
   # Gallows Hall
@@ -1465,9 +1495,10 @@ plugins:
       - C.Water
       - Graphics
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xBAFF0369
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 7
         udr: 4
   # Ghosts of the Tribunal
@@ -1488,6 +1519,11 @@ plugins:
         crc: 0xD45403A6
         util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
+      # v1.6.1170.0
+      - <<: *quickClean
+        crc: 0x54B4F536
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 1
   # Goblins
   - name: 'ccbgssse040-advobgobs.esl'
     tag:
@@ -1501,9 +1537,10 @@ plugins:
       - C.Name
       - C.Water
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0x86A233E1
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
         udr: 4
   # Goldbrand
@@ -1518,15 +1555,17 @@ plugins:
       - C.Name
       - C.Water
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0x832A954E
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 6
   # Headman's Cleaver
   - name: 'ccbgssse068-bloodfall.esl'
     clean:
+      # v1.6.1170.0
       - crc: 0x767BDEC9
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Hendhraheim
   - name: 'cceejsse004-hall.esl'
     tag:
@@ -1539,9 +1578,10 @@ plugins:
       - C.Music
       - C.Name
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xFBD7033E
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 5
   # Horse Armor - Elven
   - name: 'ccbgssse011-hrsarmrelvn.esl'
@@ -1549,27 +1589,31 @@ plugins:
       - Graphics
       - ObjectBounds
     clean:
+      # v1.6.1170.0
       - crc: 0x4D90586A
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Horse Armor - Steel
   - name: 'ccbgssse012-hrsarmrstl.esl'
     tag:
       - Graphics
       - ObjectBounds
     clean:
+      # v1.6.1170.0
       - crc: 0x4287AA21
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Lord's Mail
   - name: 'ccbgssse021-lordsmail.esl'
     clean:
+      # v1.6.1170.0
       - crc: 0x3755436F
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Myrwatch
   - name: 'cceejsse002-tower.esl'
     tag: [ C.Location ]
     clean:
+      # v1.6.1170.0
       - crc: 0x7D7DE5B5
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Nchuanthumz: Dwarven Home
   - name: 'ccafdsse001-dwesanctuary.esm'
     tag:
@@ -1580,8 +1624,9 @@ plugins:
       - C.Music
       - C.Name
     clean:
+      # v1.6.1170.0
       - crc: 0x5442BD0C
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Necromantic Grimoire
   - name: 'ccvsvsse003-necroarts.esl'
     msg: [ *patch3rdParty_SRPC_Redux ]
@@ -1590,12 +1635,18 @@ plugins:
         crc: 0x8D0AE774
         util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 1
+      # v1.6.1170.0
+      - <<: *quickClean
+        crc: 0xF955CA36
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        udr: 1
   # Netch Leather Armor
   - name: 'ccbgssse041-netchleather.esl'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0x87F09B67
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
   # Nix-Hound
   - name: 'ccbgssse035-petnhound.esl'
@@ -1604,50 +1655,57 @@ plugins:
       - R.Stats
       - R.Voice-M
     clean:
+      # v1.6.1170.0
       - crc: 0xDA4CBDA5
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Nordic Jewelry
   - name: 'ccedhsse001-norjewel.esl'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0x1059E62C
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 8
   # Pets of Skyrim
   - name: 'ccvsvsse002-pets.esl'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0x474A4A90
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 8
   # Plague of the Dead
   - name: 'ccbgssse003-zombies.esl'
     msg: [ *patch3rdParty_SRPC_Redux ]
     tag: [ Delev ]
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xFE6BE367
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
   # Redguard Elite Armaments
   - name: 'ccedhsse003-redguard.esl'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0x802755BA
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
   # Ruin's Edge
   - name: 'ccbgssse004-ruinsedge.esl'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0x5EE1F7FA
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 2
   # Saturalia Holiday Pack
   - name: 'ccvsvsse001-winter.esl'
     clean:
+      # v1.6.1170.0
       - crc: 0xDEC857BE
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Shadowfoot Sanctum
   - name: 'cceejsse003-hollow.esl'
     tag:
@@ -1663,8 +1721,9 @@ plugins:
       - Keywords
       - Names
     clean:
+      # v1.6.1170.0
       - crc: 0xA7C5D720
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Shadowrend
   - name: 'ccbgssse018-shadowrend.esl'
     dirty:
@@ -1672,41 +1731,58 @@ plugins:
         crc: 0x2256DD07
         util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
+      # v1.6.1170.0
+      - <<: *quickClean
+        crc: 0x6C31393E
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 1
   # Spell Knight Armor
   - name: 'ccedhsse002-splkntset.esl'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xFCF374B9
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 11
   # Staff of Hasedoki
   - name: 'ccbgssse045-hasedoki.esl'
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xE75D726D
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 6
   # Staff of Sheogorath
   - name: 'ccbgssse019-staffofsheogorath.esl'
     clean:
       - crc: 0xFCBD8672
         util: 'SSEEdit v4.0.4c'
+      # v1.6.1170.0
+      - crc: 0x994267A8
+        util: 'SSEEdit v4.1.5d'
   # Staves
   - name: 'ccbgssse066-staves.esl'
     clean:
+      # v1.6.1170.0
       - crc: 0xF19EB095
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Stendarr's Hammer
   - name: 'ccbgssse006-stendarshammer.esl'
     clean:
+      # v1.6.1170.0
       - crc: 0xB2139281
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Sunder & Wraithguard
   - name: 'ccbgssse008-wraithguard.esl'
     dirty:
       - <<: *quickClean
         crc: 0x2B01BC19
         util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 20
+      # v1.6.1170.0
+      - <<: *quickClean
+        crc: 0x326A2273
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 20
   # The Cause
   - name: 'ccbgssse067-daedinv.esm'
@@ -1727,23 +1803,33 @@ plugins:
         crc: 0x4D769AAB
         util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 275
+      # v1.6.1170.0
+      - <<: *quickClean
+        crc: 0x31597B4B
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 275
   # The Contest
   - name: 'ccbgssse069-contest.esl'
     clean:
       - crc: 0xD2910DFE
         util: 'SSEEdit v4.0.4c'
+      # v1.6.1170.0
+      - crc: 0xB7C72F9B
+        util: 'SSEEdit v4.1.5d'
   # The Gray Cowl Returns!
   - name: 'ccbgssse020-graycowl.esl'
     clean:
+      # v1.6.1170.0
       - crc: 0x5231E7EF
-        util: 'SSEEdit v4.0.4c'
+        util: 'SSEEdit v4.1.5d'
   # Tundra Homestead
   - name: 'cceejsse001-hstead.esm'
     tag: [ C.Location ]
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0x8D907DED
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
   # Umbra
   - name: 'ccbgssse016-umbra.esm'
@@ -1757,17 +1843,19 @@ plugins:
       - C.Name
       - C.Water
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0xA9D2211B
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         udr: 10
   # Vigil Enforcer Armor Set
   - name: 'ccmtysse002-ve.esl'
     tag: [ C.Water ]
     dirty:
+      # v1.6.1170.0
       - <<: *quickClean
         crc: 0x90AD3545
-        util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 11
   # Wild Horses
   - name: 'ccbgssse034-mntuni.esl'
@@ -1775,6 +1863,11 @@ plugins:
       - <<: *quickClean
         crc: 0x39037200
         util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 26
+      # v1.6.1170.0
+      - <<: *quickClean
+        crc: 0xBE31E11C
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 26
 
 ###### Verified Creations ######

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -898,6 +898,17 @@ plugins:
         itm: 385
         udr: 93
         nav: 3
+      # v1.6.1170.0
+      - <<: *reqManualFix
+        crc: 0xE6BA88BB
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 386
+        udr: 93
+        nav: 3
+      - <<: *reqManualFix
+        crc: 0xA14EED01
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        nav: 3
       # GOG v1.6.659
       - <<: *quickClean
         crc: 0xC3E0D564
@@ -949,6 +960,22 @@ plugins:
         itm: 840
         udr: 82
         nav: 59
+      # v1.6.1170.0
+      - <<: *reqManualFix
+        crc: 0xD399544A
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 842
+        udr: 82
+        nav: 59
+      - <<: *reqManualFix
+        crc: 0xA62C1C10
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 7
+        nav: 59
+      - <<: *reqManualFix
+        crc: 0xA5AB2927
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        nav: 59
       # GOG v1.6.659
       - <<: *quickClean
         crc: 0xC855C37C
@@ -989,6 +1016,17 @@ plugins:
         util: '[SSEEdit v4.1.5 EXPERIMENTAL](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 220
         udr: 11
+        nav: 5
+      # v1.6.1170.0
+      - <<: *reqManualFix
+        crc: 0xA1EC149B
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 221
+        udr: 11
+        nav: 5
+      - <<: *reqManualFix
+        crc: 0x2913D707
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         nav: 5
       # GOG v1.6.659
       - <<: *quickClean
@@ -1039,6 +1077,17 @@ plugins:
         itm: 86
         udr: 8
         nav: 1
+      # v1.6.1170.0
+      - <<: *reqManualFix
+        crc: 0x1120165C
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 88
+        udr: 8
+        nav: 1
+      - <<: *reqManualFix
+        crc: 0x077954E6
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        nav: 1
       # GOG v1.6.659
       - <<: *quickClean
         crc: 0x7BE33EB9
@@ -1070,6 +1119,16 @@ plugins:
         util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
         udr: 4
+    # v1.6.1170.0
+    dirty:
+      - <<: *quickClean
+        crc: 0x70E3300E
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 3
+        udr: 4
+    clean:
+      - crc: 0x6B3BE132
+        util: 'SSEEdit v4.1.5d'
   # Survival Mode
   - name: 'ccqdrsse001-survivalmode.esl'
     tag:
@@ -1081,11 +1140,24 @@ plugins:
         crc: 0x87023079
         util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 1
+    # v1.6.1170.0
+    dirty:
+      - <<: *quickClean
+        crc: 0x25BC177E
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 1
+    clean:
+      - crc: 0x518EFEB6
+        util: 'SSEEdit v4.1.5d'
   # Rare Curios
   - name: 'ccbgssse037-curios.esl'
     clean:
       - crc: 0xEA917D0B
         util: 'SSEEdit v4.0.4c'
+    # v1.6.1170.0
+    clean:
+      - crc: 0xEA917D0B
+        util: 'SSEEdit v4.1.5d'
   # Saints & Seducers
   - name: 'ccbgssse025-advdsgs.esm'
     msg: [ *patch3rdParty_SRPC_Redux ]
@@ -1097,8 +1169,21 @@ plugins:
         crc: 0xA3D900E1
         util: '[SSEEdit v4.0.4c](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
+    # v1.6.1170.0
+    dirty:
+      - <<: *quickClean
+        crc: 0xEBBC9DA9
+        util: '[SSEEdit v4.1.5d](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
+        itm: 3
+    clean:
+      - crc: 0x84B79395
+        util: 'SSEEdit v4.1.5d'
   # Resource Pack
   - name: '_ResourcePack.esl'
+    # v1.6.1170.0
+    clean:
+      - crc: 0x7898501C
+        util: 'SSEEdit v4.1.5d'
     group: *ccGroup
   ### Anniversary Edition ###
   # Adventurer's Backpack


### PR DESCRIPTION
Added latest xEditQuickAutoClean data for v1.6.1170 vanilla masters

LOOT 0.22.3 isn't correctly flagging all applicable plugins for cleaning for the latest game files for Steam v1.6.1170 (Anniversary Upgrade), and some of the current masterlist cleaning data is outdated in relation to the latest game files, so I'm attempting to remedy this. 
First time contributing, so I have only added updated cleaning info for the official game files and the CC base game files. My xEdit summaries are a bit different with the latest version of xEdit, so I'd like some guidance if I've included redundant info. See the attached archive for complete summary and evidence I'm using here.

Thanks

[Autoclean - SSE-1.6.1170.zip](https://github.com/loot/skyrimse/files/14752332/Autoclean.-.SSE-1.6.1170.zip)
