### PR TITLE
Adding ParallaxGen - Dynamic Mesh Patcher

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2487,6 +2487,10 @@ plugins:
     after: [ 'DynDOLOD.esp' ]
     msg: [ *runxLODGen ]
 
+  - name: 'ParallaxGen.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/120946/' ]
+    group: *lateChangesGroup
+
   - name: 'Smashed Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrim/mods/90987/' ]
     group: *dynamicPatchGroup


### PR DESCRIPTION
ParallaxGen ([Nexus](https://www.nexusmods.com/skyrimspecialedition/mods/120946)/[GitHub](https://github.com/hakasapl/ParallaxGen)) is a dynamic mesh patching tool that can be used to enable certain shaders (for now `Parallax`, `Complex Material`, and `PBR` is supported) on meshes based on the textures a user has in their load order. This requires editing texture sets in meshes, which causes issues when the TXST records in the plugins do not match. ParallaxGen 0.6 will release with this feature in the coming weeks. The plugin patching component will:

1. Patch TXST records where necessary based on the winning overrides in the load order
2. Create new TXST records for instances where a single TXST record is used for more than one shader
    1. In this case the alternate texture reference in the MODL record is also overridden and modified to refer to the newly created TXST record

The output filename is `ParallaxGen.esp`. It is required to load later than any plugin that would have a TXST record except dynamic LOD plugins, so it probably makes sense for the group to be `lateChangesGroup`, please let me know if that sounds correct.