### PR TITLE
fix url mixup of link and name for "Book Covers Skyrim - Lost Library"

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18197,14 +18197,14 @@ plugins:
 
   - name: 'Book Covers Skyrim - Lost Library.esp'
     url:
-      - name: 'https://www.nexusmods.com/skyrimspecialedition/mods/902/'
-        link: 'Book Covers Skyrim - Lost Library'
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/902/'
+        name: 'Book Covers Skyrim - Lost Library'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3203152/'
         name: 'BCS Lost Library - Original'
       - link: 'https://bethesda.net/en/mods/skyrim/mod-detail/3203032/'
         name: 'BCS Lost Library - Desaturated'
-      - name: 'https://www.nexusmods.com/skyrimspecialedition/mods/70272/'
-        link: 'Book Covers Skyrim - Lost Library REDUX'
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/70272/'
+        name: 'Book Covers Skyrim - Lost Library REDUX'
     msg:
       - <<: *alreadyInLotD
         condition: 'active("LegacyoftheDragonborn.esm") and not checksum("Book Covers Skyrim - Lost Library.esp", 6D8408E1)'


### PR DESCRIPTION
This pull request includes a small change to the `masterlist.yaml` file. The change corrects the order of the `name` and `link` fields for two location entries under the 'Book Covers Skyrim - Lost Library.esp' plugin.