### PR TITLE
Update Particle Patch ENB Helper condition for KiLoader distribution

### DIFF
--- a/masterlist.yaml
+++ b/masterlist.yaml
@@ -2927,7 +2927,7 @@ plugins:
     msg:
       - <<: *alsoUseX
         subs: [ '[ENB Helper](https://www.nexusmods.com/skyrimspecialedition/mods/23174/)' ]
-        condition: 'file("../skse64_loader.exe") and file("../enblocal.ini") and not file("skse/plugins/ENBHelperSE.dll")'
+        condition: 'file("../skse64_loader.exe") and file("../enblocal.ini") and not file("skse/plugins/ENBHelperSE.dll") and not file("KiLoader/Plugins/ENBHelperSE.dll")'
     tag:
       - -C.Climate
       - -C.ImageSpace


### PR DESCRIPTION
Some distributions of ENB Helper SE install the DLL to `KiLoader/Plugins/ENBHelperSE.dll` instead of the standard `SKSE/Plugins/` path. One example is the KiLoader distribution on Nexus: https://www.nexusmods.com/skyrimspecialedition/mods/99406

This updates the `Particle Patch` recommendation message condition so it does not appear when ENB Helper is installed via KiLoader.