### PR TITLE
Updated Identity Crisis patching recommendation

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -21044,16 +21044,7 @@ plugins:
         crc: 0xDA11D0DA
         util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 21
-
-  - name: 'BS Bruma Patch.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/39634/' ]
-    inc:
-      - name: 'Identity Crisis.esp'
-        display: 'Identity Crisis'
-    msg:
-      - <<: *patchOutdated
-        condition: 'active("BS Bruma Patch.esp")'
-        
+       
   - name: 'Maslea.esm'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18327/'

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -21054,7 +21054,17 @@ plugins:
     msg:
       - <<: *patchProvided
         subs: [ 'Beyond Skyrim - Bruma SE' ]
-        condition: 'active("BSHeartland.esm") and not active("BS Bruma Patch.esp")'
+        condition: 'active("BSHeartland.esm") and not active("BS Bruma Patch.esp") and version("Identity Crisis.esp", <, "1.5")'
+
+  - name: 'BS Bruma Patch.esp'
+    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/39634/' ]
+    inc:
+      - name: 'Identity Crisis.esp'
+        display: 'Identity Crisis'
+    msg:
+      - <<: *patchOutdated
+        condition: 'active("BS Bruma Patch.esp") and version("Identity Crisis.esp", >=, "1.5")'
+        
 
   - name: 'Maslea.esm'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -21045,17 +21045,6 @@ plugins:
         util: '[SSEEdit v4.0.3](https://www.nexusmods.com/skyrimspecialedition/mods/164)'
         itm: 21
 
-  - name: 'Identity Crisis.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/39634/' ]
-    inc:
-      - name: 'BSHeartland.esm'
-        display: 'Beyond Skyrim - Bruma SE'
-        condition: 'not active("BS Bruma Patch.esp")'
-    msg:
-      - <<: *patchProvided
-        subs: [ 'Beyond Skyrim - Bruma SE' ]
-        condition: 'active("BSHeartland.esm") and not active("BS Bruma Patch.esp") and version("Identity Crisis.esp", <, "1.5")'
-
   - name: 'BS Bruma Patch.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/39634/' ]
     inc:
@@ -21063,9 +21052,8 @@ plugins:
         display: 'Identity Crisis'
     msg:
       - <<: *patchOutdated
-        condition: 'active("BS Bruma Patch.esp") and version("Identity Crisis.esp", >=, "1.5")'
+        condition: 'active("BS Bruma Patch.esp")'
         
-
   - name: 'Maslea.esm'
     url:
       - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/18327/'


### PR DESCRIPTION
As of [Identity Crisis](https://www.nexusmods.com/skyrimspecialedition/mods/39634) 1.4, a patch for Beyond Skyrim Bruma is no longer necessary nor provided. The author has resolved the conflicts. See pinned post [here](https://www.nexusmods.com/skyrimspecialedition/mods/39634?tab=posts) for details.