### PR TITLE
Format compatPatchForX condition for JKs Interiors Patch Collection

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -791,7 +791,6 @@ globals:
     subs:
       - 'JK''s Interiors'
       - '[JK''s Interiors Patch Collection](https://www.nexusmods.com/skyrimspecialedition/mods/35910/)'
-    # active() or active() and not active()
     condition: 'active("JK''?s (Angelines Aromatics|Arcadia''s Cauldron|Arnleif and Sons Trading Company|Bee and Barb|Belethor''s General Goods|Bits and Pieces|Candlehearth Hall|Elgrims Elixirs|Haelga''s Bunkhouse|New Gnisis Cornerclub|Radiant Raiment|Riverwood Trader|Sadris Used Wares|Septimus Signus''s Outpost|Silver-Blood Inn|Sinderion''s Field Laboratory|Sleeping Giant Inn|Temple of (Dibella|Kynareth|Mara|Talos|the Divines)|The (Bannered Mare|Drunken Huntsman|Hag''s Cure|Pawned Prawn|Ragged Flagon|Winking Skeever)|Warmaiden''s|White Phial)\.esp") or
                 active("JK''?s (Blue Palace|Dragonsreach|Mistveil Keep|Palace of the Kings|Understone Keep)\.esp") and
                 not active("Palaces Castles Enhanced.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -792,36 +792,8 @@ globals:
       - 'JK''s Interiors'
       - '[JK''s Interiors Patch Collection](https://www.nexusmods.com/skyrimspecialedition/mods/35910/)'
     # active() or active() and not active()
-    condition: 'active("JK''?s (Angelines Aromatics|
-                                Arcadia''s Cauldron|
-                                Arnleif and Sons Trading Company|
-                                Bee and Barb|
-                                Belethor''s General Goods|
-                                Bits and Pieces|
-                                Candlehearth Hall|
-                                Elgrims Elixirs|
-                                Haelga''s Bunkhouse|
-                                New Gnisis Cornerclub|
-                                Radiant Raiment|
-                                Riverwood Trader|
-                                Sadris Used Wares|
-                                Septimus Signus''s Outpost|
-                                Silver-Blood Inn|
-                                Sinderion''s Field Laboratory|
-                                Sleeping Giant Inn|
-                                Temple of (Dibella|Kynareth|Mara|Talos|the Divines)|
-                                The (Bannered Mare|Drunken Huntsman|Hag''s Cure|Pawned Prawn|Ragged Flagon|Winking Skeever)|
-                                Warmaiden''s|
-                                White Phial
-                               )\.esp"
-                      ) or
-                active("JK''?s (Blue Palace|
-                                Dragonsreach|
-                                Mistveil Keep|
-                                Palace of the Kings|
-                                Understone Keep
-                               )\.esp"
-                      ) and
+    condition: 'active("JK''?s (Angelines Aromatics|Arcadia''s Cauldron|Arnleif and Sons Trading Company|Bee and Barb|Belethor''s General Goods|Bits and Pieces|Candlehearth Hall|Elgrims Elixirs|Haelga''s Bunkhouse|New Gnisis Cornerclub|Radiant Raiment|Riverwood Trader|Sadris Used Wares|Septimus Signus''s Outpost|Silver-Blood Inn|Sinderion''s Field Laboratory|Sleeping Giant Inn|Temple of (Dibella|Kynareth|Mara|Talos|the Divines)|The (Bannered Mare|Drunken Huntsman|Hag''s Cure|Pawned Prawn|Ragged Flagon|Winking Skeever)|Warmaiden''s|White Phial)\.esp") or
+                active("JK''?s (Blue Palace|Dragonsreach|Mistveil Keep|Palace of the Kings|Understone Keep)\.esp") and
                 not active("Palaces Castles Enhanced.esp")'
   - <<: *compatPatchForX
     subs:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -791,7 +791,38 @@ globals:
     subs:
       - 'JK''s Interiors'
       - '[JK''s Interiors Patch Collection](https://www.nexusmods.com/skyrimspecialedition/mods/35910/)'
-    condition: 'active("JK''?s (Angelines Aromatics|Arcadia''s Cauldron|Arnleif and Sons Trading Company|Bee and Barb|Belethor''s General Goods|Bits and Pieces|Candlehearth Hall|Elgrims Elixirs|Haelga''s Bunkhouse|New Gnisis Cornerclub|Radiant Raiment|Riverwood Trader|Sadris Used Wares|Septimus Signus''s Outpost|Silver-Blood Inn|Sinderion''s Field Laboratory|Sleeping Giant Inn|Temple of Dibella|Temple of Kynareth|Temple of Mara|Temple of Talos|Temple of the Divines|The Bannered Mare|The Drunken Huntsman|The Hag''s Cure|The Pawned Prawn|The Ragged Flagon|The Winking Skeever|Warmaiden''s|White Phial)\.esp") or active("JK''?s (Blue Palace|Dragonsreach|Mistveil Keep|Palace of the Kings|Understone Keep)\.esp") and not active("Palaces Castles Enhanced.esp")'
+    # active() or active() and not active()
+    condition: 'active("JK''?s (Angelines Aromatics|
+                                Arcadia''s Cauldron|
+                                Arnleif and Sons Trading Company|
+                                Bee and Barb|
+                                Belethor''s General Goods|
+                                Bits and Pieces|
+                                Candlehearth Hall|
+                                Elgrims Elixirs|
+                                Haelga''s Bunkhouse|
+                                New Gnisis Cornerclub|
+                                Radiant Raiment|
+                                Riverwood Trader|
+                                Sadris Used Wares|
+                                Septimus Signus''s Outpost|
+                                Silver-Blood Inn|
+                                Sinderion''s Field Laboratory|
+                                Sleeping Giant Inn|
+                                Temple of (Dibella|Kynareth|Mara|Talos|the Divines)|
+                                The (Bannered Mare|Drunken Huntsman|Hag''s Cure|Pawned Prawn|Ragged Flagon|Winking Skeever)|
+                                Warmaiden''s|
+                                White Phial
+                               )\.esp"
+                      ) or
+                active("JK''?s (Blue Palace|
+                                Dragonsreach|
+                                Mistveil Keep|
+                                Palace of the Kings|
+                                Understone Keep
+                               )\.esp"
+                      ) and
+                not active("Palaces Castles Enhanced.esp")'
   - <<: *compatPatchForX
     subs:
       - 'JK''s Guild HQ Interiors'


### PR DESCRIPTION
Setup:
`condition: active() or active() and not active()`

I've tried to write the condition like this:
```yaml
    condition: 'active("JK''?s (Angelines Aromatics|
                                Arcadia''s Cauldron|
                                Arnleif and Sons Trading Company|
                                Bee and Barb|
                                Belethor''s General Goods|
                                Bits and Pieces|
                                Candlehearth Hall|
                                Elgrims Elixirs|
                                Haelga''s Bunkhouse|
                                New Gnisis Cornerclub|
                                Radiant Raiment|
                                Riverwood Trader|
                                Sadris Used Wares|
                                Septimus Signus''s Outpost|
                                Silver-Blood Inn|
                                Sinderion''s Field Laboratory|
                                Sleeping Giant Inn|
                                Temple of (Dibella|Kynareth|Mara|Talos|the Divines)|
                                The (Bannered Mare|Drunken Huntsman|Hag''s Cure|Pawned Prawn|Ragged Flagon|Winking Skeever)|
                                Warmaiden''s|
                                White Phial
                               )\.esp"
                      ) or
                active("JK''?s (Blue Palace|
                                Dragonsreach|
                                Mistveil Keep|
                                Palace of the Kings|
                                Understone Keep
                               )\.esp"
                      ) and
                not active("Palaces Castles Enhanced.esp")'
```
But the checks failed on that:
> ERROR: yaml-cpp: error at line 790, column 5: bad conversion: invalid condition syntax: Failed to parse condition "active("JK'?s (Angelines Aromatics| Arcadia's Cauldron| Arnleif and Sons Trading Company| Bee and Barb| Belethor's General Goods| Bits and Pieces| Candlehearth Hall| Elgrims Elixirs| Haelga's Bunkhouse| New Gnisis Cornerclub| Radiant Raiment| Riverwood Trader| Sadris Used Wares| Septimus Signus's Outpost| Silver-Blood Inn| Sinderion's Field Laboratory| Sleeping Giant Inn| Temple of (Dibella|Kynareth|Mara|Talos|the Divines)| The (Bannered Mare|Drunken Huntsman|Hag's Cure|Pawned Prawn|Ragged Flagon|Winking Skeever)| Warmaiden's| White Phial )\.esp" ) or active("JK'?s (Blue Palace| Dragonsreach| Mistveil Keep| Palace of the Kings| Understone Keep )\.esp" ) and not active("Palaces Castles Enhanced.esp")". Details: The parser did not consume the following input: "active("JK'?s (Angelines Aromatics| Arcadia's Cauldron| Arnleif and Sons Trading Company| Bee and Barb| Belethor's General Goods| Bits and Pieces| Candlehearth Hall| Elgrims Elixirs| Haelga's Bunkhouse| New Gnisis Cornerclub| Radiant Raiment| Riverwood Trader| Sadris Used Wares| Septimus Signus's Outpost| Silver-Blood Inn| Sinderion's Field Laboratory| Sleeping Giant Inn| Temple of (Dibella|Kynareth|Mara|Talos|the Divines)| The (Bannered Mare|Drunken Huntsman|Hag's Cure|Pawned Prawn|Ragged Flagon|Winking Skeever)| Warmaiden's| White Phial )\.esp" ) or active("JK'?s (Blue Palace| Dragonsreach| Mistveil Keep| Palace of the Kings| Understone Keep )\.esp" ) and not active("Palaces Castles Enhanced.esp")": loot condition interpreter error

So I've opted to write the condition in a more condensed form, which is still an improvement over it's original form:
```yaml
    condition: 'active("JK''?s (Angelines Aromatics|Arcadia''s Cauldron|Arnleif and Sons Trading Company|Bee and Barb|Belethor''s General Goods|Bits and Pieces|Candlehearth Hall|Elgrims Elixirs|Haelga''s Bunkhouse|New Gnisis Cornerclub|Radiant Raiment|Riverwood Trader|Sadris Used Wares|Septimus Signus''s Outpost|Silver-Blood Inn|Sinderion''s Field Laboratory|Sleeping Giant Inn|Temple of (Dibella|Kynareth|Mara|Talos|the Divines)|The (Bannered Mare|Drunken Huntsman|Hag''s Cure|Pawned Prawn|Ragged Flagon|Winking Skeever)|Warmaiden''s|White Phial)\.esp") or
                active("JK''?s (Blue Palace|Dragonsreach|Mistveil Keep|Palace of the Kings|Understone Keep)\.esp") and
                not active("Palaces Castles Enhanced.esp")'
```