### PR TITLE
Update Unofficial Skyrim Special Edition Patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2303,12 +2303,8 @@ plugins:
           - '1.6.1130'
           - 'Skyrim Special Edition'
         condition: 'readable("../SkyrimSE.exe") and product_version("../SkyrimSE.exe", "1.6.1130.0", <) and version("unofficial skyrim special edition patch.esp", "4.3.1", >=)'
-    dirty:
-      - <<: *quickClean
-        crc: 0xCE922FDA
-        util: '[SSEEdit v4.1.5p](https://www.nexusmods.com/skyrimspecialedition/mods/164/)'
-        itm: 78
     clean:
+      # Do not clean - 1 ITM that is likely not worth cleaning
       # German
       - crc: 0xB3AB07FD
         util: 'SSEEdit v4.0.4'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2304,7 +2304,7 @@ plugins:
           - 'Skyrim Special Edition'
         condition: 'readable("../SkyrimSE.exe") and product_version("../SkyrimSE.exe", "1.6.1130.0", <) and version("unofficial skyrim special edition patch.esp", "4.3.1", >=)'
     clean:
-      # Do not clean - 1 ITM that is likely not worth cleaning
+      # Do not clean - Breaks dialogues due to xEdit mishandling PNAM subrecords.
       # German
       - crc: 0xB3AB07FD
         util: 'SSEEdit v4.0.4'


### PR DESCRIPTION
Ref [Discord](https://discord.com/channels/473542112974077963/496196499890241546/1475196664422731846)
> https://github.com/loot/skyrimse/commit/f669859671d8315824ab968f001c5c22e0afa678
> This commit needs to be reversed. The 78 "ITMs" reported here are a false positive as the result of xEdit not handling PNAM subrecords correctly with dialogue. Removing these from the USSEP will break dialogue fixes we've done over the years.
> 
> -- arthmoor in #loot-discussions at 2026-02-22, 10:24 AM PST