### PR TITLE
Update Additional Clockwork - Load Superior Sorting After Bug Fixes

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -28239,6 +28239,7 @@ plugins:
       - crc: 0xB4C1E773
         util: 'SSEEdit v4.0.4b'
   - name: 'ClockworkSuperiorSorting.esp'
+    after: [ 'ClockworkBugFixes.esp' ]
     req:
       - *PapyrusExtender
       - *SKSE


### PR DESCRIPTION
Been a while since I last did this!

A user pointed out to me today that two of Additional Clockwork's plugins conflict with one another. Specifically, `ClockworkSuperiorSorting.esp` and `ClockworkBugFixes.esp`. The conflict is minor—the positions of a few miscellaneous refs—but, now knowing about and having investigated the conflict, I do have an intended loading order.

`ClockworkSuperiorSorting.esp` should load after `ClockworkBugFixes.esp` in order to avoid minor, likely hard-to-notice visual inconsistencies.

Thank you for all the hard work you guys do keeping the community sane and I look forward to the review :saluting_face: 