### PR TITLE
fix backslash typo

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9669,7 +9669,7 @@ plugins:
         util: '[SSEEdit v4.0.3g](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 3
 
-  - name: 'Crossbow Integration.*/.esp'
+  - name: 'Crossbow Integration.*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/28766/' ]
   - name: 'Crossbow Integration.esp'
     tag:


### PR DESCRIPTION
This pull request includes a minor change to the `masterlist.yaml` file. The change corrects the regular expression pattern for the 'Crossbow Integration' plugin name.

* [`masterlist.yaml`](diffhunk://#diff-afbffa678ef6846824e6d4877fc43c39f999baf799201fd1e9ec60332390ae9cL9672-R9672): Fixed the regular expression pattern for 'Crossbow Integration' plugin name to properly escape the dot character.