### PR TITLE
AI Overhaul - NPC Protection relationship update

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9889,6 +9889,7 @@ plugins:
   - name: 'Protected NPCs.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/26999/' ]
     group: *earlyLoadersGroup
+    after: [ 'AI Overhaul.esp' ]
     tag: [ Actors.ACBS ]
 
   - name: 'ProtectUniqueNPCs.esp'
@@ -9896,6 +9897,7 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/49667/'
         name: 'Protect Unique NPCs'
     group: *earlyLoadersGroup
+    after: [ 'AI Overhaul.esp' ]
     inc:
       - 'NPCs Protected and Uncapped.esp'
       - 'NPCs Protected Redux.esp'


### PR DESCRIPTION
Fixed the relationship between protection attribute mods and "AI Overhaul".
If the load order of "AI Overhaul" is later than the mod that changes the protective attribute, the protective attribute will return to its original state.
[AI-Overhaul-Patcher](https://github.com/Excinerus/AI-Overhaul-Patcher/issues/9)