### PR TITLE
Add Weightless Overhaul Order

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -30914,3 +30914,9 @@ plugins:
   - name: 'Tonal Architect.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/51199/' ]
     msg: [ *patchUnavailableRequiem ]
+
+  - name: 'WeightlessOV_MERGED.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/5407/'
+        name: 'Weightless Overhaul'
+    after: [ 'Complete Alchemy & Cooking Overhaul.esp' ]


### PR DESCRIPTION
Weightless Overhaul has to override Complete Alchemy and Cooking Overhaul to make all the items weightless that has been modified by CA&CO.

Weightless Overhaul: https://www.nexusmods.com/skyrimspecialedition/mods/5407
Complete Alchemy and Cooking Overhaul: https://www.nexusmods.com/skyrimspecialedition/mods/19924