### PR TITLE
Update to Requiem 6

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -18315,6 +18315,8 @@ plugins:
         condition: 'active("Complete Crafting Overhaul_Remastered.esp") and not active("AetheriumSwordsnArmor_CCOR_Patch.esp")'
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_AetheriumWeapons_Patch.esp") and version("LegacyoftheDragonborn.esm", "5.0.24", >=)'
+      - <<: *patch3rdParty_RPC
+        condition: 'active("Requiem.esp") and not active("Requiem - Aetherium Armor.esp")'
     clean:
       - crc: 0xFA7F23A7
         util: 'SSEEdit v4.0.4b'
@@ -29334,6 +29336,11 @@ plugins:
         condition: 'file("DBM_Requiem_Patch.esp")'
 
   ### Requiem Patch Central ###
+  - name: 'Requiem - Aetherium Armor.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/64410/'
+        name: 'Requiem Patch Central'
+    after: [ 'Requiem - Improved Closefaced Helmets.esp' ]
   - name: 'Requiem - ArteFakes.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/64410/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -29531,6 +29531,13 @@ plugins:
         display: 'Requiem v6.0.0+'
         condition: 'version("Requiem.esp", "6.0.0", >=)'
 
+  - name: 'Requiem - Summermyst.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/67594/' ]
+    inc:
+      - name: 'Requiem.esp'
+        display: 'Requiem v5.3.0+'
+        condition: 'version("Requiem.esp", "5.3.0", >=)'
+
   - name: 'Requiem - Triumvirate.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/88561/' ]
     inc:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -20012,7 +20012,12 @@ plugins:
       - <<: *patch3rdParty_MLU
         condition: 'active("MLU.esp") and not active("MLU_HeavyArmory Patch.esp")'
       - <<: *patch3rdParty_RPC
-        condition: 'active("Requiem.esp") and not active("Requiem - Heavy Armory.esp")'
+        condition: 'active("Requiem.esp") and not active("Requiem - Heavy Armory.esp") and version("Requiem.esp", "5.3.0", <)'
+      - <<: *patch3rdParty
+        subs:
+          - 'Requiem - The Roleplaying Overhaul'
+          - '[Requiem - Heavy Armory Patch](https://www.nexusmods.com/skyrimspecialedition/mods/89009/)'
+        condition: 'active("Requiem.esp") and not active("Requiem - Heavy Armory Patch.esp") and version("Requiem.esp", "5.3.0", >=)'
       - <<: *patchIncluded
         subs: [ 'Weapons Armor Clothing and Clutter Fixes' ]
         condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp") and not active("PrvtI_HeavyArmory_WACCF_Patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -30516,3 +30516,12 @@ plugins:
       - C.Owner
       - Keywords
       - Names
+
+  - name: 'VMUVM.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/3125/'
+        name: 'Vastly More Unique Visage of Mzund'
+    msg:
+      - <<: *alreadyInX
+        subs: [ '**Requiem.esp**' ]
+        condition: 'active("Requiem.esp") and version("Requiem.esp", "6.0.0", >=)'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -29486,9 +29486,8 @@ plugins:
 
   - name: 'Requiem - Standing Stones Reimagined.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/113346/' ]
-    inc:
-      - name: 'Requiem.esp'
-        display: 'Requiem v6.0.0+'
+    msg:
+      - <<: *patchOutdated
         condition: 'version("Requiem.esp", "6.0.0", >=)'
 
   ### Requiem - WACCF CCOR ACE Patches ###
@@ -29496,53 +29495,46 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/31758/'
         name: 'Requiem - WACCF CCOR ACE Patches'
-    inc:
-      - name: 'Requiem.esp'
-        display: 'Requiem v6.0.0+'
+    msg:
+      - <<: *patchOutdated
         condition: 'version("Requiem.esp", "6.0.0", >=)'
   - name: 'Requiem - WACCF - ACE.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/31758/'
         name: 'Requiem - WACCF CCOR ACE Patches'
-    inc:
-      - name: 'Requiem.esp'
-        display: 'Requiem v6.0.0+'
+    msg:
+      - <<: *patchOutdated
         condition: 'version("Requiem.esp", "6.0.0", >=)'
   - name: 'Requiem - CCOR.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/31758/'
         name: 'Requiem - WACCF CCOR ACE Patches'
-    inc:
-      - name: 'Requiem.esp'
-        display: 'Requiem v6.0.0+'
+    msg:
+      - <<: *patchOutdated
         condition: 'version("Requiem.esp", "6.0.0", >=)'
 
   - name: 'Requiem - Sacrilege.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/72578/' ]
-    inc:
-      - name: 'Requiem.esp'
-        display: 'Requiem v6.0.0+'
+    msg:
+      - <<: *patchOutdated
         condition: 'version("Requiem.esp", "6.0.0", >=)'
 
   - name: 'Requiem - Sacrosanct Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/62406/' ]
-    inc:
-      - name: 'Requiem.esp'
-        display: 'Requiem v6.0.0+'
+    msg:
+      - <<: *patchOutdated
         condition: 'version("Requiem.esp", "6.0.0", >=)'
 
   - name: 'Requiem - Summermyst.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/67594/' ]
-    inc:
-      - name: 'Requiem.esp'
-        display: 'Requiem v5.3.0+'
+    msg:
+      - <<: *patchOutdated
         condition: 'version("Requiem.esp", "5.3.0", >=)'
 
   - name: 'Requiem - Triumvirate.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/88561/' ]
-    inc:
-      - name: 'Requiem.esp'
-        display: 'Requiem v6.0.0+'
+    msg:
+      - <<: *patchOutdated
         condition: 'version("Requiem.esp", "6.0.0", >=)'
 
   - name: 'rll(_lite)?_scarcity_patch\.esp'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10529,7 +10529,7 @@ plugins:
       - 'SkyRe_Main.esp'
     msg:
       - <<: *compatNotes
-        subs: [ 'https://requiem.atlassian.net/wiki/spaces/RSSE/pages/2658926593/Compatibility+Advice' ]
+        subs: [ 'https://github.com/ProbablyManuel/requiem/wiki#compatibility-advice' ]
       - *includesMBBF
   - name: 'Requiem - No Overencumbered Messages.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -477,6 +477,12 @@ common:
       - 'Vokrii - Minimalistic Perks of Skyrim'
       - '[Umgak''s Vokrii Compatibility Patch Compendium](https://www.nexusmods.com/skyrimspecialedition/mods/26278/)'
 
+  # &patchUnavailable
+  - &patchUnavailableRequiem
+    <<: *patchUnavailable
+    subs: [ 'Requiem - The Roleplaying Overhaul' ]
+    condition: 'active("Requiem.esp")'
+
   # &requiresMCM_X
   - &requiresMCM
     <<: *requiresMCM_X
@@ -11557,9 +11563,11 @@ plugins:
         subs:
           - 'Requiem - The Roleplaying Overhaul'
           - '[Requiem - WACCF CCOR ACE Patches](https://www.nexusmods.com/skyrimspecialedition/mods/31758/)'
-        condition: 'active("Requiem.esp") and not active("Requiem - CCOR.esp")'
+        condition: 'active("Requiem.esp") and not active("Requiem - CCOR.esp") and version("Requiem.esp", "6.0.0", <)'
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_CCOR_Patch.esp") and version("LegacyoftheDragonborn.esm", "5.0.24", >=)'
+      - <<: *patchUnavailableRequiem
+        condition: 'active("Requiem.esp") and version("Requiem.esp", "6.0.0", >=)'
       - <<: *patchUpdateAvailable
         type: warn
         subs: [ '[CCOR PRUFEI Chest CTD Hotfix](https://www.nexusmods.com/skyrimspecialedition/mods/28608/)' ]
@@ -12983,7 +12991,7 @@ plugins:
         subs:
           - 'Requiem - The Roleplaying Overhaul'
           - '[Requiem - WACCF CCOR ACE Patches](https://www.nexusmods.com/skyrimspecialedition/mods/31758/)'
-        condition: 'active("Requiem.esp") and not active("Requiem - WACCF.esp")'
+        condition: 'active("Requiem.esp") and not active("Requiem - WACCF.esp") and version("Requiem.esp", "6.0.0", <)'
       - <<: *patch3rdParty
         subs:
           - 'Triss Armor Retextured'
@@ -12995,6 +13003,8 @@ plugins:
         condition: 'active("Vokrii - Minimalistic Perks of Skyrim.esp") and not active("Vokrii - WACCF Patch.esp") and not active("Complete Crafting Overhaul_Remastered.esp")'
       - <<: *patch3rdParty_LotD
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_WACCF_Patch.esp")'
+      - <<: *patchUnavailableRequiem
+        condition: 'active("Requiem.esp") and version("Requiem.esp", "6.0.0", >=)'
     clean:
       - crc: 0xA8EBA40E
         util: 'SSEEdit v4.0.3h (Hotfix 1)'
@@ -18481,7 +18491,9 @@ plugins:
         subs:
           - 'Requiem - The Roleplaying Overhaul'
           - '[Requiem - WACCF CCOR ACE Patches](https://www.nexusmods.com/skyrimspecialedition/mods/31758/)'
-        condition: 'active("Requiem.esp") and not active("Requiem - WACCF - ACE.esp")'
+        condition: 'active("Requiem.esp") and not active("Requiem - WACCF - ACE.esp") and version("Requiem.esp", "6.0.0", <)'
+      - <<: *patchUnavailableRequiem
+        condition: 'active("Requiem.esp") and version("Requiem.esp", "6.0.0", >=)'
       - *requiresMCM
       - *requiresMCMVR
     tag:
@@ -29438,6 +29450,32 @@ plugins:
         name: 'Requiem Patch Central'
     after: [ 'Fozars_Dragonborn_-_Requiem_Patch.esp' ]
     inc: [ 'Requiem - SkyTEST.esp' ]
+
+  ### Requiem - WACCF CCOR ACE Patches ###
+  - name: 'Requiem - WACCF.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/31758/'
+        name: 'Requiem - WACCF CCOR ACE Patches'
+    inc:
+      - name: 'Requiem.esp'
+        display: 'Requiem v6.0.0+'
+        condition: 'version("Requiem.esp", "6.0.0", >=)'
+  - name: 'Requiem - WACCF - ACE.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/31758/'
+        name: 'Requiem - WACCF CCOR ACE Patches'
+    inc:
+      - name: 'Requiem.esp'
+        display: 'Requiem v6.0.0+'
+        condition: 'version("Requiem.esp", "6.0.0", >=)'
+  - name: 'Requiem - CCOR.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/31758/'
+        name: 'Requiem - WACCF CCOR ACE Patches'
+    inc:
+      - name: 'Requiem.esp'
+        display: 'Requiem v6.0.0+'
+        condition: 'version("Requiem.esp", "6.0.0", >=)'
 
   - name: 'rll(_lite)?_scarcity_patch\.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -19568,12 +19568,15 @@ plugins:
   - name: 'KatanaCrafting.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5306/' ]
     msg:
+      - <<: *alreadyInX
+        subs: [ '**Requiem.esp**' ]
+        condition: 'active("Requiem.esp") and version("Requiem.esp", "5.3.0", >=)'
       - <<: *patch3rdParty_KPH_CCOR
         condition: 'active("Complete Crafting Overhaul_Remastered.esp") and not active("KatanaCrafting_CCOR_Patch.esp")'
       - <<: *patch3rdParty_KPH_WACCF
         condition: 'active("Weapons Armor Clothing & Clutter Fixes.esp") and not active("Complete Crafting Overhaul_Remastered.esp") and not active("KatanaCrafting_WACCF_Patch.esp")'
       - <<: *patch3rdParty_RPC
-        condition: 'active("Requiem.esp") and not active("Requiem - Katana Crafting.esp")'
+        condition: 'active("Requiem.esp") and not active("Requiem - Katana Crafting.esp") and version("Requiem.esp", "5.3.0", <)'
 
   - name: 'ktWeaponPackSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/15050/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -29426,7 +29426,8 @@ plugins:
     after:
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
       - 'Requiem - Minor Arcana - Vigilants of Stendarr.esp'
-      - 'Requiem - Warmonger Armory.esp'
+      - name: 'Requiem - Warmonger Armory.esp'
+        condition: 'version("Requiem - Royal Armory.esp", "5.02", <)'
   - name: 'Requiem - Scoped Bows.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/64410/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -29524,6 +29524,13 @@ plugins:
         display: 'Requiem v6.0.0+'
         condition: 'version("Requiem.esp", "6.0.0", >=)'
 
+  - name: 'Requiem - Sacrosanct Patch.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/62406/' ]
+    inc:
+      - name: 'Requiem.esp'
+        display: 'Requiem v6.0.0+'
+        condition: 'version("Requiem.esp", "6.0.0", >=)'
+
   - name: 'Requiem - Triumvirate.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/88561/' ]
     inc:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -29524,6 +29524,13 @@ plugins:
         display: 'Requiem v6.0.0+'
         condition: 'version("Requiem.esp", "6.0.0", >=)'
 
+  - name: 'Requiem - Triumvirate.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/88561/' ]
+    inc:
+      - name: 'Requiem.esp'
+        display: 'Requiem v6.0.0+'
+        condition: 'version("Requiem.esp", "6.0.0", >=)'
+
   - name: 'rll(_lite)?_scarcity_patch\.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/20812/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -29355,7 +29355,8 @@ plugins:
         name: 'Requiem Patch Central'
     after:
       - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
-      - 'Requiem - Cutting Room Floor.esp'
+      - name: 'Requiem - Cutting Room Floor.esp'
+        condition: 'version("Requiem - Audio Overhaul Skyrim.esp", "5.06", <)'
   - name: 'Requiem - Book Covers Skyrim.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/64410/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -29517,6 +29517,13 @@ plugins:
         display: 'Requiem v6.0.0+'
         condition: 'version("Requiem.esp", "6.0.0", >=)'
 
+  - name: 'Requiem - Sacrilege.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/72578/' ]
+    inc:
+      - name: 'Requiem.esp'
+        display: 'Requiem v6.0.0+'
+        condition: 'version("Requiem.esp", "6.0.0", >=)'
+
   - name: 'rll(_lite)?_scarcity_patch\.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/20812/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -3369,8 +3369,11 @@ plugins:
         name: 'ArteFakes - Unique Artifacts Replacer'
   - name: 'ArteFake.esp'
     msg:
+      - <<: *alreadyInX
+        subs: [ '**Requiem.esp**' ]
+        condition: 'active("Requiem.esp") and version("Requiem.esp", "6.0.0", >=)'
       - <<: *patch3rdParty_RPC
-        condition: 'active("Requiem.esp") and not active("Requiem - ArteFakes.esp")'
+        condition: 'active("Requiem.esp") and not active("Requiem - ArteFakes.esp") and version("Requiem.esp", "6.0.0", <)'
     tag:
       - Actors.ACBS
       - Actors.DeathItem

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -29383,7 +29383,9 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/64410/'
         name: 'Requiem Patch Central'
-    after: [ 'Requiem - Minor Arcana - Roleplaying.esp' ]
+    after:
+      - name: 'Requiem - Minor Arcana - Roleplaying.esp'
+        condition: 'version("Requiem - ESF Companions.esp", "5.02", <)'
   - name: 'Requiem - Flora Fixes.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/64410/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -29484,6 +29484,13 @@ plugins:
     after: [ 'Fozars_Dragonborn_-_Requiem_Patch.esp' ]
     inc: [ 'Requiem - SkyTEST.esp' ]
 
+  - name: 'Requiem - Standing Stones Reimagined.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/113346/' ]
+    inc:
+      - name: 'Requiem.esp'
+        display: 'Requiem v6.0.0+'
+        condition: 'version("Requiem.esp", "6.0.0", >=)'
+
   ### Requiem - WACCF CCOR ACE Patches ###
   - name: 'Requiem - WACCF.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -29335,6 +29335,15 @@ plugins:
         subs: [ 'Requiem - Legacy of the Dragonborn patch' ]
         condition: 'file("DBM_Requiem_Patch.esp")'
 
+  - name: 'Fozars_Dragonborn_-_Requiem_Patch.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/34829/'
+        name: 'Requiem - Dragonborn Patch'
+    msg:
+      - <<: *alreadyInX
+        subs: [ '**Requiem.esp**' ]
+        condition: 'active("Requiem.esp") and version("Requiem.esp", "6.0.0", >=)'
+
   ### Requiem Patch Central ###
   - name: 'Requiem - Aetherium Armor.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -29411,7 +29411,9 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/64410/'
         name: 'Requiem Patch Central'
-    after: [ 'Fozars_Dragonborn_-_Requiem_Patch.esp' ]
+    after:
+      - 'Fozars_Dragonborn_-_Requiem_Patch.esp'
+      - 'Requiem - Creation Club.esp'
   - name: 'Requiem - Rough Leather Armor.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/64410/'


### PR DESCRIPTION
- Display an error if any of the following mods are used alongside Requiem 6.0.0 since they are already included.
    - ArteFakes
    - Fozar's Dragonborn Patch
    - Katana Crafting
    - Vastly More Unique Visage of Mzund
- Mark outdated patches as such and refer to up to date patches instead if available.
- Updated some load after rules for compatibility patches.
- Fixed link to Requiem's compatibility advice.