### PR TITLE
Update Ryn's Farms

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -24744,11 +24744,6 @@ plugins:
           - 'Ryn''s Standing Stones'
           - '[Ryn''s Skyrim Official Patch Hub](https://www.nexusmods.com/skyrimspecialedition/mods/73778/)'
         condition: 'active("Ryn''s Standing Stones.esp") and not active("Ryn''s_Standing_Stones_Ryn''s_Farms_PATCH.esp")'
-      - <<: *patch3rdParty
-        subs:
-          - 'Skyrim Sewers'
-          - '[Patches for Ryn''s](https://www.nexusmods.com/skyrimspecialedition/mods/74233/)'
-        condition: 'active("SkyrimSewers.esp") and not active("Ryn''s Farms - Skyrim Sewers.esp")'
     clean:
       - crc: 0x1BE50A99
         util: 'SSEEdit v4.0.4'


### PR DESCRIPTION
Remove the message for the Skyrim Sewers patch since it is no longer necessary according to the patch page.