### PR TITLE
Add Favor Quests Separated - Headhunter Patch

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -28407,6 +28407,13 @@ plugins:
       - C.ImageSpace
       - C.Light
 
+  - name: 'Favor Quests Separated - Headhunter( Missives)? Patch\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/180452/'
+        name: 'Favor Quests Separated - Headhunter Patch'
+    after: [ 'BountiesRedone_MissivesExtension.esp' ]
+    inc: [ 'Favor Quests Seperated - Bounty Quests.esp' ]
+
   - name: 'Fixes for Armor and Clothing Extension.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/28059/' ]
     msg:
@@ -30058,12 +30065,3 @@ plugins:
   - name: 'Tonal Architect.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/51199/' ]
     msg: [ *patchUnavailableRequiem ]
-
-  - name: 'Favor Quests Separated - Headhunter( Missives)? Patch\.esp'
-    url:
-      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/180452'
-        name: 'Favor Quests Separated - Headhunter Patch'
-    after:
-      - 'Missives.esp'
-      - 'BountiesRedone_MissivesExtension.esp'
-    inc: [ 'Favor Quests Seperated - Bounty Quests.esp' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -30058,3 +30058,12 @@ plugins:
   - name: 'Tonal Architect.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/51199/' ]
     msg: [ *patchUnavailableRequiem ]
+
+  - name: 'Favor Quests Separated - Headhunter( Missives)? Patch\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/180452'
+        name: 'Favor Quests Separated - Headhunter Patch'
+    after:
+      - 'Missives.esp'
+      - 'BountiesRedone_MissivesExtension.esp'
+    inc: [ 'Favor Quests Seperated - Bounty Quests.esp' ]


### PR DESCRIPTION
This adds an entry for a patch I made, which should load after other plugins editing bounty quests and also has an incompatibility with an optional file from Favor Quests Separated.
There are 2 versions of the patch, but both of them should load after Missives.esp as that is also editing bounty quests.

I didn't know where to put it so I added it to the end of the masterlist.
[x] I did test the change locally.

Reference: https://www.nexusmods.com/skyrimspecialedition/mods/180452