### PR TITLE
Add compatibility notice for Requiem and Path of Sorcery

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10521,6 +10521,7 @@ plugins:
     group: *perksGroup
     inc:
       - 'Ordinator - Perks of Skyrim.esp'
+      - 'PathOfSorcery.esp'
       - 'PerkusMaximus_Mage.esp'
       - 'PerkusMaximus_Master.esp'
       - 'PerkusMaximus_Thief.esp'
@@ -17569,7 +17570,6 @@ plugins:
       - 'Adamant.esp'
       - name: 'Ordinator - Perks of Skyrim.esp'
         condition: 'not file("Path to Ordinance.esp") and not file("Vokriinator( Black)?\.esp")'
-      - 'Requiem.esp'
       - 'SPERG-SSE.esp'
       - name: 'Vokrii - Minimalistic Perks of Skyrim.esp'
         condition: 'not file("Vokriinator( Black)?\.esp")'


### PR DESCRIPTION
The two mods are incompatible regardless of load order