### PR TITLE
Add PBR textures to New Legion condition

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18627,7 +18627,7 @@ plugins:
       - <<: *requiresX
         type: error
         subs: [ 'New Legion textures' ]
-        condition: 'not file("Textures/Armor_Replacer/2_Legion")'
+        condition: 'not file("Textures/Armor_Replacer/2_Legion") and not file("textures/pbr/Armor_Replacer/2_Legion")'
     tag:
       - Delev
       - Graphics


### PR DESCRIPTION
Adds to texture check condition the paths for PBR textures from NordwarUA's Legion - Complex Material and PBR
https://www.nexusmods.com/skyrimspecialedition/mods/137994

Note that "DIS_Heavy_Legion.esp" can also refer to esp replacer from RMB SPIDified - New Legion  (https://www.nexusmods.com/skyrimspecialedition/mods/84974)

~~But it is also from: "Heavy Legion SSE" - https://www.nexusmods.com/skyrimspecialedition/mods/22877~~
~~( and RMB SPIDified - Heavy Legion - https://www.nexusmods.com/skyrimspecialedition/mods/101461)
Textures paths would be:
\Textures\1_Soldier_Replacer
\Textures\pbr\1_Soldier_Replacer~~

~~Not sure if should just add those paths.~~