### PR TITLE
Add Happy PBR Trees

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -9261,6 +9261,10 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/17909/' ]
     group: *earlyLoadersGroup
 
+  - name: 'HappyPBRTrees.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/129150' ]
+    after: [ 'HappyLittleTrees.esp' ]
+
   - name: 'HD Lods SSE.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/3333/' ]
     group: *fixesGroup


### PR DESCRIPTION
As the author of the mod stated in the mod description, this plugin should overwrite Happy Little Trees plugin. Since there is no dependency between the two plugins, it should be sorted by LOOT.