### PR TITLE
Update Alternate Perspective

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -15638,6 +15638,8 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/50307/'
         name: 'Alternate Perspective - Alternate Start'
     group: *altStartGroup
+    after:
+      - 'Realm of Lorkhan - Custom Alternate Start - Choose your own adventure.esp'
     req:
       - *PapyrusUtil
       - *SilentVoice
@@ -15646,12 +15648,16 @@ plugins:
       - 'Original Opening Scene.esp'
       - 'QuickVanillaStart.esl'
       - 'Random Alternate Start Reborn SE.esp'
-      - 'Realm of Lorkhan - Custom Alternate Start - Choose your own adventure.esp'
       - 'Skyrim Unbound.esp'
     msg:
       - <<: *patchUnavailable
         subs: [ 'Touring Carriages' ]
         condition: 'active("TouringCarriages.esp")'
+      - <<: *patch3rdParty
+        subs: 
+          - 'Realm of Lorkhan - Freeform Alternate Start'
+          - '[Alternate Perspective - Realm of Lorkhan Patch](https://www.nexusmods.com/skyrimspecialedition/mods/104545/)
+        condition: 'file("Realm of Lorkhan - Custom Alternate Start - Choose your own adventure.esp") and not file("SHE_LorkhanPerspective.esp")'
     tag:
       - Actors.ACBS
       - Actors.AIData

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6,7 +6,7 @@ prelude:
   # Message Anchors
     - &alreadyInX
       type: error
-      content: 'Delete. Already included in {0}.'  
+      content: 'Delete. Already included in {0}.'
 
     - &alreadyInOrFixedByX
       type: error

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -6,7 +6,7 @@ prelude:
   # Message Anchors
     - &alreadyInX
       type: error
-      content: 'Delete. Already included in {0}.'
+      content: 'Delete. Already included in {0}.'  
 
     - &alreadyInOrFixedByX
       type: error
@@ -15650,14 +15650,14 @@ plugins:
       - 'Random Alternate Start Reborn SE.esp'
       - 'Skyrim Unbound.esp'
     msg:
+      - <<: *patch3rdParty
+        subs:
+          - 'Realm of Lorkhan - Freeform Alternate Start'
+          - '[Alternate Perspective - Realm of Lorkhan Patch](https://www.nexusmods.com/skyrimspecialedition/mods/104545/)'
+        condition: 'file("Realm of Lorkhan - Custom Alternate Start - Choose your own adventure.esp") and not file("SHE_LorkhanPerspective.esp")'
       - <<: *patchUnavailable
         subs: [ 'Touring Carriages' ]
         condition: 'active("TouringCarriages.esp")'
-      - <<: *patch3rdParty
-        subs: 
-          - 'Realm of Lorkhan - Freeform Alternate Start'
-          - '[Alternate Perspective - Realm of Lorkhan Patch](https://www.nexusmods.com/skyrimspecialedition/mods/104545/)
-        condition: 'file("Realm of Lorkhan - Custom Alternate Start - Choose your own adventure.esp") and not file("SHE_LorkhanPerspective.esp")'
     tag:
       - Actors.ACBS
       - Actors.AIData

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -15638,8 +15638,6 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/50307/'
         name: 'Alternate Perspective - Alternate Start'
     group: *altStartGroup
-    after:
-      - 'Realm of Lorkhan - Custom Alternate Start - Choose your own adventure.esp'
     req:
       - *PapyrusUtil
       - *SilentVoice


### PR DESCRIPTION
Removing incompatibility line with Alternate Perspective for Realm of Lorkhan

Adding new 3rd party patch message for Alternate Perspective if detected along-side Realm Of Lorkhan

Adding rule to load Alternate Perspective After Realm of Lorkhan

Alternate Perspective - Realm of Lorkhan Patch
https://www.nexusmods.com/skyrimspecialedition/mods/104545

Realm of Lorkhan - Freeform Alternate Start
https://www.nexusmods.com/skyrimspecialedition/mods/18223

Alternate Perspective - Realm of Lorkhan Patch
https://www.nexusmods.com/skyrimspecialedition/mods/50307