### PR TITLE
Add constraint to AI Overhaul - KaliliesNPCs Patch.esp

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7125,7 +7125,9 @@ plugins:
       - crc: 0x9B789EF8
         util: 'SSEEdit v4.0.3f'
   - name: 'AI Overhaul - KaliliesNPCs Patch.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/30247/' ]
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/30247/'
+        name: 'Kalilies NPCs'
     req:
       - name: 'cutting room floor.esp'
         display: 'a version of Cutting Room Floor older than v3.1.23'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7128,6 +7128,8 @@ plugins:
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/30247/' ]
     req:
       - name: 'cutting room floor.esp'
+        display: 'a version of Cutting Room Floor older than v3.1.23'
+        constraint: 'version("Cutting Room Floor.esp", "3.1.23", <)'
         condition: 'checksum("AI Overhaul - KaliliesNPCs Patch.esp", D063D027)'
     msg:
       - <<: *useVersion

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -7131,7 +7131,7 @@ plugins:
     req:
       - name: 'cutting room floor.esp'
         display: 'a version of Cutting Room Floor older than v3.1.23'
-        constraint: 'version("Cutting Room Floor.esp", "3.1.23", <)'
+        constraint: 'version("cutting room floor.esp", "3.1.23", <)'
         condition: 'checksum("AI Overhaul - KaliliesNPCs Patch.esp", D063D027)'
     msg:
       - <<: *useVersion


### PR DESCRIPTION
[Discord Discussion](https://discord.com/channels/473542112974077963/496196499890241546/1356312687335702609)

<img width="892" height="975" alt="image" src="https://github.com/user-attachments/assets/dd2e13f9-aff8-4d04-868d-41a6cceba40a" />

<img width="892" height="773" alt="image" src="https://github.com/user-attachments/assets/8ef67ff8-6995-45bd-ac03-5e8030670db2" />

[Documentation - Constraint](https://loot-api.readthedocs.io/en/latest/api/cpp_api_reference.html#classes)

> A condition string that must evaluate to true for the file’s existence to be recognised. 

[Kalilies NPCs](https://www.nexusmods.com/skyrimspecialedition/mods/30247/)
[AI Overhaul SSE](https://www.nexusmods.com/skyrimspecialedition/mods/21654/)
[Unofficial Skyrim Special Edition Patch - USSEP](https://www.nexusmods.com/skyrimspecialedition/mods/266/)
[Cutting Room Floor - SSE](https://www.nexusmods.com/skyrimspecialedition/mods/276/)

`AI Overhaul - KaliliesNPCs Patch.esp` has the following masters:
```
Skyrim.esm
Update.esm
Dragonborn.esm
Unofficial Skyrim Special Edition Patch.esp
KaliliesNPCs.esp
AI Overhaul.esp
```
The patch was created for `AI Overhaul v1.6.4`, and an older version of `Cutting Room Floor`, while not having it as a master (it was uploaded to Nexus on the 16th of February 2021).

While the patch has not been updated since then (but continues to be available), CRF has been updated multiple times in the meantime (v3.1.23a as of 2nd December 2025 - `3.1.23` in `SNAM`).

Since the only version of CRF available is the very latest version, add a `constraint` to the requirement `req` (plus a `display` for the error message).

```yaml
  - name: 'AI Overhaul - KaliliesNPCs Patch.esp'
    req:
      - name: 'cutting room floor.esp'
        display: 'a version of Cutting Room Floor older than v3.1.23'
        constraint: 'version("cutting room floor.esp", "3.1.23", <)'
        condition: 'checksum("AI Overhaul - KaliliesNPCs Patch.esp", D063D027)'
```

In case the `condition` is `true`, but the `constraint` evaluates to `false` (so if the actual version of CRF is `>= 3.1.23`):

<img width="730" height="98" alt="constraint" src="https://github.com/user-attachments/assets/5f2ced39-d928-4e49-b64b-fb2997384b12" />


