### PR TITLE
Update Unique Region Names

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17870,24 +17870,8 @@ plugins:
 
   - name: 'Unique Region Names.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/56452/' ]
-    msg:
-      - <<: *patchProvided
-        subs: [ 'Realistic Water Two SE' ]
-        condition: 'active("RealisticWaterTwo.esp") and not active("cutting room floor.esp") and not active("MissingEZs_AllExteriors.esp") and not active("RealisticWaterTwo - Unique Region Names.esp") and not active("RealisticWaterTwo - Unique Region Names - (Cutting Room Floor|MissingEZs_AllExteriors)\.esp")'
-      - <<: *patchProvided
-        subs: [ 'Realistic Water Two SE and Cutting Room Floor SSE' ]
-        condition: 'active("RealisticWaterTwo.esp") and active("cutting room floor.esp") and not active("RealisticWaterTwo - Unique Region Names - Cutting Room Floor.esp")'
-      - <<: *patchProvided
-        subs: [ 'Realistic Water Two SE and Missing Encounter Zones FIXED' ]
-        condition: 'active("RealisticWaterTwo.esp") and active("MissingEZs_AllExteriors.esp") and not active("RealisticWaterTwo - Unique Region Names - MissingEZs_AllExteriors.esp")'
-  - name: 'RealisticWaterTwo - Unique Region Names.esp'
-    msg:
-      - <<: *alreadyInX
-        subs: [ 'RealisticWaterTwo - Unique Region Names - Cutting Room Floor.esp' ]
-        condition: 'active("RealisticWaterTwo - Unique Region Names - Cutting Room Floor.esp")'
-      - <<: *alreadyInX
-        subs: [ 'RealisticWaterTwo - Unique Region Names - MissingEZs_AllExteriors.esp' ]
-        condition: 'active("RealisticWaterTwo - Unique Region Names - MissingEZs_AllExteriors.esp")'
+  - name: 'RealisticWaterTwo - Unique Region Names( - Cutting Room Floor| - MissingEZs_AllExteriors)?\.esp'
+    msg: [ *patchOutdated ]
 
   - name: 'ValdacilsItemSorting.esp'
     url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/5224/' ]

--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -17868,8 +17868,10 @@ plugins:
   - name: 'TESL-LS-VanillaLSRemover.esp'
     group: *lateLoadersGroup
 
-  - name: 'Unique Region Names.esp'
-    url: [ 'https://www.nexusmods.com/skyrimspecialedition/mods/56452/' ]
+  - name: '(RealisticWaterTwo - )?Unique Region Names( - Cutting Room Floor| - MissingEZs_AllExteriors)?\.esp'
+    url:
+      - link: 'https://www.nexusmods.com/skyrimspecialedition/mods/56452/'
+        name: 'Unique Region Names'
   - name: 'RealisticWaterTwo - Unique Region Names( - Cutting Room Floor| - MissingEZs_AllExteriors)?\.esp'
     msg: [ *patchOutdated ]
 


### PR DESCRIPTION
Ref [Discord](https://discord.com/channels/473542112974077963/473542230095822848/1522240555713691648)

The linked Discord message is:

> Second note: Unique Region Names.esp, LOOT says compatibility patch for Realistic Water Two SE and Cutting Room Floor SSE, from the mod's page; however, that patch is incompatible with current versions of these plugins.
> 
> -- .mizar in #support at 2026-7-2, 6:57 AM PDT