### PR TITLE
Update Alternate Perspective

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -15265,7 +15265,6 @@ plugins:
     req:
       - *PapyrusUtil
       - *SilentVoice
-      - 'UIExtensions.esp'
     inc:
       - 'Alternate Start - Live Another Life.esp'
       - 'Original Opening Scene.esp'


### PR DESCRIPTION
Resolves https://github.com/loot/skyrimse/issues/2981

[Alternate Perspective - Alternate Start](https://www.nexusmods.com/skyrimspecialedition/mods/50307/)
As of version 4.0.0 `AlternatePerspective.esp` no longer has `UIExtensions.esp` as a requirement.