### PR TITLE
Changed ParallaxGen.esp to new PG_X.esp name

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2832,7 +2832,7 @@ plugins:
     after: [ 'DynDOLOD.esp' ]
     msg: [ *runxLODGen ]
 
-  - name: 'ParallaxGen.esp'
+  - name: 'PG_\d+\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/120946/' ]
     group: *lateChangesGroup
 

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2832,7 +2832,7 @@ plugins:
     after: [ 'DynDOLOD.esp' ]
     msg: [ *runxLODGen ]
 
-  - name: 'PG_\d+\.esp'
+  - name: 'P(arallaxGen|G_\d+)\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/120946/' ]
     group: *lateChangesGroup
 


### PR DESCRIPTION
Recent versions of PGPatcher (used to be ParallaxGen) use `PG_1.esp`, `PG_2.esp`, etc. where the number can be any number starting from 1 as required to get around the 255 master limit (required for some large load orders).

This PR will change the name to match `PG_X.esp` where `X` is any number.