### PR TITLE
Update condition for versionSkseIncSSE instances

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -673,10 +673,10 @@ globals:
     condition: 'readable("../SkyrimSE.exe") and product_version("../SkyrimSE.exe", "1.6.1179.0", ==) and not file("../skse64_1_6_1179.dll") and file("../skse64_loader.exe")'
   # SKSE AE EGS - Game Runtime
   - <<: *versionSkseIncSSE
-    condition: 'file("../EOSSDK-Win64-Shipping.dll") and file("../skse64_loader.exe")'
+    condition: 'file("../SkyrimSE.exe") and file("../EOSSDK-Win64-Shipping.dll") and file("../skse64_loader.exe")'
   # SKSE SE - Game Runtime
   - <<: *versionSkseIncSSE
-    condition: 'file("../skse(vr)?_loader.exe") and not file("../skse64_loader.exe")'
+    condition: 'file("../SkyrimSE.exe") and file("../skse(vr)?_loader.exe") and not file("../skse64_loader.exe")'
   - <<: *versionSkseIncSSE
     condition: 'readable("../SkyrimSE.exe") and product_version("../SkyrimSE.exe", "1.5.50.0", ==) and version("../skse64_loader.exe", "0.2.0.8", <) and file("../skse64_loader.exe")'
   - <<: *versionSkseIncSSE


### PR DESCRIPTION
Since LOOT v0.26.0 Skyrim VR now uses the `skyrimse` masterlist by default. The following error get's displayed:

![image](https://github.com/user-attachments/assets/5fbee137-7d99-414f-b2ea-fc8848da4ee2)

Reported by WillowArcane on [AFKmods](https://www.afkmods.com/index.php?/topic/5042-relz-loot-load-order-optimisation-tool/page/53/#findComment-192102)