### PR TITLE
Format Unofficial Creation Club Content Patch entry

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2309,7 +2309,50 @@ plugins:
       - crc: 0xB3AB07FD
         util: 'SSEEdit v4.0.4'
 
-  - name: 'Unofficial (Skyrim Creation Club Content|Arcane Accessories|(Arcane Archer|Expanded Crossbow|Saturalia Holiday) Pack|Arms of Chaos|Bittercup|Bloodchill Manor|Bone Wolf|Bow of Shadows|Chrysamere|Civil War Champions|(Daedric|Dragon|Dwarven|Ebony|Elven Hunter|Iron|Netch Leather|Orcish|Silver|Spell Knight|Stalhrim Fur|Steel Soldier|Vigil Enforcer) ?(Mail|Plate|Scaled?)? Armor(s| Set)?|Dawnfang and Duskfang|Dead Man''s Dread|Divine Crusader|Dwarven (Armored Mudcrab|Home)|Elite Crossbows|Farming|Forgotten Seasons|Gallows Hall|Ghosts of the Tribunal|Goblins|Goldbrand|Gray Cowl Returns|Headmans Cleaver|Hendraheim|Lord''s Mail|Myrwatch|Necromantic Grimoire|Nix-Hound|Nordic Jewelry|Pets of Skyrim|Plague of the Dead|Redguard Elite Armaments|Ruin''s Edge|Shadowfoot Sanctum|Shadowrend|Staff of Sheogorath|Staves|Stendarr''s Hammer|Sunder & Wraithguard|The (Cause|Contest)|Tundra Homestead|Umbra|Wild Horses) Patch\.esl'
+  - name: 'Unofficial (Skyrim Creation Club Content
+                      {0}|Arcane Accessories
+                      {0}|(Arcane Archer|Expanded Crossbow|Saturalia Holiday) Pack
+                      {0}|Arms of Chaos
+                      {0}|Bittercup
+                      {0}|Bloodchill Manor
+                      {0}|Bone Wolf
+                      {0}|Bow of Shadows
+                      {0}|Chrysamere
+                      {0}|Civil War Champions
+                      {0}|(Daedric|Dragon|Dwarven|Ebony|Elven Hunter|Iron|Netch Leather|Orcish|Silver|Spell Knight|Stalhrim Fur|Steel Soldier|Vigil Enforcer) ?(Mail|Plate|Scaled?)? Armor(s| Set)?
+                      {0}|Dawnfang and Duskfang
+                      {0}|Dead Man''s Dread
+                      {0}|Divine Crusader
+                      {0}|Dwarven (Armored Mudcrab|Home)
+                      {0}|Elite Crossbows
+                      {0}|Farming
+                      {0}|Forgotten Seasons
+                      {0}|Gallows Hall
+                      {0}|Ghosts of the Tribunal
+                      {0}|Goblins
+                      {0}|Goldbrand
+                      {0}|Gray Cowl Returns
+                      {0}|Headmans Cleaver
+                      {0}|Hendraheim
+                      {0}|Lord''s Mail
+                      {0}|Myrwatch
+                      {0}|Necromantic Grimoire
+                      {0}|Nix-Hound
+                      {0}|Nordic Jewelry
+                      {0}|Pets of Skyrim
+                      {0}|Plague of the Dead
+                      {0}|Redguard Elite Armaments
+                      {0}|Ruin''s Edge
+                      {0}|Shadowfoot Sanctum
+                      {0}|Shadowrend
+                      {0}|Staff of Sheogorath
+                      {0}|Staves
+                      {0}|Stendarr''s Hammer
+                      {0}|Sunder & Wraithguard
+                      {0}|The (Cause|Contest)
+                      {0}|Tundra Homestead
+                      {0}|Umbra
+                      {0}|Wild Horses) Patch\.esl'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18975/'
         name: 'Unofficial Skyrim Creation Club Content Patches'


### PR DESCRIPTION
Utilizing Ortham's idea of using `{0}` (which means "exactly zero times") to ignore spaces in front of it.

Ref [Discord](https://discord.com/channels/473542112974077963/496196499890241546/1481002136887361617)
> Ortham in #loot-discussions at 2026-03-10, 7:53 PM

<img width="780" height="409" alt="image" src="https://github.com/user-attachments/assets/74e488c8-fa1b-44ea-b96c-d991e47f967a" />