### PR TITLE
Add group Player Character Dialogue

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -14701,7 +14701,7 @@ plugins:
 
   - name: 'BA_KhajiitSpeakRedux_MAIN.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/37197/' ]
-    group: *kSpeakGroup
+    group: *playerDialogueGroup
   - name: 'BA_KSR_.*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/37197/' ]
     after:
@@ -14730,7 +14730,7 @@ plugins:
 
   - name: 'dwagonbown goes uwu.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/35441/' ]
-    group: *lateLoadersGroup
+    group: *playerDialogueGroup
 
   - name: 'Fertility Mode.esm'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/13068/' ]
@@ -14900,7 +14900,7 @@ plugins:
 
   - name: 'mjhKhajiitSpeak.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/441/' ]
-    group: *kSpeakGroup
+    group: *playerDialogueGroup
     after: [ 'BA_KhajiitSpeakRedux_MAIN.esp' ]
   - name: 'mjhKhajiitSpeakMod.*\.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/441/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -844,9 +844,13 @@ groups:
   - name: &lvlListsGroup Leveled List Modifiers
     after: [ *kSpeakGroup ]
 
+  - name: &playerDialogueGroup Player Character Dialogue
+    description: 'A group for mods that modify the player character dialogue.'
+    after: [ *lvlListsGroup ]
+
   - name: &worldSettingsGroup Worldspace Settings
     description: 'A group for modules that need to be loaded late to preserve worldspace settings.'
-    after: [ *lvlListsGroup ]
+    after: [ *playerDialogueGroup ]
 
   - name: &paperMapsGroup Paper Maps
     description: 'A group for paper map mods that need to be loaded late to preserve worldspace settings.'


### PR DESCRIPTION
Creating to move dwagonbown goes uwu and Khajiit Speak to the same group.
Both mods alter mostly the same records in dialogue.