### PR TITLE
 Add compatibility notices for Requiem and some unpatched mods

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17379,7 +17379,7 @@ plugins:
 
   - name: 'EnchantingAwakened.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/18558/' ]
-    after: [ 'Requiem.esp' ]
+    msg: [ *patchUnavailableRequiem ]
 
   - name: 'Growl - Werebeasts of Skyrim.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/31245/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -16792,7 +16792,7 @@ plugins:
 
   - name: 'Religion.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/25487/' ]
-    after: [ 'Requiem.esp' ]
+    msg: [ *patchUnavailableRequiem ]
     tag:
       - Graphics
       - Keywords

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -19287,6 +19287,7 @@ plugins:
         condition: 'active("LegacyoftheDragonborn.esm") and not active("DBM_IA_Patch.esp")'
       - <<: *patch3rdParty_KPH_CCOR
         condition: 'active("Complete Crafting Overhaul_Remastered.esp") and not active("Hothtrooper44_ArmorCompilation_CCOR_Patch.esp") and not active("IARR, CCOR Patch.esp")'
+      - <<: *patchUnavailableRequiem
       - <<: *requiresResources
         subs: [ '[Immersive Armors - Asdasfa Tweaks and Fixes](https://www.nexusmods.com/skyrimspecialedition/mods/85433/)' ]
         condition: 'version("Hothtrooper44_ArmorCompilation.esp", "1.2.0IARR", ==) and not file("meshes/armor/ala")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -8539,6 +8539,7 @@ plugins:
           - 'Wintersun - Faiths of Skyrim'
           - '[Wintersun - More Patches](https://www.nexusmods.com/skyrimspecialedition/mods/24228/)'
         condition: 'active("Wintersun - Faiths of Skyrim.esp") and not active("Wintersun - SIC Patch.esp")'
+      - <<: *patchUnavailableRequiem
       - *requiresMCM
       - *requiresMCMVR
       - type: say

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -19429,6 +19429,7 @@ plugins:
           - 'A Rose in the Snow - Reborn'
           - '[Patch for A Rose in the Snow - Reborn and Immersive Weapons](https://www.nexusmods.com/skyrimspecialedition/mods/149020/)'
         condition: 'active("A Rose in the Snow.esp") and not active("ARIS_WI_Patch.esp")'
+      - <<: *patchUnavailableRequiem
     tag:
       - Delev
       - Graphics


### PR DESCRIPTION
The following mods require a patch for full compatibility with Requiem, but none is currently available:

- Enchanting Awakened
- Immersive Armors
- Immersive Weapons
- Religion
- Skyrim Immersive Creatures