### PR TITLE
RDO after ASLAL

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7821,6 +7821,12 @@ plugins:
 
   - name: 'SofiaFollower.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/2180/' ]
+    msg:
+      - <<: *patch3rdParty
+        subs:
+          - 'Relationship Dialogue Overhaul - RDO SE'
+          - '[Sofia Bug and Patch Hub](https://www.nexusmods.com/skyrimspecialedition/mods/70950)'
+        condition: 'active("Relationship Dialogue Overhaul.esp") and not active("Sofia - RDO Patch.esp")'
     clean:
       # version: 2.51
       - crc: 0xD87DD508

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -15485,7 +15485,9 @@ plugins:
         name: 'Relationship Dialogue Overhaul - RDO SE'
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/42068/'
         name: 'Relationship Dialogue Overhaul Lite Fixed'
-    after: [ '018Auri.esp' ]
+    after:
+      - '018Auri.esp'
+      - 'alternate start - live another life.esp'
     # Removed load after for Immersive Citizens, as it can lead to hoisting of too many other mods.
     # Which may not work for every users load order. User can add the rule manually instead.
     msg:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -15499,6 +15499,11 @@ plugins:
     msg:
       - <<: *patch3rdParty_AOOPH
         condition: 'active("AI Overhaul.esp") and not active("AI Overhaul - (Relationship Dialogue Overhaul|RDO Updated) Patch\.esp")'
+      - <<: *patch3rdParty
+        subs:
+          - 'Sofia - The Funny Fully Voiced Follower'
+          - '[Sofia Bug and Patch Hub](https://www.nexusmods.com/skyrimspecialedition/mods/70950)'
+        condition: 'active("SofiaFollower.esp") and not active("Sofia - RDO Patch.esp")'
       - <<: *patchProvided
         subs: [ 'Amazing Follower Tweaks' ]
         condition: 'checksum("Relationship Dialogue Overhaul.esp", 20DC9B97) and (checksum("AmazingFollowerTweaks.esp", 88F9C8B8) or checksum("AmazingFollowerTweaks.esp", F43B6124)) and not active("RDO - AFT v1.66 Patch.esp")'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -29903,6 +29903,11 @@ plugins:
       - <<: *useInstead
         subs: [ '[lilebonymace''s patches and xEdit scripts](https://www.nexusmods.com/skyrimspecialedition/mods/36042/) (**Open World Loot - C.O.I.N.esp**)' ]
 
+  - name: 'Sofia - RDO Patch.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/70950' ]
+    # Missing RDO as a master
+    after: [ 'Relationship Dialogue Overhaul.esp' ]
+
   - name: 'Spell Research - Even More Patches.esp'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/61177/'


### PR DESCRIPTION
Quotation from [Relationship Dialogue Overhaul - RDO SE](https://www.nexusmods.com/skyrimspecialedition/mods/1187) page:
> **Load RDO AFTER the following mods listed below:**
> 
> ...
> 
> - Alternate Start - Live Another Life (LAL) 
>   - A handful of records conflict between RDO and LAL. RDO includes the changes made to these conflicting records by LAL, and therefore should be loaded after LAL so that changes from both mods are applied.