### PR TITLE
Update checksum for XP32 CTD fix for VR

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3289,7 +3289,7 @@ plugins:
         subs:
           - 'Skyrim VR'
           - '[XP32 First Person Skeleton CTD Bugfix for VR](https://www.nexusmods.com/skyrimspecialedition/mods/34301/)'
-        condition: 'file("../SkyrimVR.exe") and not checksum("meshes/actors/character/_1stperson/skeleton.nif", D3F2B285) and not active("Skyrim VR SSE USSEP Compatibility Mod.esp")'
+        condition: 'file("../SkyrimVR.exe") and not checksum("meshes/actors/character/_1stperson/skeleton.nif", DB54B071) and not active("Skyrim VR SSE USSEP Compatibility Mod.esp")'
       - <<: *patch3rdParty
         type: warn
         subs:


### PR DESCRIPTION
The current checksum in the masterlist is from the outdated version of the mod 5 years ago.