### PR TITLE
Update Elianora's Breezehome Overhaul

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26430,6 +26430,9 @@ plugins:
       - <<: *alreadyInX
         subs: [ 'Eli_Breezehome [PATCH - RS + ELE].esp' ]
         condition: 'file("Eli_Breezehome [PATCH - RS + ELE].esp") and file("ELE_SSE.esp") and file("RelightingSkyrim_SSE.esp")'
+      - <<: *useInstead
+        subs: [ 'Eli_Breezehome [PATCH - RS + ELE].esp' ]
+        condition: 'not file("Eli_Breezehome [PATCH - RS + ELE].esp") and file("ELE_SSE.esp") and file("RelightingSkyrim_SSE.esp")'
 
   - name: 'Eli_Halla.esp'
     url:

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -26429,7 +26429,7 @@ plugins:
     msg:
       - <<: *alreadyInX
         subs: [ 'Eli_Breezehome [PATCH - RS + ELE].esp' ]
-        condition: 'file("Eli_Breezehome \[PATCH - (ELE|RS)\]\.esp")'
+        condition: 'file("Eli_Breezehome [PATCH - RS + ELE].esp") and file("ELE_SSE.esp") and file("RelightingSkyrim_SSE.esp")'
 
   - name: 'Eli_Halla.esp'
     url:


### PR DESCRIPTION
Ref [Discord](https://discord.com/channels/473542112974077963/473542230095822848/1521899826214736062)

The linked Discord message is:

> I don't know where to report likely erros with LOOT messages (other then ignoring them).   LOOT thinks an ESP is installed which is not for Elianore's Breezehome Overhaul (EBO) with ELFX and Relightning Skyrim installed and patches picked in the Breezehome installer.  LOOT says to DELETE "Eli_Breezehome [PATCH - RS]" because it is already included in "Eli_Breezehome [PATCH - RS + ELE].esp".  The latter is not installed so the message is incorrect.  RS is Relighting Skyrim (installed) and ELE is Enhancing Lighting for ENB (not installed).
> 
> -- .mizar in #support at 2026-7-1, 8:26 AM PDT