### PR TITLE
Add Edmond's Immersive Needs ESL

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10238,6 +10238,11 @@ plugins:
       - crc: 0x70BF869A
         util: 'SSEEdit v4.0.3'
 
+  - name: 'Immersive Needs ESL.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/129738/'
+        name: 'Edmond''s Immersive Needs ESL'
+
   - name: 'Improved Traps.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/17592/' ]
     tag:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10243,6 +10243,16 @@ plugins:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/129738/'
         name: 'Edmond''s Immersive Needs ESL'
     after: [ 'Growl - Werebeasts of Skyrim.esp' ]
+    clean:
+      # Base Mod v6.0
+      - crc: 0xF60C1E54
+        util: 'SSEEdit v4.1.5p 32bit fix version'
+      # Base Mod+USSEP v6.0
+      - crc: 0xDFDA0190
+        util: 'SSEEdit v4.1.5p 32bit fix version'
+      # Base Mod+USSEP+KID(+SPID)+BOS v6.0
+      - crc: 0xDBA89F4D
+        util: 'SSEEdit v4.1.5p 32bit fix version'
 
   - name: 'Improved Traps.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/17592/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -10242,6 +10242,7 @@ plugins:
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/129738/'
         name: 'Edmond''s Immersive Needs ESL'
+    after: [ 'Growl - Werebeasts of Skyrim.esp' ]
 
   - name: 'Improved Traps.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/17592/' ]


### PR DESCRIPTION
Ref [Nexus Mods](https://www.nexusmods.com/site/mods/439?tab=posts&comment_id=166387288)

From LeavingUndad:
> EdmondNoir, the author of the Edmond's Immersive Needs ESL - Light Weight SPID and KID Needs Mod for the Future (a mod for Skyrim SE), said recently in the Posts section of their mod that Immersive Needs ESL.esp should be placed in the load order after Growl - Werebeasts of Skyrim.esp from the Growl - Werebeasts of Skyrim (or any other werewolf overhaul mod), otherwise feeding on corpses in modded werewolf form wouldn't quench the hunger from INESL. Hopefully LOOT Team will take it into account when they release the next updated Masterlist for Skyrim SE (currently LOOT places Immersive Needs ESL.esp before Growl - Werebeasts of Skyrim.esp). 

From EdmondNoir:
> To be clear only Growl is impacted no other werewolf mod is. The conflict in Growl is a dirty edit that doesnt do anything. Thus placing my needs mod after Growl allows my mod to function and growl to continue to function due to the edit in growl being dirty or accidental. So if you make Loot rules to auto place my needs mod after both mods will then work.  